### PR TITLE
Add Apollo search param validation via LLM + caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.73.0",
     "@sentry/node": "^8.0.0",
     "cors": "^2.8.5",
     "drizzle-orm": "^0.36.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.73.0
+        version: 0.73.0
       '@sentry/node':
         specifier: ^8.0.0
         version: 8.55.0
@@ -57,6 +60,15 @@ importers:
 
 packages:
 
+  '@anthropic-ai/sdk@0.73.0':
+    resolution: {integrity: sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -69,6 +81,10 @@ packages:
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -1421,6 +1437,10 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1688,6 +1708,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -1805,6 +1828,10 @@ packages:
 
 snapshots:
 
+  '@anthropic-ai/sdk@0.73.0':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -1812,6 +1839,8 @@ snapshots:
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/runtime@7.28.6': {}
 
   '@babel/types@7.29.0':
     dependencies:
@@ -3048,6 +3077,11 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      ts-algebra: 2.0.0
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3333,6 +3367,8 @@ snapshots:
   tinyrainbow@3.0.3: {}
 
   toidentifier@1.0.1: {}
+
+  ts-algebra@2.0.0: {}
 
   tsx@4.21.0:
     dependencies:

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -3,15 +3,16 @@ const APOLLO_SERVICE_API_KEY = process.env.APOLLO_SERVICE_API_KEY || "";
 
 async function callApolloService<T>(
   path: string,
-  options: { method?: string; body?: unknown } = {}
+  options: { method?: string; body?: unknown; headers?: Record<string, string> } = {}
 ): Promise<T> {
-  const { method = "GET", body } = options;
+  const { method = "GET", body, headers: extraHeaders } = options;
 
   const response = await fetch(`${APOLLO_SERVICE_URL}${path}`, {
     method,
     headers: {
       "Content-Type": "application/json",
       "X-API-Key": APOLLO_SERVICE_API_KEY,
+      ...extraHeaders,
     },
     body: body ? JSON.stringify(body) : undefined,
   });
@@ -66,4 +67,81 @@ export async function apolloSearch(
     console.error("[apollo-client] Search failed:", error);
     return null;
   }
+}
+
+// --- Validation ---
+
+export interface ValidationError {
+  field: string;
+  message: string;
+  value?: unknown;
+}
+
+export interface ValidationResult {
+  index: number;
+  valid: boolean;
+  endpoint: string;
+  errors: ValidationError[];
+}
+
+export interface ValidationResponse {
+  results: ValidationResult[];
+}
+
+export async function validateSearchParams(
+  params: Record<string, unknown>,
+  clerkOrgId?: string | null
+): Promise<ValidationResult> {
+  const headers: Record<string, string> = {};
+  if (clerkOrgId) headers["x-clerk-org-id"] = clerkOrgId;
+
+  const response = await callApolloService<ValidationResponse>("/validate", {
+    method: "POST",
+    body: { endpoint: "search", items: [params] },
+    headers,
+  });
+
+  return response.results[0];
+}
+
+// --- Reference Data ---
+
+export interface ApolloIndustry {
+  id: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+export interface ApolloEmployeeRange {
+  value: string;
+  label: string;
+  [key: string]: unknown;
+}
+
+let industriesCache: { data: ApolloIndustry[]; fetchedAt: number } | null = null;
+let employeeRangesCache: { data: ApolloEmployeeRange[]; fetchedAt: number } | null = null;
+const REFERENCE_CACHE_TTL = 24 * 60 * 60 * 1000; // 24h
+
+export async function fetchIndustries(clerkOrgId?: string | null): Promise<ApolloIndustry[]> {
+  if (industriesCache && Date.now() - industriesCache.fetchedAt < REFERENCE_CACHE_TTL) {
+    return industriesCache.data;
+  }
+  const headers: Record<string, string> = {};
+  if (clerkOrgId) headers["x-clerk-org-id"] = clerkOrgId;
+
+  const data = await callApolloService<ApolloIndustry[]>("/reference/industries", { headers });
+  industriesCache = { data, fetchedAt: Date.now() };
+  return data;
+}
+
+export async function fetchEmployeeRanges(clerkOrgId?: string | null): Promise<ApolloEmployeeRange[]> {
+  if (employeeRangesCache && Date.now() - employeeRangesCache.fetchedAt < REFERENCE_CACHE_TTL) {
+    return employeeRangesCache.data;
+  }
+  const headers: Record<string, string> = {};
+  if (clerkOrgId) headers["x-clerk-org-id"] = clerkOrgId;
+
+  const data = await callApolloService<ApolloEmployeeRange[]>("/reference/employee-ranges", { headers });
+  employeeRangesCache = { data, fetchedAt: Date.now() };
+  return data;
 }

--- a/src/lib/search-transform.ts
+++ b/src/lib/search-transform.ts
@@ -1,0 +1,173 @@
+import Anthropic from "@anthropic-ai/sdk";
+import {
+  validateSearchParams,
+  fetchIndustries,
+  fetchEmployeeRanges,
+  type ApolloSearchParams,
+  type ValidationResult,
+} from "./apollo-client.js";
+import { addCosts } from "./runs-client.js";
+
+const MAX_RETRIES = 3;
+const CACHE_TTL = 6 * 30 * 24 * 60 * 60 * 1000; // ~6 months
+
+// In-memory cache: hash(raw input) → validated ApolloSearchParams
+const transformCache = new Map<string, { params: ApolloSearchParams; cachedAt: number }>();
+
+function cacheKey(input: Record<string, unknown>): string {
+  return JSON.stringify(input, Object.keys(input).sort());
+}
+
+function getCached(key: string): ApolloSearchParams | null {
+  const entry = transformCache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.cachedAt > CACHE_TTL) {
+    transformCache.delete(key);
+    return null;
+  }
+  return entry.params;
+}
+
+function buildSystemPrompt(
+  industries: Array<{ id: string; name: string }>,
+  employeeRanges: Array<{ value: string; label: string }>
+): string {
+  return `You transform search parameters into Apollo API search format.
+
+Output ONLY valid JSON matching ApolloSearchParams. No explanation, no markdown.
+
+ApolloSearchParams fields:
+- personTitles: string[] — job titles (e.g. ["VP Sales", "Head of Marketing"])
+- organizationLocations: string[] — locations (e.g. ["San Francisco, California, United States"])
+- organizationIndustries: string[] — industry tag IDs from the list below
+- organizationNumEmployeesRanges: string[] — exact enum values from the list below
+- keywords: string[] — additional search keywords
+
+Valid employee ranges:
+${employeeRanges.map((r) => `- "${r.value}" (${r.label})`).join("\n")}
+
+Valid industry IDs (use the id, not the name):
+${industries.map((i) => `- "${i.id}" (${i.name})`).join("\n")}
+
+Rules:
+- Only include fields that are relevant to the input
+- Use exact enum values for employee ranges
+- Use industry IDs (not names) for organizationIndustries
+- Output raw JSON only, no wrapping`;
+}
+
+function buildRetryPrompt(
+  previousAttempt: string,
+  errors: ValidationResult["errors"]
+): string {
+  const errorLines = errors
+    .map((e) => `- Field "${e.field}": ${e.message}${e.value ? ` (got: ${JSON.stringify(e.value)})` : ""}`)
+    .join("\n");
+  return `Your previous output was invalid:
+
+${previousAttempt}
+
+Validation errors:
+${errorLines}
+
+Fix these errors and output corrected JSON only.`;
+}
+
+let anthropicClient: Anthropic | null = null;
+
+function getClient(): Anthropic {
+  if (!anthropicClient) {
+    anthropicClient = new Anthropic();
+  }
+  return anthropicClient;
+}
+
+export async function transformSearchParams(
+  rawParams: Record<string, unknown>,
+  clerkOrgId?: string | null,
+  runId?: string | null
+): Promise<ApolloSearchParams> {
+  // Check cache first
+  const key = cacheKey(rawParams);
+  const cached = getCached(key);
+  if (cached) {
+    console.log("[search-transform] Cache hit");
+    return cached;
+  }
+
+  // Fetch reference data for the LLM prompt
+  const [industries, employeeRanges] = await Promise.all([
+    fetchIndustries(clerkOrgId),
+    fetchEmployeeRanges(clerkOrgId),
+  ]);
+
+  const systemPrompt = buildSystemPrompt(industries, employeeRanges);
+  const client = getClient();
+  let lastAttempt = "";
+  let lastErrors: ValidationResult["errors"] = [];
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    const userMessage =
+      attempt === 1
+        ? `Transform this into ApolloSearchParams:\n${JSON.stringify(rawParams, null, 2)}`
+        : buildRetryPrompt(lastAttempt, lastErrors);
+
+    const response = await client.messages.create({
+      model: "claude-opus-4-5",
+      max_tokens: 1024,
+      system: systemPrompt,
+      messages: [{ role: "user", content: userMessage }],
+    });
+
+    totalInputTokens += response.usage.input_tokens;
+    totalOutputTokens += response.usage.output_tokens;
+
+    const text = response.content[0].type === "text" ? response.content[0].text : "";
+    lastAttempt = text.trim();
+
+    let parsed: ApolloSearchParams;
+    try {
+      parsed = JSON.parse(lastAttempt);
+    } catch {
+      console.error(`[search-transform] Attempt ${attempt}: invalid JSON`);
+      lastErrors = [{ field: "root", message: "Response was not valid JSON" }];
+      continue;
+    }
+
+    // Validate via Apollo
+    const validation = await validateSearchParams(parsed, clerkOrgId);
+
+    if (validation.valid) {
+      console.log(`[search-transform] Valid on attempt ${attempt}`);
+      transformCache.set(key, { params: parsed, cachedAt: Date.now() });
+      await logCosts(runId, totalInputTokens, totalOutputTokens);
+      return parsed;
+    }
+
+    console.warn(`[search-transform] Attempt ${attempt} invalid:`, validation.errors);
+    lastErrors = validation.errors;
+  }
+
+  await logCosts(runId, totalInputTokens, totalOutputTokens);
+  throw new Error(
+    `Failed to transform search params after ${MAX_RETRIES} attempts. Last errors: ${JSON.stringify(lastErrors)}`
+  );
+}
+
+async function logCosts(
+  runId: string | null | undefined,
+  inputTokens: number,
+  outputTokens: number
+): Promise<void> {
+  if (!runId || (inputTokens === 0 && outputTokens === 0)) return;
+  try {
+    await addCosts(runId, [
+      { costName: "anthropic-opus-4.5-tokens-input", quantity: inputTokens },
+      { costName: "anthropic-opus-4.5-tokens-output", quantity: outputTokens },
+    ]);
+  } catch (err) {
+    console.error("[search-transform] Failed to log costs:", err);
+  }
+}


### PR DESCRIPTION
Implements LLM-driven transformation of raw search parameters to Apollo format with automatic validation and 6-month caching. Reference data endpoints fetch industries and employee ranges with 24h cache. Uses Claude Opus 4.5 with retry logic (max 3 attempts) for format validation. Costs tracked via RunsService (anthropic-opus-4.5-tokens-input/output).