### PR TITLE
Add POST /stats endpoint for service-to-service calls

### DIFF
--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,8 +1,8 @@
 import { Router } from "express";
-import { eq, and, count, type SQL } from "drizzle-orm";
+import { eq, and, count, inArray, or, type SQL } from "drizzle-orm";
 import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
 import { db } from "../db/index.js";
-import { servedLeads } from "../db/schema.js";
+import { servedLeads, organizations } from "../db/schema.js";
 
 const router = Router();
 
@@ -30,6 +30,77 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
       .select({ totalServed: count() })
       .from(servedLeads)
       .where(and(...conditions));
+
+    const totalServed = result?.totalServed ?? 0;
+    res.json({ totalServed });
+  } catch (error) {
+    console.error("[stats] Error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.post("/stats", async (req, res) => {
+  /*
+    #swagger.summary = 'Get served lead count (internal)'
+    #swagger.requestBody = {
+      required: true,
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            properties: {
+              runIds: { type: "array", items: { type: "string" } },
+              appId: { type: "string" },
+              brandId: { type: "string" },
+              campaignId: { type: "string" },
+              clerkOrgId: { type: "string" }
+            }
+          }
+        }
+      }
+    }
+  */
+  try {
+    const { runIds, appId, brandId, campaignId, clerkOrgId } = req.body ?? {};
+
+    const conditions: SQL[] = [];
+
+    if (runIds && Array.isArray(runIds) && runIds.length > 0) {
+      conditions.push(
+        or(
+          inArray(servedLeads.parentRunId, runIds),
+          inArray(servedLeads.runId, runIds)
+        )!
+      );
+    }
+    if (brandId) {
+      conditions.push(eq(servedLeads.brandId, brandId));
+    }
+    if (campaignId) {
+      conditions.push(eq(servedLeads.campaignId, campaignId));
+    }
+    if (clerkOrgId) {
+      conditions.push(eq(servedLeads.clerkOrgId, clerkOrgId));
+    }
+    if (appId) {
+      const orgs = await db.query.organizations.findMany({
+        where: eq(organizations.appId, appId),
+      });
+      if (orgs.length > 0) {
+        conditions.push(
+          inArray(servedLeads.organizationId, orgs.map((o) => o.id))
+        );
+      } else {
+        return res.json({ totalServed: 0 });
+      }
+    }
+
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+    const [result] = await db
+      .select({ totalServed: count() })
+      .from(servedLeads)
+      .where(where);
 
     const totalServed = result?.totalServed ?? 0;
     res.json({ totalServed });


### PR DESCRIPTION
## Summary
Adds `POST /stats` endpoint to match the microservice convention used by other services (campaign, email-generation, instantly, apollo, postmark). The campaign service calls `POST /stats` with optional filters but the lead service only had `GET /stats`, causing stats to return 0.

## Fix
- New `POST /stats` endpoint accepts optional filters: `runIds`, `appId`, `brandId`, `campaignId`, `clerkOrgId`
- Matches both `parent_run_id` and `run_id` to correctly handle campaign run IDs
- All filters are optional; null/missing means don't filter on it
- Returns `{ totalServed: N }` matching the response format

## Test plan
- Campaign service can now call `POST /stats` with `{ runIds: [...], appId: "mcpfactory", ... }` and get correct counts
- `GET /stats` remains unchanged for backward compatibility