### PR TITLE
Fix Sentry Express instrumentation with ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "node --import ./dist/instrument.js dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:unit": "vitest run tests/unit",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import "./instrument.js";
 import * as Sentry from "@sentry/node";
 import express from "express";
 import cors from "cors";


### PR DESCRIPTION
Use Node's --import flag to load Sentry before Express initializes. This allows Sentry to properly instrument the Express framework per the ESM setup requirements in Sentry v8+.

Fixes the warning: 'express is not instrumented. Please make sure to initialize Sentry in a separate file that you `--import` when running node.'