### PR TITLE
Fix Sentry Express instrumentation with ESM

### DIFF
--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -6,6 +6,7 @@ if (process.env.SENTRY_DSN) {
     environment: process.env.NODE_ENV || "development",
     tracesSampleRate: 0.1,
     sendDefaultPii: true,
+    registerEsmLoaderHooks: { exclude: [/drizzle-orm/] },
   });
   Sentry.setTag("service", "lead-service");
 }


### PR DESCRIPTION
The import-in-the-middle ESM loader hooks were failing to wrap drizzle-orm's barrel exports, causing named exports like 'and' and 'eq' to become unavailable at runtime. Exclude drizzle-orm from ESM loader hook wrapping to allow Node.js to load it natively with all exports intact.