### PR TITLE
Include Apollo stats in /stats response

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -436,7 +436,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Lead stats by status",
+            "description": "Lead stats by status with Apollo search/enrichment metrics",
             "content": {
               "application/json": {
                 "schema": {
@@ -444,7 +444,8 @@
                   "required": [
                     "served",
                     "buffered",
-                    "skipped"
+                    "skipped",
+                    "apollo"
                   ],
                   "properties": {
                     "served": {
@@ -458,6 +459,27 @@
                     "skipped": {
                       "type": "integer",
                       "description": "Leads where no email was found"
+                    },
+                    "apollo": {
+                      "type": "object",
+                      "properties": {
+                        "enrichedLeadsCount": {
+                          "type": "integer",
+                          "description": "Number of enriched lead records"
+                        },
+                        "searchCount": {
+                          "type": "integer",
+                          "description": "Number of search operations performed"
+                        },
+                        "fetchedPeopleCount": {
+                          "type": "integer",
+                          "description": "Sum of people returned from searches"
+                        },
+                        "totalMatchingPeople": {
+                          "type": "integer",
+                          "description": "Sum of total matching people in Apollo"
+                        }
+                      }
                     }
                   }
                 }
@@ -480,7 +502,7 @@
         "description": "Service-to-service endpoint. Returns counts of leads by status: served (delivered with verified email), buffered (awaiting enrichment), and skipped (no email found).",
         "responses": {
           "200": {
-            "description": "Lead stats by status",
+            "description": "Lead stats by status with Apollo search/enrichment metrics",
             "content": {
               "application/json": {
                 "schema": {
@@ -488,7 +510,8 @@
                   "required": [
                     "served",
                     "buffered",
-                    "skipped"
+                    "skipped",
+                    "apollo"
                   ],
                   "properties": {
                     "served": {
@@ -502,6 +525,27 @@
                     "skipped": {
                       "type": "integer",
                       "description": "Leads where no email was found"
+                    },
+                    "apollo": {
+                      "type": "object",
+                      "properties": {
+                        "enrichedLeadsCount": {
+                          "type": "integer",
+                          "description": "Number of enriched lead records"
+                        },
+                        "searchCount": {
+                          "type": "integer",
+                          "description": "Number of search operations performed"
+                        },
+                        "fetchedPeopleCount": {
+                          "type": "integer",
+                          "description": "Sum of people returned from searches"
+                        },
+                        "totalMatchingPeople": {
+                          "type": "integer",
+                          "description": "Sum of total matching people in Apollo"
+                        }
+                      }
                     }
                   }
                 }

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -177,6 +177,36 @@ export async function fetchEmployeeRanges(clerkOrgId?: string | null): Promise<A
   return data;
 }
 
+// --- Stats ---
+
+export interface ApolloStats {
+  enrichedLeadsCount: number;
+  searchCount: number;
+  fetchedPeopleCount: number;
+  totalMatchingPeople: number;
+}
+
+export async function fetchApolloStats(
+  filters: { runIds?: string[]; appId?: string; brandId?: string; campaignId?: string },
+  clerkOrgId?: string | null
+): Promise<ApolloStats> {
+  try {
+    const headers: Record<string, string> = {};
+    if (clerkOrgId) headers["x-clerk-org-id"] = clerkOrgId;
+
+    const result = await callApolloService<{ stats: ApolloStats }>("/stats", {
+      method: "POST",
+      body: filters,
+      headers,
+    });
+
+    return result.stats;
+  } catch (error) {
+    console.error("[apollo-client] Stats fetch failed:", error);
+    return { enrichedLeadsCount: 0, searchCount: 0, fetchedPeopleCount: 0, totalMatchingPeople: 0 };
+  }
+}
+
 // --- Enrichment ---
 
 export interface ApolloEnrichResult {


### PR DESCRIPTION
## Summary
- Added `fetchApolloStats()` to `apollo-client.ts` — calls Apollo service's `POST /stats` with the same filters
- Both GET and POST `/stats` now return an `apollo` object alongside `served`, `buffered`, `skipped`
- All queries (DB + Apollo) run in parallel via `Promise.all`
- Gracefully falls back to zeros if Apollo service is unreachable

## Response Format
```json
{
  "served": 2,
  "buffered": 5,
  "skipped": 18,
  "apollo": {
    "enrichedLeadsCount": 2,
    "searchCount": 1,
    "fetchedPeopleCount": 25,
    "totalMatchingPeople": 1200
  }
}
```

## Breaking Change
Response now includes the `apollo` field (additive, non-breaking for clients that ignore unknown fields).