### PR TITLE
Document x-app-id and x-org-id headers in OpenAPI spec

### DIFF
--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -15,6 +15,15 @@ const doc = {
   host: process.env.SERVICE_URL || "http://localhost:3006",
   basePath: "/",
   schemes: ["https"],
+  securityDefinitions: {
+    apiKey: {
+      type: "apiKey",
+      in: "header",
+      name: "x-api-key",
+      description: "API key for authenticating requests. Must match the LEAD_SERVICE_API_KEY env var on the server.",
+    },
+  },
+  security: [{ apiKey: [] }],
 };
 
 const outputFile = join(projectRoot, "openapi.json");

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -6,6 +6,29 @@ import { ensureOrganization, createRun, updateRun } from "../lib/runs-client.js"
 const router = Router();
 
 router.post("/buffer/push", authenticate, async (req: AuthenticatedRequest, res) => {
+  /*
+    #swagger.summary = 'Push leads into the buffer'
+    #swagger.parameters['x-app-id'] = { in: 'header', required: true, type: 'string', description: 'Identifies the calling application, e.g. mcpfactory' }
+    #swagger.parameters['x-org-id'] = { in: 'header', required: true, type: 'string', description: 'External organization ID, e.g. Clerk org ID' }
+    #swagger.requestBody = {
+      required: true,
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            required: ["campaignId", "brandId", "leads"],
+            properties: {
+              campaignId: { type: "string" },
+              brandId: { type: "string" },
+              parentRunId: { type: "string" },
+              clerkUserId: { type: "string" },
+              leads: { type: "array", items: { type: "object" } }
+            }
+          }
+        }
+      }
+    }
+  */
   try {
     const { campaignId, brandId, parentRunId, clerkUserId, leads } = req.body;
     const clerkOrgId = req.externalOrgId ?? null;
@@ -57,6 +80,29 @@ router.post("/buffer/push", authenticate, async (req: AuthenticatedRequest, res)
 });
 
 router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res) => {
+  /*
+    #swagger.summary = 'Pull the next lead from the buffer'
+    #swagger.parameters['x-app-id'] = { in: 'header', required: true, type: 'string', description: 'Identifies the calling application, e.g. mcpfactory' }
+    #swagger.parameters['x-org-id'] = { in: 'header', required: true, type: 'string', description: 'External organization ID, e.g. Clerk org ID' }
+    #swagger.requestBody = {
+      required: true,
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            required: ["campaignId", "brandId"],
+            properties: {
+              campaignId: { type: "string" },
+              brandId: { type: "string" },
+              parentRunId: { type: "string" },
+              searchParams: { type: "object" },
+              clerkUserId: { type: "string" }
+            }
+          }
+        }
+      }
+    }
+  */
   try {
     const { campaignId, brandId, parentRunId, searchParams, clerkUserId } = req.body;
     const clerkOrgId = req.externalOrgId ?? null;

--- a/src/routes/cursor.ts
+++ b/src/routes/cursor.ts
@@ -7,6 +7,11 @@ import { cursors } from "../db/schema.js";
 const router = Router();
 
 router.get("/cursor/:namespace", authenticate, async (req: AuthenticatedRequest, res) => {
+  /*
+    #swagger.summary = 'Get cursor state for a namespace'
+    #swagger.parameters['x-app-id'] = { in: 'header', required: true, type: 'string', description: 'Identifies the calling application, e.g. mcpfactory' }
+    #swagger.parameters['x-org-id'] = { in: 'header', required: true, type: 'string', description: 'External organization ID, e.g. Clerk org ID' }
+  */
   try {
     const { namespace } = req.params;
 
@@ -25,6 +30,25 @@ router.get("/cursor/:namespace", authenticate, async (req: AuthenticatedRequest,
 });
 
 router.put("/cursor/:namespace", authenticate, async (req: AuthenticatedRequest, res) => {
+  /*
+    #swagger.summary = 'Set cursor state for a namespace'
+    #swagger.parameters['x-app-id'] = { in: 'header', required: true, type: 'string', description: 'Identifies the calling application, e.g. mcpfactory' }
+    #swagger.parameters['x-org-id'] = { in: 'header', required: true, type: 'string', description: 'External organization ID, e.g. Clerk org ID' }
+    #swagger.requestBody = {
+      required: true,
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            required: ["state"],
+            properties: {
+              state: { type: "object", description: "Arbitrary JSON cursor state" }
+            }
+          }
+        }
+      }
+    }
+  */
   try {
     const { namespace } = req.params;
     const { state } = req.body;

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -7,6 +7,14 @@ import { servedLeads, enrichments } from "../db/schema.js";
 const router = Router();
 
 router.get("/leads", authenticate, async (req: AuthenticatedRequest, res) => {
+  /*
+    #swagger.summary = 'List served leads with enrichment data'
+    #swagger.parameters['x-app-id'] = { in: 'header', required: true, type: 'string', description: 'Identifies the calling application, e.g. mcpfactory' }
+    #swagger.parameters['x-org-id'] = { in: 'header', required: true, type: 'string', description: 'External organization ID, e.g. Clerk org ID' }
+    #swagger.parameters['brandId'] = { in: 'query', type: 'string', required: false }
+    #swagger.parameters['clerkOrgId'] = { in: 'query', type: 'string', required: false }
+    #swagger.parameters['clerkUserId'] = { in: 'query', type: 'string', required: false }
+  */
   try {
     const { brandId, clerkOrgId, clerkUserId } = req.query;
 

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -7,6 +7,13 @@ import { servedLeads } from "../db/schema.js";
 const router = Router();
 
 router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
+  /*
+    #swagger.summary = 'Get served lead count'
+    #swagger.parameters['x-app-id'] = { in: 'header', required: true, type: 'string', description: 'Identifies the calling application, e.g. mcpfactory' }
+    #swagger.parameters['x-org-id'] = { in: 'header', required: true, type: 'string', description: 'External organization ID, e.g. Clerk org ID' }
+    #swagger.parameters['brandId'] = { in: 'query', type: 'string', required: false }
+    #swagger.parameters['campaignId'] = { in: 'query', type: 'string', required: false }
+  */
   try {
     const { brandId, campaignId } = req.query;
 


### PR DESCRIPTION
Added swagger-autogen comments to all authenticated routes documenting the three required authentication headers:

- **x-api-key** — API key for server authentication
- **x-app-id** — Identifies the calling application (e.g., mcpfactory)
- **x-org-id** — External organization ID (e.g., Clerk org ID)

The generated openapi.json now includes complete parameter documentation for all endpoints, making it clear to API consumers what headers are required.