### PR TITLE
Add detailed backend logging for lead retrieval debugging

### DIFF
--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -58,10 +58,13 @@ export async function apolloSearch(
   page: number = 1
 ): Promise<ApolloSearchResult | null> {
   try {
-    return await callApolloService<ApolloSearchResult>("/search", {
+    console.log(`[apollo-client] Searching page=${page} url=${APOLLO_SERVICE_URL}/search`);
+    const result = await callApolloService<ApolloSearchResult>("/search", {
       method: "POST",
       body: { ...params, page },
     });
+    console.log(`[apollo-client] Response: ${result.people.length} people, page ${result.pagination.page}/${result.pagination.totalPages} (total=${result.pagination.totalEntries})`);
+    return result;
   } catch (error) {
     console.error("[apollo-client] Search failed:", error);
     return null;

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -20,6 +20,8 @@ export async function pushLeads(params: {
   let buffered = 0;
   let skippedAlreadyServed = 0;
 
+  console.log(`[pushLeads] Processing ${params.leads.length} leads for org=${params.organizationId} ns=${params.namespace}`);
+
   for (const lead of params.leads) {
     const alreadyServed = await isServed(
       params.organizationId,
@@ -28,6 +30,7 @@ export async function pushLeads(params: {
     );
 
     if (alreadyServed) {
+      console.log(`[pushLeads] Skipped (already served): ${lead.email}`);
       skippedAlreadyServed++;
       continue;
     }
@@ -47,6 +50,7 @@ export async function pushLeads(params: {
     buffered++;
   }
 
+  console.log(`[pushLeads] Done: buffered=${buffered} skipped=${skippedAlreadyServed}`);
   return { buffered, skippedAlreadyServed };
 }
 
@@ -98,20 +102,39 @@ async function fillBufferFromSearch(params: {
 }): Promise<{ filled: number; exhausted: boolean }> {
   const cursor = await getCursor(params.organizationId, params.namespace);
 
+  console.log(`[fillBuffer] org=${params.organizationId} ns=${params.namespace} cursor={page:${cursor.page}, exhausted:${cursor.exhausted}}`);
+
   if (cursor.exhausted) {
+    console.log("[fillBuffer] Cursor already exhausted, returning 0");
     return { filled: 0, exhausted: true };
   }
 
+  console.log(`[fillBuffer] Calling Apollo search page=${cursor.page} params=${JSON.stringify(params.searchParams)}`);
   const result = await apolloSearch(params.searchParams, cursor.page);
 
-  if (!result || result.people.length === 0) {
+  if (!result) {
+    console.log("[fillBuffer] Apollo returned null (search failed or network error)");
     await setCursor(params.organizationId, params.namespace, { page: cursor.page, exhausted: true });
     return { filled: 0, exhausted: true };
   }
 
+  if (result.people.length === 0) {
+    console.log(`[fillBuffer] Apollo returned 0 people (page=${cursor.page} totalPages=${result.pagination.totalPages} totalEntries=${result.pagination.totalEntries})`);
+    await setCursor(params.organizationId, params.namespace, { page: cursor.page, exhausted: true });
+    return { filled: 0, exhausted: true };
+  }
+
+  console.log(`[fillBuffer] Apollo returned ${result.people.length} people (page=${cursor.page}/${result.pagination.totalPages}, total=${result.pagination.totalEntries})`);
+
   let filled = 0;
+  let skippedNoEmail = 0;
+  let skippedAlreadyServed = 0;
+
   for (const person of result.people) {
-    if (!person.email) continue;
+    if (!person.email) {
+      skippedNoEmail++;
+      continue;
+    }
 
     const alreadyServed = await isServed(
       params.organizationId,
@@ -119,7 +142,10 @@ async function fillBufferFromSearch(params: {
       person.email
     );
 
-    if (alreadyServed) continue;
+    if (alreadyServed) {
+      skippedAlreadyServed++;
+      continue;
+    }
 
     await db.insert(leadBuffer).values({
       organizationId: params.organizationId,
@@ -141,6 +167,8 @@ async function fillBufferFromSearch(params: {
     page: cursor.page + 1,
     exhausted: isExhausted,
   });
+
+  console.log(`[fillBuffer] Done: filled=${filled} skippedNoEmail=${skippedNoEmail} skippedAlreadyServed=${skippedAlreadyServed} exhausted=${isExhausted}`);
 
   return { filled, exhausted: isExhausted && filled === 0 };
 }
@@ -165,7 +193,11 @@ export async function pullNext(params: {
     clerkUserId: string | null;
   };
 }> {
+  console.log(`[pullNext] Called for org=${params.organizationId} ns=${params.namespace} hasSearchParams=${!!params.searchParams}`);
+
+  let iterations = 0;
   while (true) {
+    iterations++;
     const row = await db.query.leadBuffer.findFirst({
       where: and(
         eq(leadBuffer.organizationId, params.organizationId),
@@ -175,8 +207,10 @@ export async function pullNext(params: {
     });
 
     if (!row) {
+      console.log(`[pullNext] Buffer empty (iteration ${iterations})`);
       // Buffer empty - try to fill from search if searchParams provided
       if (params.searchParams) {
+        console.log("[pullNext] Attempting to fill buffer from Apollo search...");
         const { filled, exhausted } = await fillBufferFromSearch({
           organizationId: params.organizationId,
           namespace: params.namespace,
@@ -188,19 +222,25 @@ export async function pullNext(params: {
         });
 
         if (filled > 0) {
+          console.log(`[pullNext] Buffer filled with ${filled} leads, retrying pull`);
           continue; // Retry pulling from buffer
         }
 
         if (exhausted) {
+          console.log("[pullNext] Search exhausted, no more leads available -> found=false");
           return { found: false };
         }
 
         // No results but not exhausted - keep trying next page
+        console.log("[pullNext] Page had no usable results but not exhausted, trying next page");
         continue;
       }
 
+      console.log("[pullNext] No searchParams provided and buffer empty -> found=false");
       return { found: false };
     }
+
+    console.log(`[pullNext] Found buffered lead: ${row.email} (iteration ${iterations})`);
 
     const alreadyServed = await isServed(
       params.organizationId,
@@ -209,6 +249,7 @@ export async function pullNext(params: {
     );
 
     if (alreadyServed) {
+      console.log(`[pullNext] Lead ${row.email} already served, skipping`);
       await db
         .update(leadBuffer)
         .set({ status: "skipped" })
@@ -233,6 +274,8 @@ export async function pullNext(params: {
       .update(leadBuffer)
       .set({ status: "served" })
       .where(eq(leadBuffer.id, row.id));
+
+    console.log(`[pullNext] Serving lead: ${row.email} (after ${iterations} iterations)`);
 
     return {
       found: true,

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -62,6 +62,7 @@ export async function authenticate(
     req.organizationId = org.id;
     req.appId = appId;
     req.externalOrgId = externalOrgId;
+    console.log(`[auth] Resolved org: appId=${appId} externalOrgId=${externalOrgId} -> internalOrgId=${org.id}`);
     next();
   } catch (error) {
     console.error("[auth] Error:", error);

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -9,7 +9,10 @@ router.post("/buffer/push", authenticate, async (req: AuthenticatedRequest, res)
   try {
     const { namespace, parentRunId, brandId, clerkOrgId, clerkUserId, leads } = req.body;
 
+    console.log(`[buffer/push] Called for org=${req.organizationId} namespace=${namespace} leads=${Array.isArray(leads) ? leads.length : "invalid"} brandId=${brandId || "none"} clerkOrgId=${clerkOrgId || "none"}`);
+
     if (!namespace || !Array.isArray(leads)) {
+      console.log("[buffer/push] Rejected: missing namespace or leads[]");
       return res.status(400).json({ error: "namespace and leads[] required" });
     }
 
@@ -40,6 +43,8 @@ router.post("/buffer/push", authenticate, async (req: AuthenticatedRequest, res)
       leads,
     });
 
+    console.log(`[buffer/push] Result: buffered=${result.buffered} skippedAlreadyServed=${result.skippedAlreadyServed}`);
+
     if (pushRunId) {
       try {
         await updateRun(pushRunId, "completed");
@@ -59,7 +64,10 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
   try {
     const { namespace, parentRunId, searchParams, brandId, clerkOrgId, clerkUserId } = req.body;
 
+    console.log(`[buffer/next] Called for org=${req.organizationId} namespace=${namespace} hasSearchParams=${!!searchParams} brandId=${brandId || "none"} clerkOrgId=${clerkOrgId || "none"}`);
+
     if (!namespace) {
+      console.log("[buffer/next] Rejected: missing namespace");
       return res.status(400).json({ error: "namespace required" });
     }
 
@@ -90,6 +98,8 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       clerkOrgId: clerkOrgId ?? null,
       clerkUserId: clerkUserId ?? null,
     });
+
+    console.log(`[buffer/next] Result: found=${result.found} email=${result.lead?.email || "none"}`);
 
     if (serveRunId) {
       try {

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -10,6 +10,14 @@ router.get("/leads", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const { brandId, clerkOrgId, clerkUserId } = req.query;
 
+    const filters = {
+      organizationId: req.organizationId,
+      brandId: brandId || null,
+      clerkOrgId: clerkOrgId || null,
+      clerkUserId: clerkUserId || null,
+    };
+    console.log("[leads] GET /leads called with filters:", JSON.stringify(filters));
+
     // Build filter conditions
     const conditions: SQL[] = [eq(servedLeads.organizationId, req.organizationId!)];
 
@@ -28,6 +36,11 @@ router.get("/leads", authenticate, async (req: AuthenticatedRequest, res) => {
       where: and(...conditions),
     });
 
+    console.log(`[leads] Found ${leads.length} served leads for org=${req.organizationId}`);
+    if (leads.length === 0) {
+      console.log("[leads] 0 leads returned. Possible causes: no leads served yet for this org, or filters too restrictive. Filters applied:", JSON.stringify(filters));
+    }
+
     // Get enrichment data for all leads
     const emails = leads.map((l) => l.email.toLowerCase());
     const enrichmentData = emails.length > 0
@@ -35,6 +48,10 @@ router.get("/leads", authenticate, async (req: AuthenticatedRequest, res) => {
           where: (table, { inArray }) => inArray(table.email, emails),
         })
       : [];
+
+    if (leads.length > 0) {
+      console.log(`[leads] Found ${enrichmentData.length}/${leads.length} enrichments`);
+    }
 
     // Create email -> enrichment map
     const enrichmentMap = new Map(


### PR DESCRIPTION
Adds comprehensive console logs across the lead service to diagnose zero lead returns:

- Auth middleware: logs org resolution (appId -> internalId)
- GET /leads: logs query filters and result counts  
- POST /buffer/push: logs input params and buffering stats
- POST /buffer/next: logs invocation and result
- Buffer logic: logs cursor state, Apollo search responses, and filtering stats (noEmail, alreadyServed)
- Apollo client: logs search requests and pagination info

Enables clear diagnosis of why 0 leads occur: org not found, buffer empty, search returned 0 results, cursor exhausted, or all results already served.