### PR TITLE
Pass runId and clerkOrgId to Apollo search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "lead-service",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.73.0",
         "@sentry/node": "^8.0.0",
         "cors": "^2.8.5",
         "drizzle-orm": "^0.36.0",
@@ -25,6 +26,26 @@
         "tsx": "^4.0.0",
         "typescript": "^5.3.0",
         "vitest": "^4.0.18"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.73.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+      "integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -61,6 +82,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -3551,6 +3581,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4426,6 +4469,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -56,13 +56,18 @@ export interface ApolloSearchResult {
 
 export async function apolloSearch(
   params: ApolloSearchParams,
-  page: number = 1
+  page: number = 1,
+  options?: { runId?: string | null; clerkOrgId?: string | null }
 ): Promise<ApolloSearchResult | null> {
   try {
-    console.log(`[apollo-client] Searching page=${page} url=${APOLLO_SERVICE_URL}/search`);
+    console.log(`[apollo-client] Searching page=${page} runId=${options?.runId ?? "none"} url=${APOLLO_SERVICE_URL}/search`);
+    const headers: Record<string, string> = {};
+    if (options?.clerkOrgId) headers["x-clerk-org-id"] = options.clerkOrgId;
+
     const result = await callApolloService<ApolloSearchResult>("/search", {
       method: "POST",
-      body: { ...params, page },
+      body: { ...params, page, ...(options?.runId ? { runId: options.runId } : {}) },
+      headers,
     });
     console.log(`[apollo-client] Response: ${result.people.length} people, page ${result.pagination.page}/${result.pagination.totalPages} (total=${result.pagination.totalEntries})`);
     return result;

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -117,8 +117,11 @@ async function fillBufferFromSearch(params: {
     params.pushRunId
   );
 
-  console.log(`[fillBuffer] Calling Apollo search page=${cursor.page} params=${JSON.stringify(validatedParams)}`);
-  const result = await apolloSearch(validatedParams, cursor.page);
+  console.log(`[fillBuffer] Calling Apollo search page=${cursor.page} runId=${params.pushRunId ?? "none"} params=${JSON.stringify(validatedParams)}`);
+  const result = await apolloSearch(validatedParams, cursor.page, {
+    runId: params.pushRunId,
+    clerkOrgId: params.clerkOrgId,
+  });
 
   if (!result) {
     console.log("[fillBuffer] Apollo returned null (search failed or network error)");


### PR DESCRIPTION
## Summary
Pass runId and clerkOrgId when calling Apollo search endpoint so Apollo can properly track which search operation produced which leads.

## Changes
- `apolloSearch()` now accepts optional runId and clerkOrgId in an options parameter
- runId is included in request body to Apollo
- clerkOrgId is sent as x-clerk-org-id header (matching other Apollo calls)
- `fillBufferFromSearch()` passes through both values from the parent run context

This fixes the issue where Apollo service was receiving search calls without runId context.