### PR TITLE
Prioritize leads with cached emails in pullNext

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -1,4 +1,4 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { leadBuffer, cursors } from "../db/schema.js";
 import { isServed, markServed } from "./dedup.js";
@@ -222,6 +222,7 @@ export async function pullNext(params: {
         eq(leadBuffer.namespace, params.campaignId),
         eq(leadBuffer.status, "buffered")
       ),
+      orderBy: [sql`CASE WHEN ${leadBuffer.email} != '' THEN 0 ELSE 1 END`],
     });
 
     if (!row) {


### PR DESCRIPTION
## Summary
When Apollo search returns cached emails from previous enrichments, prioritize serving those leads first to reduce unnecessary enrichment API calls and conserve Apollo credits.

## Changes
- Added `orderBy` clause to buffer query in `pullNext()` to prefer leads with non-empty emails
- Leads with emails are fetched first (CASE value 0), leads without emails second (CASE value 1)
- Minimal change: 2 lines in src/lib/buffer.ts (1 import addition, 1 orderBy clause)

## Test Plan
- TypeScript compilation passes
- Existing deduplication and enrichment flows remain unchanged
- Monitor logs to confirm leads with emails are served without enrichment calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)