### PR TITLE
Fix runs service API field name in ensureOrganization

### DIFF
--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -32,7 +32,7 @@ export async function ensureOrganization(externalOrgId: string): Promise<string>
 
   const result = await callRunsService("/organizations", {
     method: "POST",
-    body: { clerkOrgId: externalOrgId },
+    body: { externalId: externalOrgId },
   }) as { id: string };
 
   orgCache.set(externalOrgId, result.id);


### PR DESCRIPTION
The /organizations endpoint requires 'externalId' field, not 'clerkOrgId'. This fixes the 400 error when creating child runs from buffer/next endpoint.