### PR TITLE
Configure environment variables and add CI/integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Unit tests
         run: pnpm test:unit
 
+      - name: Push database schema
+        env:
+          LEAD_SERVICE_DATABASE_URL: ${{ secrets.LEAD_SERVICE_DATABASE_URL }}
+        run: pnpm drizzle-kit push --force
+
       - name: Integration tests
         env:
           NODE_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - name: Unit tests
+        run: pnpm test:unit
+
+      - name: Integration tests
+        env:
+          NODE_ENV: test
+          LEAD_SERVICE_DATABASE_URL: ${{ secrets.LEAD_SERVICE_DATABASE_URL }}
+        run: pnpm test:integration

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   out: "./drizzle",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    url: process.env.LEAD_SERVICE_DATABASE_URL!,
   },
 });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:unit": "vitest run tests/unit",
+    "test:integration": "vitest run tests/integration",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2,10 +2,10 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema.js";
 
-const connectionString = process.env.DATABASE_URL;
+const connectionString = process.env.LEAD_SERVICE_DATABASE_URL;
 
 if (!connectionString) {
-  throw new Error("DATABASE_URL is not set");
+  throw new Error("LEAD_SERVICE_DATABASE_URL is not set");
 }
 
 export const sql = postgres(connectionString);

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -16,7 +16,7 @@ export async function authenticate(
 ) {
   try {
     const apiKey = req.headers["x-api-key"] as string;
-    if (!apiKey || apiKey !== process.env.API_KEY) {
+    if (!apiKey || apiKey !== process.env.LEAD_SERVICE_API_KEY) {
       return res.status(401).json({ error: "Invalid API key" });
     }
 

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import request from "supertest";
+import app from "../../src/index.js";
+import {
+  setupTestOrg,
+  cleanupTestData,
+  closeDb,
+  getAuthHeaders,
+  TEST_API_KEY,
+} from "./setup.js";
+
+describe("API Integration Tests", () => {
+  beforeAll(async () => {
+    process.env.LEAD_SERVICE_API_KEY = TEST_API_KEY;
+    await setupTestOrg();
+  });
+
+  afterAll(async () => {
+    await cleanupTestData();
+    await closeDb();
+  });
+
+  describe("Authentication", () => {
+    it("rejects requests without API key", async () => {
+      const res = await request(app)
+        .post("/buffer/push")
+        .send({ namespace: "test", leads: [] });
+
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects requests with invalid API key", async () => {
+      const res = await request(app)
+        .post("/buffer/push")
+        .set("x-api-key", "wrong-key")
+        .set("x-app-id", "test")
+        .set("x-org-id", "test")
+        .send({ namespace: "test", leads: [] });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("POST /buffer/push", () => {
+    it("buffers new leads", async () => {
+      const res = await request(app)
+        .post("/buffer/push")
+        .set(getAuthHeaders())
+        .send({
+          namespace: "brand-a",
+          leads: [
+            { email: "alice@example.com", externalId: "e1", data: { name: "Alice" } },
+            { email: "bob@example.com", externalId: "e2", data: { name: "Bob" } },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.buffered).toBe(2);
+      expect(res.body.skippedAlreadyServed).toBe(0);
+    });
+
+    it("returns 400 when namespace missing", async () => {
+      const res = await request(app)
+        .post("/buffer/push")
+        .set(getAuthHeaders())
+        .send({ leads: [] });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("POST /buffer/next", () => {
+    it("pulls next lead from buffer", async () => {
+      // First push a lead
+      await request(app)
+        .post("/buffer/push")
+        .set(getAuthHeaders())
+        .send({
+          namespace: "brand-b",
+          leads: [{ email: "charlie@example.com", data: { name: "Charlie" } }],
+        });
+
+      // Then pull it
+      const res = await request(app)
+        .post("/buffer/next")
+        .set(getAuthHeaders())
+        .send({ namespace: "brand-b" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.found).toBe(true);
+      expect(res.body.lead.email).toBe("charlie@example.com");
+    });
+
+    it("returns found: false when buffer empty", async () => {
+      const res = await request(app)
+        .post("/buffer/next")
+        .set(getAuthHeaders())
+        .send({ namespace: "empty-namespace" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.found).toBe(false);
+    });
+
+    it("deduplicates — same lead not served twice", async () => {
+      // Push same lead twice to a new namespace
+      await request(app)
+        .post("/buffer/push")
+        .set(getAuthHeaders())
+        .send({
+          namespace: "brand-c",
+          leads: [{ email: "dedup@example.com" }],
+        });
+
+      // Pull it once
+      const first = await request(app)
+        .post("/buffer/next")
+        .set(getAuthHeaders())
+        .send({ namespace: "brand-c" });
+
+      expect(first.body.found).toBe(true);
+
+      // Push again
+      const pushAgain = await request(app)
+        .post("/buffer/push")
+        .set(getAuthHeaders())
+        .send({
+          namespace: "brand-c",
+          leads: [{ email: "dedup@example.com" }],
+        });
+
+      expect(pushAgain.body.skippedAlreadyServed).toBe(1);
+
+      // Pull again — should find nothing
+      const second = await request(app)
+        .post("/buffer/next")
+        .set(getAuthHeaders())
+        .send({ namespace: "brand-c" });
+
+      expect(second.body.found).toBe(false);
+    });
+  });
+
+  describe("Cursor endpoints", () => {
+    it("GET returns null for non-existent cursor", async () => {
+      const res = await request(app)
+        .get("/cursor/new-namespace")
+        .set(getAuthHeaders());
+
+      expect(res.status).toBe(200);
+      expect(res.body.state).toBeNull();
+    });
+
+    it("PUT creates cursor, GET retrieves it", async () => {
+      const state = { page: 5, lastId: "abc123" };
+
+      const putRes = await request(app)
+        .put("/cursor/my-namespace")
+        .set(getAuthHeaders())
+        .send({ state });
+
+      expect(putRes.status).toBe(200);
+      expect(putRes.body.ok).toBe(true);
+
+      const getRes = await request(app)
+        .get("/cursor/my-namespace")
+        .set(getAuthHeaders());
+
+      expect(getRes.status).toBe(200);
+      expect(getRes.body.state).toEqual(state);
+    });
+
+    it("PUT updates existing cursor", async () => {
+      await request(app)
+        .put("/cursor/update-test")
+        .set(getAuthHeaders())
+        .send({ state: { v: 1 } });
+
+      await request(app)
+        .put("/cursor/update-test")
+        .set(getAuthHeaders())
+        .send({ state: { v: 2 } });
+
+      const res = await request(app)
+        .get("/cursor/update-test")
+        .set(getAuthHeaders());
+
+      expect(res.body.state).toEqual({ v: 2 });
+    });
+  });
+});

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,0 +1,45 @@
+import { db, sql } from "../../src/db/index.js";
+import { organizations, servedLeads, leadBuffer, cursors } from "../../src/db/schema.js";
+import { eq } from "drizzle-orm";
+
+export const TEST_API_KEY = "test-api-key-12345";
+export const TEST_APP_ID = "test-app";
+export const TEST_ORG_ID = "test-org-integration";
+
+let testOrgUuid: string | null = null;
+
+export async function setupTestOrg(): Promise<string> {
+  // Clean up any existing test org
+  await cleanupTestData();
+
+  // Create test organization
+  const [org] = await db
+    .insert(organizations)
+    .values({ appId: TEST_APP_ID, externalId: TEST_ORG_ID })
+    .returning();
+
+  testOrgUuid = org.id;
+  return org.id;
+}
+
+export async function cleanupTestData(): Promise<void> {
+  if (testOrgUuid) {
+    await db.delete(cursors).where(eq(cursors.organizationId, testOrgUuid));
+    await db.delete(leadBuffer).where(eq(leadBuffer.organizationId, testOrgUuid));
+    await db.delete(servedLeads).where(eq(servedLeads.organizationId, testOrgUuid));
+    await db.delete(organizations).where(eq(organizations.id, testOrgUuid));
+    testOrgUuid = null;
+  }
+}
+
+export async function closeDb(): Promise<void> {
+  await sql.end();
+}
+
+export function getAuthHeaders() {
+  return {
+    "x-api-key": TEST_API_KEY,
+    "x-app-id": TEST_APP_ID,
+    "x-org-id": TEST_ORG_ID,
+  };
+}


### PR DESCRIPTION
Configures environment variables to use LEAD_SERVICE prefixes and sets up CI/integration testing infrastructure.

- Renames DATABASE_URL to LEAD_SERVICE_DATABASE_URL and API_KEY to LEAD_SERVICE_API_KEY
- Adds GitHub Actions workflow for building and running tests
- Adds integration test suite covering buffer and cursor API endpoints
- Includes test setup helpers with authentication and cleanup

Tests pass locally (10 unit tests). Integration tests will run in CI with the database secret.