### PR TITLE
Add GET /stats/:namespace endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import healthRoutes from "./routes/health.js";
 import bufferRoutes from "./routes/buffer.js";
 import cursorRoutes from "./routes/cursor.js";
 import leadsRoutes from "./routes/leads.js";
+import statsRoutes from "./routes/stats.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -33,6 +34,7 @@ app.use(healthRoutes);
 app.use(bufferRoutes);
 app.use(cursorRoutes);
 app.use(leadsRoutes);
+app.use(statsRoutes);
 
 app.use((req, res) => {
   res.status(404).json({ error: "Not found" });

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -6,11 +6,11 @@ import { servedLeads } from "../db/schema.js";
 
 const router = Router();
 
-router.get("/stats/:namespace", authenticate, async (req: AuthenticatedRequest, res) => {
+router.get("/stats/:brandId", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
-    const { namespace } = req.params;
+    const { brandId } = req.params;
 
-    console.log(`[stats] GET /stats/${namespace} called for org=${req.organizationId}`);
+    console.log(`[stats] GET /stats/${brandId} called for org=${req.organizationId}`);
 
     const [result] = await db
       .select({ totalServed: count() })
@@ -18,12 +18,12 @@ router.get("/stats/:namespace", authenticate, async (req: AuthenticatedRequest, 
       .where(
         and(
           eq(servedLeads.organizationId, req.organizationId!),
-          eq(servedLeads.brandId, namespace)
+          eq(servedLeads.brandId, brandId)
         )
       );
 
     const totalServed = result?.totalServed ?? 0;
-    console.log(`[stats] brand=${namespace} org=${req.organizationId} totalServed=${totalServed}`);
+    console.log(`[stats] brand=${brandId} org=${req.organizationId} totalServed=${totalServed}`);
 
     res.json({ totalServed });
   } catch (error) {

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,0 +1,35 @@
+import { Router } from "express";
+import { eq, and, count } from "drizzle-orm";
+import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
+import { db } from "../db/index.js";
+import { servedLeads } from "../db/schema.js";
+
+const router = Router();
+
+router.get("/stats/:namespace", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { namespace } = req.params;
+
+    console.log(`[stats] GET /stats/${namespace} called for org=${req.organizationId}`);
+
+    const [result] = await db
+      .select({ totalServed: count() })
+      .from(servedLeads)
+      .where(
+        and(
+          eq(servedLeads.organizationId, req.organizationId!),
+          eq(servedLeads.brandId, namespace)
+        )
+      );
+
+    const totalServed = result?.totalServed ?? 0;
+    console.log(`[stats] brand=${namespace} org=${req.organizationId} totalServed=${totalServed}`);
+
+    res.json({ totalServed });
+  } catch (error) {
+    console.error("[stats] Error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- The `/stats/:namespace` endpoint was never implemented, causing every call to return 404
- This caused campaigns to bypass `maxLeads` limits (e.g. a campaign with maxLeads=1 sent 5-7 emails)
- Added `GET /stats/:namespace` that counts served leads by `organizationId` + `brandId` and returns `{ totalServed }`

## Details
- The namespace param is the `brandId` (e.g. `d7a16b98-4ce9-43f8-850e-bca2cabb8cdd`)
- Uses the same `authenticate` middleware (requires `X-API-Key`, `X-App-Id`, `X-Org-Id`)
- Queries the existing `servedLeads` table — no schema changes needed
- `totalServed` is automatically tracked when `/buffer/next` calls `markServed()`

## Test plan
- [ ] Deploy to staging and verify `GET /stats/{brandId}` returns `{ totalServed: <number> }` instead of 404
- [ ] Verify maxLeads enforcement works end-to-end with a campaign limited to 1 lead

🤖 Generated with [Claude Code](https://claude.com/claude-code)