### PR TITLE
Fix Apollo enrich endpoint field name

### DIFF
--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -196,7 +196,7 @@ export async function apolloEnrich(
 
     const result = await callApolloService<ApolloEnrichResult>("/enrich", {
       method: "POST",
-      body: { id: personId, ...(options?.runId ? { runId: options.runId } : {}) },
+      body: { apolloPersonId: personId, ...(options?.runId ? { runId: options.runId } : {}) },
       headers,
     });
 


### PR DESCRIPTION
The /enrich endpoint requires 'apolloPersonId' but the code was sending 'id'. This caused all enrichment calls to fail with 400 errors, skipping leads without pre-existing emails.