### PR TITLE
Scope cursor and buffer per campaignId, dedup per brandId

### DIFF
--- a/drizzle/0002_cursor_per_campaign.sql
+++ b/drizzle/0002_cursor_per_campaign.sql
@@ -1,0 +1,20 @@
+-- Add campaign_id to lead_buffer
+ALTER TABLE "lead_buffer" ADD COLUMN "campaign_id" text;--> statement-breakpoint
+UPDATE "lead_buffer" SET "campaign_id" = "namespace" WHERE "campaign_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "lead_buffer" ALTER COLUMN "campaign_id" SET NOT NULL;--> statement-breakpoint
+
+-- Add campaign_id to served_leads
+ALTER TABLE "served_leads" ADD COLUMN "campaign_id" text;--> statement-breakpoint
+UPDATE "served_leads" SET "campaign_id" = "namespace" WHERE "campaign_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "served_leads" ALTER COLUMN "campaign_id" SET NOT NULL;--> statement-breakpoint
+
+-- Make brand_id NOT NULL on served_leads (backfill from namespace for existing rows)
+UPDATE "served_leads" SET "brand_id" = "namespace" WHERE "brand_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "served_leads" ALTER COLUMN "brand_id" SET NOT NULL;--> statement-breakpoint
+
+-- Replace dedup unique index: (orgId, namespace, email) → (orgId, brandId, email)
+DROP INDEX IF EXISTS "idx_served_org_ns_email";--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_served_org_brand_email" ON "served_leads" USING btree ("organization_id", "brand_id", "email");--> statement-breakpoint
+
+-- Add campaign index on served_leads
+CREATE INDEX "idx_served_campaign" ON "served_leads" USING btree ("campaign_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1770346338317,
       "tag": "0001_glossy_fenris",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1770422400000,
+      "tag": "0002_cursor_per_campaign",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -4,13 +4,13 @@ import { servedLeads } from "../db/schema.js";
 
 export async function isServed(
   organizationId: string,
-  namespace: string,
+  brandId: string,
   email: string
 ): Promise<boolean> {
   const existing = await db.query.servedLeads.findFirst({
     where: and(
       eq(servedLeads.organizationId, organizationId),
-      eq(servedLeads.namespace, namespace),
+      eq(servedLeads.brandId, brandId),
       eq(servedLeads.email, email)
     ),
   });
@@ -20,12 +20,13 @@ export async function isServed(
 export async function markServed(params: {
   organizationId: string;
   namespace: string;
+  brandId: string;
+  campaignId: string;
   email: string;
   externalId?: string | null;
   metadata?: unknown;
   parentRunId?: string | null;
   runId?: string | null;
-  brandId?: string | null;
   clerkOrgId?: string | null;
   clerkUserId?: string | null;
 }): Promise<{ inserted: boolean }> {
@@ -39,7 +40,8 @@ export async function markServed(params: {
       metadata: params.metadata ?? null,
       parentRunId: params.parentRunId ?? null,
       runId: params.runId ?? null,
-      brandId: params.brandId ?? null,
+      brandId: params.brandId,
+      campaignId: params.campaignId,
       clerkOrgId: params.clerkOrgId ?? null,
       clerkUserId: params.clerkUserId ?? null,
     })

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -7,13 +7,13 @@ const router = Router();
 
 router.post("/buffer/push", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
-    const { namespace, parentRunId, brandId, clerkOrgId, clerkUserId, leads } = req.body;
+    const { campaignId, brandId, parentRunId, clerkOrgId, clerkUserId, leads } = req.body;
 
-    console.log(`[buffer/push] Called for org=${req.organizationId} namespace=${namespace} leads=${Array.isArray(leads) ? leads.length : "invalid"} brandId=${brandId || "none"} clerkOrgId=${clerkOrgId || "none"}`);
+    console.log(`[buffer/push] Called for org=${req.organizationId} campaignId=${campaignId || "none"} brandId=${brandId || "none"} leads=${Array.isArray(leads) ? leads.length : "invalid"} clerkOrgId=${clerkOrgId || "none"}`);
 
-    if (!namespace || !Array.isArray(leads)) {
-      console.log("[buffer/push] Rejected: missing namespace or leads[]");
-      return res.status(400).json({ error: "namespace and leads[] required" });
+    if (!campaignId || !brandId || !Array.isArray(leads)) {
+      console.log("[buffer/push] Rejected: missing campaignId, brandId, or leads[]");
+      return res.status(400).json({ error: "campaignId, brandId, and leads[] required" });
     }
 
     // Create child run for traceability
@@ -35,9 +35,9 @@ router.post("/buffer/push", authenticate, async (req: AuthenticatedRequest, res)
 
     const result = await pushLeads({
       organizationId: req.organizationId!,
-      namespace,
+      campaignId,
+      brandId,
       pushRunId,
-      brandId: brandId ?? null,
       clerkOrgId: clerkOrgId ?? null,
       clerkUserId: clerkUserId ?? null,
       leads,
@@ -62,13 +62,13 @@ router.post("/buffer/push", authenticate, async (req: AuthenticatedRequest, res)
 
 router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
-    const { namespace, parentRunId, searchParams, brandId, clerkOrgId, clerkUserId } = req.body;
+    const { campaignId, brandId, parentRunId, searchParams, clerkOrgId, clerkUserId } = req.body;
 
-    console.log(`[buffer/next] Called for org=${req.organizationId} namespace=${namespace} hasSearchParams=${!!searchParams} brandId=${brandId || "none"} clerkOrgId=${clerkOrgId || "none"}`);
+    console.log(`[buffer/next] Called for org=${req.organizationId} campaignId=${campaignId || "none"} brandId=${brandId || "none"} hasSearchParams=${!!searchParams} clerkOrgId=${clerkOrgId || "none"}`);
 
-    if (!namespace) {
-      console.log("[buffer/next] Rejected: missing namespace");
-      return res.status(400).json({ error: "namespace required" });
+    if (!campaignId || !brandId) {
+      console.log("[buffer/next] Rejected: missing campaignId or brandId");
+      return res.status(400).json({ error: "campaignId and brandId required" });
     }
 
     // Create child run for traceability
@@ -90,11 +90,11 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
 
     const result = await pullNext({
       organizationId: req.organizationId!,
-      namespace,
+      campaignId,
+      brandId,
       parentRunId: parentRunId ?? null,
       runId: serveRunId,
       searchParams: searchParams ?? undefined,
-      brandId: brandId ?? null,
       clerkOrgId: clerkOrgId ?? null,
       clerkUserId: clerkUserId ?? null,
     });

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -35,7 +35,8 @@ describe("buffer", () => {
 
       const result = await pushLeads({
         organizationId: "org-1",
-        namespace: "brand-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
         leads: [
           { email: "alice@acme.com", externalId: "e-1", data: { name: "Alice" } },
           { email: "bob@acme.com", externalId: "e-2", data: { name: "Bob" } },
@@ -52,12 +53,14 @@ describe("buffer", () => {
         .mockResolvedValueOnce({
           id: "uuid-1",
           organizationId: "org-1",
-          namespace: "brand-1",
+          namespace: "campaign-1",
           email: "alice@acme.com",
           externalId: null,
           metadata: null,
           parentRunId: null,
           runId: null,
+          brandId: "brand-1",
+          campaignId: "campaign-1",
           servedAt: new Date(),
         })
         .mockResolvedValueOnce(undefined);
@@ -67,7 +70,8 @@ describe("buffer", () => {
 
       const result = await pushLeads({
         organizationId: "org-1",
-        namespace: "brand-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
         leads: [
           { email: "alice@acme.com", externalId: "e-1" },
           { email: "bob@acme.com", externalId: "e-2" },
@@ -85,7 +89,8 @@ describe("buffer", () => {
 
       const result = await pullNext({
         organizationId: "org-1",
-        namespace: "brand-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
       });
 
       expect(result.found).toBe(false);
@@ -96,12 +101,16 @@ describe("buffer", () => {
       vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValue({
         id: "buf-1",
         organizationId: "org-1",
-        namespace: "brand-1",
+        namespace: "campaign-1",
+        campaignId: "campaign-1",
         email: "alice@acme.com",
         externalId: "e-1",
         data: { name: "Alice" },
         status: "buffered",
         pushRunId: null,
+        brandId: "brand-1",
+        clerkOrgId: null,
+        clerkUserId: null,
         createdAt: new Date(),
       });
 
@@ -122,7 +131,8 @@ describe("buffer", () => {
 
       const result = await pullNext({
         organizationId: "org-1",
-        namespace: "brand-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
         parentRunId: "run-1",
         runId: "child-run-1",
       });
@@ -139,23 +149,31 @@ describe("buffer", () => {
         .mockResolvedValueOnce({
           id: "buf-1",
           organizationId: "org-1",
-          namespace: "brand-1",
+          namespace: "campaign-1",
+          campaignId: "campaign-1",
           email: "alice@acme.com",
           externalId: "e-1",
           data: { name: "Alice" },
           status: "buffered",
           pushRunId: null,
+          brandId: "brand-1",
+          clerkOrgId: null,
+          clerkUserId: null,
           createdAt: new Date(),
         })
         .mockResolvedValueOnce({
           id: "buf-2",
           organizationId: "org-1",
-          namespace: "brand-1",
+          namespace: "campaign-1",
+          campaignId: "campaign-1",
           email: "bob@acme.com",
           externalId: "e-2",
           data: { name: "Bob" },
           status: "buffered",
           pushRunId: null,
+          brandId: "brand-1",
+          clerkOrgId: null,
+          clerkUserId: null,
           createdAt: new Date(),
         });
 
@@ -164,12 +182,14 @@ describe("buffer", () => {
         .mockResolvedValueOnce({
           id: "served-1",
           organizationId: "org-1",
-          namespace: "brand-1",
+          namespace: "campaign-1",
           email: "alice@acme.com",
           externalId: null,
           metadata: null,
           parentRunId: null,
           runId: null,
+          brandId: "brand-1",
+          campaignId: "campaign-1",
           servedAt: new Date(),
         })
         .mockResolvedValueOnce(undefined);
@@ -188,7 +208,8 @@ describe("buffer", () => {
 
       const result = await pullNext({
         organizationId: "org-1",
-        namespace: "brand-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
       });
 
       expect(result.found).toBe(true);

--- a/tests/unit/dedup.test.ts
+++ b/tests/unit/dedup.test.ts
@@ -21,16 +21,18 @@ describe("dedup", () => {
   });
 
   describe("isServed", () => {
-    it("returns true when email already served for org+namespace", async () => {
+    it("returns true when email already served for org+brand", async () => {
       vi.mocked(db.query.servedLeads.findFirst).mockResolvedValue({
         id: "uuid-1",
         organizationId: "org-1",
-        namespace: "brand-1",
+        namespace: "campaign-1",
         email: "alice@acme.com",
         externalId: null,
         metadata: null,
         parentRunId: null,
         runId: null,
+        brandId: "brand-1",
+        campaignId: "campaign-1",
         servedAt: new Date(),
       });
 
@@ -45,7 +47,7 @@ describe("dedup", () => {
       expect(result).toBe(false);
     });
 
-    it("scopes by namespace — same email in different namespace is not served", async () => {
+    it("scopes by brand — same email in different brand is not served", async () => {
       vi.mocked(db.query.servedLeads.findFirst).mockResolvedValue(undefined);
 
       const result = await isServed("org-1", "brand-2", "alice@acme.com");
@@ -63,7 +65,9 @@ describe("dedup", () => {
 
       const result = await markServed({
         organizationId: "org-1",
-        namespace: "brand-1",
+        namespace: "campaign-1",
+        brandId: "brand-1",
+        campaignId: "campaign-1",
         email: "alice@acme.com",
         externalId: "enrich-123",
         parentRunId: "run-1",
@@ -81,7 +85,9 @@ describe("dedup", () => {
 
       const result = await markServed({
         organizationId: "org-1",
-        namespace: "brand-1",
+        namespace: "campaign-1",
+        brandId: "brand-1",
+        campaignId: "campaign-1",
         email: "alice@acme.com",
       });
 


### PR DESCRIPTION
Fixes exhausted cursor issue where campaigns for the same brand share pagination state.

- Cursor (pagination) now scoped per campaign (was per brand)
- Buffer (staging) now scoped per campaign (was per brand)
- Dedup (servedLeads) now scoped per org+brand (prevents duplicate emails across campaigns for same brand)
- Added campaignId columns to schema and migration