### PR TITLE
Migrate from swagger-autogen to zod-to-openapi

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5,26 +5,308 @@
     "description": "Manages lead buffering, deduplication, cursor pagination, and enrichment for campaign outreach.",
     "version": "1.0.0"
   },
-  "paths": {
-    "/openapi.json": {
-      "get": {
-        "description": "",
-        "responses": {
-          "200": {
-            "description": "OK"
+  "servers": [
+    {
+      "url": "http://localhost:3006"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "components": {
+    "schemas": {
+      "HealthResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
           },
-          "404": {
-            "description": "Not Found"
+          "service": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "service"
+        ]
+      },
+      "BufferPushResponse": {
+        "type": "object",
+        "properties": {
+          "buffered": {
+            "type": "number"
+          },
+          "skippedAlreadyServed": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "buffered",
+          "skippedAlreadyServed"
+        ]
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "BufferPushRequest": {
+        "type": "object",
+        "properties": {
+          "campaignId": {
+            "type": "string"
+          },
+          "brandId": {
+            "type": "string"
+          },
+          "parentRunId": {
+            "type": "string"
+          },
+          "clerkUserId": {
+            "type": "string"
+          },
+          "leads": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "type": "string"
+                },
+                "externalId": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "data": {
+                  "nullable": true
+                }
+              },
+              "required": [
+                "email"
+              ]
+            }
+          }
+        },
+        "required": [
+          "campaignId",
+          "brandId",
+          "leads"
+        ]
+      },
+      "BufferNextResponse": {
+        "type": "object",
+        "properties": {
+          "found": {
+            "type": "boolean"
+          },
+          "lead": {
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "externalId": {
+                "type": "string",
+                "nullable": true
+              },
+              "data": {
+                "nullable": true
+              },
+              "brandId": {
+                "type": "string"
+              },
+              "clerkOrgId": {
+                "type": "string",
+                "nullable": true
+              },
+              "clerkUserId": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "email",
+              "externalId",
+              "brandId",
+              "clerkOrgId",
+              "clerkUserId"
+            ]
+          }
+        },
+        "required": [
+          "found"
+        ]
+      },
+      "BufferNextRequest": {
+        "type": "object",
+        "properties": {
+          "campaignId": {
+            "type": "string"
+          },
+          "brandId": {
+            "type": "string"
+          },
+          "parentRunId": {
+            "type": "string"
+          },
+          "searchParams": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            }
+          },
+          "clerkUserId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "campaignId",
+          "brandId"
+        ]
+      },
+      "CursorGetResponse": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "nullable": true
+          }
+        }
+      },
+      "CursorSetResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      },
+      "CursorSetRequest": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "nullable": true
+          }
+        }
+      },
+      "LeadsResponse": {
+        "type": "object",
+        "properties": {
+          "leads": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "nullable": true
+              }
+            }
+          }
+        },
+        "required": [
+          "leads"
+        ]
+      },
+      "StatsResponse": {
+        "type": "object",
+        "properties": {
+          "served": {
+            "type": "number"
+          },
+          "buffered": {
+            "type": "number"
+          },
+          "skipped": {
+            "type": "number"
+          },
+          "apollo": {
+            "type": "object",
+            "properties": {
+              "enrichedLeadsCount": {
+                "type": "number"
+              },
+              "searchCount": {
+                "type": "number"
+              },
+              "fetchedPeopleCount": {
+                "type": "number"
+              },
+              "totalMatchingPeople": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "enrichedLeadsCount",
+              "searchCount",
+              "fetchedPeopleCount",
+              "totalMatchingPeople"
+            ]
+          }
+        },
+        "required": [
+          "served",
+          "buffered",
+          "skipped",
+          "apollo"
+        ]
+      },
+      "StatsPostRequest": {
+        "type": "object",
+        "properties": {
+          "runIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "appId": {
+            "type": "string"
+          },
+          "brandId": {
+            "type": "string"
+          },
+          "campaignId": {
+            "type": "string"
+          },
+          "clerkOrgId": {
+            "type": "string"
           }
         }
       }
     },
+    "parameters": {},
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key",
+        "description": "API key for authenticating requests. Must match the LEAD_SERVICE_API_KEY env var on the server."
+      }
+    }
+  },
+  "paths": {
     "/health": {
       "get": {
-        "description": "",
+        "summary": "Health check",
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "Service is healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -32,81 +314,67 @@
     "/buffer/push": {
       "post": {
         "summary": "Push leads into the buffer",
-        "description": "",
         "parameters": [
           {
+            "in": "header",
             "name": "x-api-key",
-            "in": "header",
+            "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "API key for authenticating requests"
           },
           {
+            "in": "header",
             "name": "x-app-id",
-            "in": "header",
             "required": true,
-            "description": "Identifies the calling application, e.g. mcpfactory",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Identifies the calling application, e.g. mcpfactory"
           },
           {
-            "name": "x-org-id",
             "in": "header",
+            "name": "x-org-id",
             "required": true,
-            "description": "External organization ID, e.g. Clerk org ID",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "External organization ID, e.g. Clerk org ID"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "campaignId",
-                  "brandId",
-                  "leads"
-                ],
-                "properties": {
-                  "campaignId": {
-                    "type": "string"
-                  },
-                  "brandId": {
-                    "type": "string"
-                  },
-                  "parentRunId": {
-                    "type": "string"
-                  },
-                  "clerkUserId": {
-                    "type": "string"
-                  },
-                  "leads": {
-                    "type": "array",
-                    "items": {
-                      "type": "object"
-                    }
-                  }
+                "$ref": "#/components/schemas/BufferPushRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Leads buffered successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BufferPushResponse"
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }
@@ -114,77 +382,67 @@
     "/buffer/next": {
       "post": {
         "summary": "Pull the next lead from the buffer",
-        "description": "",
         "parameters": [
           {
+            "in": "header",
             "name": "x-api-key",
-            "in": "header",
+            "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "API key for authenticating requests"
           },
           {
+            "in": "header",
             "name": "x-app-id",
-            "in": "header",
             "required": true,
-            "description": "Identifies the calling application, e.g. mcpfactory",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Identifies the calling application, e.g. mcpfactory"
           },
           {
-            "name": "x-org-id",
             "in": "header",
+            "name": "x-org-id",
             "required": true,
-            "description": "External organization ID, e.g. Clerk org ID",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "External organization ID, e.g. Clerk org ID"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "campaignId",
-                  "brandId"
-                ],
-                "properties": {
-                  "campaignId": {
-                    "type": "string"
-                  },
-                  "brandId": {
-                    "type": "string"
-                  },
-                  "parentRunId": {
-                    "type": "string"
-                  },
-                  "searchParams": {
-                    "type": "object"
-                  },
-                  "clerkUserId": {
-                    "type": "string"
-                  }
+                "$ref": "#/components/schemas/BufferNextRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Next lead from buffer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BufferNextResponse"
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }
@@ -192,126 +450,130 @@
     "/cursor/{namespace}": {
       "get": {
         "summary": "Get cursor state for a namespace",
-        "description": "",
         "parameters": [
           {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
+            "in": "header",
             "name": "x-api-key",
-            "in": "header",
+            "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "API key for authenticating requests"
           },
           {
+            "in": "header",
             "name": "x-app-id",
-            "in": "header",
             "required": true,
-            "description": "Identifies the calling application, e.g. mcpfactory",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Identifies the calling application, e.g. mcpfactory"
           },
           {
-            "name": "x-org-id",
             "in": "header",
+            "name": "x-org-id",
             "required": true,
-            "description": "External organization ID, e.g. Clerk org ID",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "External organization ID, e.g. Clerk org ID"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "namespace",
+            "in": "path"
           }
         ],
         "responses": {
           "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
+            "description": "Cursor state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CursorGetResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized"
-          },
-          "500": {
-            "description": "Internal Server Error"
           }
         }
       },
       "put": {
         "summary": "Set cursor state for a namespace",
-        "description": "",
         "parameters": [
           {
-            "name": "namespace",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
+            "in": "header",
             "name": "x-api-key",
-            "in": "header",
+            "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "API key for authenticating requests"
           },
           {
+            "in": "header",
             "name": "x-app-id",
-            "in": "header",
             "required": true,
-            "description": "Identifies the calling application, e.g. mcpfactory",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Identifies the calling application, e.g. mcpfactory"
           },
           {
-            "name": "x-org-id",
             "in": "header",
+            "name": "x-org-id",
             "required": true,
-            "description": "External organization ID, e.g. Clerk org ID",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "External organization ID, e.g. Clerk org ID"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "namespace",
+            "in": "path"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "state"
-                ],
-                "properties": {
-                  "state": {
-                    "type": "object",
-                    "description": "Arbitrary JSON cursor state"
-                  }
+                "$ref": "#/components/schemas/CursorSetRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cursor updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CursorSetResponse"
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }
@@ -319,52 +581,53 @@
     "/leads": {
       "get": {
         "summary": "List served leads with enrichment data",
-        "description": "",
         "parameters": [
           {
+            "in": "header",
             "name": "x-api-key",
-            "in": "header",
+            "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "API key for authenticating requests"
           },
           {
+            "in": "header",
             "name": "x-app-id",
-            "in": "header",
             "required": true,
-            "description": "Identifies the calling application, e.g. mcpfactory",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Identifies the calling application, e.g. mcpfactory"
           },
           {
+            "in": "header",
             "name": "x-org-id",
-            "in": "header",
             "required": true,
-            "description": "External organization ID, e.g. Clerk org ID",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "External organization ID, e.g. Clerk org ID"
           },
           {
+            "in": "query",
             "name": "brandId",
-            "in": "query",
             "required": false,
             "schema": {
               "type": "string"
             }
           },
           {
+            "in": "query",
             "name": "clerkOrgId",
-            "in": "query",
             "required": false,
             "schema": {
               "type": "string"
             }
           },
           {
-            "name": "clerkUserId",
             "in": "query",
+            "name": "clerkUserId",
             "required": false,
             "schema": {
               "type": "string"
@@ -373,16 +636,17 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request"
+            "description": "List of served leads",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeadsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized"
-          },
-          "500": {
-            "description": "Internal Server Error"
           }
         }
       }
@@ -393,41 +657,43 @@
         "description": "Returns counts of leads by status: served (delivered with verified email), buffered (awaiting enrichment), and skipped (no email found).",
         "parameters": [
           {
+            "in": "header",
             "name": "x-api-key",
-            "in": "header",
+            "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "API key for authenticating requests"
           },
           {
+            "in": "header",
             "name": "x-app-id",
-            "in": "header",
             "required": true,
-            "description": "Identifies the calling application, e.g. mcpfactory",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Identifies the calling application, e.g. mcpfactory"
           },
           {
+            "in": "header",
             "name": "x-org-id",
-            "in": "header",
             "required": true,
-            "description": "External organization ID, e.g. Clerk org ID",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "External organization ID, e.g. Clerk org ID"
           },
           {
-            "name": "brandId",
             "in": "query",
+            "name": "brandId",
             "required": false,
             "schema": {
               "type": "string"
             }
           },
           {
-            "name": "campaignId",
             "in": "query",
+            "name": "campaignId",
             "required": false,
             "schema": {
               "type": "string"
@@ -436,172 +702,58 @@
         ],
         "responses": {
           "200": {
-            "description": "Lead stats by status with Apollo search/enrichment metrics",
+            "description": "Lead stats by status with Apollo metrics",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": [
-                    "served",
-                    "buffered",
-                    "skipped",
-                    "apollo"
-                  ],
-                  "properties": {
-                    "served": {
-                      "type": "integer",
-                      "description": "Leads with verified email, delivered to campaign"
-                    },
-                    "buffered": {
-                      "type": "integer",
-                      "description": "Leads awaiting email enrichment"
-                    },
-                    "skipped": {
-                      "type": "integer",
-                      "description": "Leads where no email was found"
-                    },
-                    "apollo": {
-                      "type": "object",
-                      "properties": {
-                        "enrichedLeadsCount": {
-                          "type": "integer",
-                          "description": "Number of enriched lead records"
-                        },
-                        "searchCount": {
-                          "type": "integer",
-                          "description": "Number of search operations performed"
-                        },
-                        "fetchedPeopleCount": {
-                          "type": "integer",
-                          "description": "Sum of people returned from searches"
-                        },
-                        "totalMatchingPeople": {
-                          "type": "integer",
-                          "description": "Sum of total matching people in Apollo"
-                        }
-                      }
-                    }
-                  }
+                  "$ref": "#/components/schemas/StatsResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request"
-          },
           "401": {
             "description": "Unauthorized"
-          },
-          "500": {
-            "description": "Internal Server Error"
           }
         }
       },
       "post": {
         "summary": "Get lead stats by status (internal)",
-        "description": "Service-to-service endpoint. Returns counts of leads by status: served (delivered with verified email), buffered (awaiting enrichment), and skipped (no email found).",
-        "responses": {
-          "200": {
-            "description": "Lead stats by status with Apollo search/enrichment metrics",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "served",
-                    "buffered",
-                    "skipped",
-                    "apollo"
-                  ],
-                  "properties": {
-                    "served": {
-                      "type": "integer",
-                      "description": "Leads with verified email, delivered to campaign"
-                    },
-                    "buffered": {
-                      "type": "integer",
-                      "description": "Leads awaiting email enrichment"
-                    },
-                    "skipped": {
-                      "type": "integer",
-                      "description": "Leads where no email was found"
-                    },
-                    "apollo": {
-                      "type": "object",
-                      "properties": {
-                        "enrichedLeadsCount": {
-                          "type": "integer",
-                          "description": "Number of enriched lead records"
-                        },
-                        "searchCount": {
-                          "type": "integer",
-                          "description": "Number of search operations performed"
-                        },
-                        "fetchedPeopleCount": {
-                          "type": "integer",
-                          "description": "Sum of people returned from searches"
-                        },
-                        "totalMatchingPeople": {
-                          "type": "integer",
-                          "description": "Sum of total matching people in Apollo"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
+        "description": "Service-to-service endpoint. Returns counts of leads by status.",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "runIds": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "appId": {
-                    "type": "string"
-                  },
-                  "brandId": {
-                    "type": "string"
-                  },
-                  "campaignId": {
-                    "type": "string"
-                  },
-                  "clerkOrgId": {
-                    "type": "string"
-                  }
+                "$ref": "#/components/schemas/StatsPostRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Lead stats by status with Apollo metrics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatsResponse"
                 }
               }
             }
           }
         }
       }
-    }
-  },
-  "components": {
-    "securitySchemes": {
-      "apiKey": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "x-api-key",
-        "description": "API key for authenticating requests. Must match the LEAD_SERVICE_API_KEY env var on the server."
+    },
+    "/openapi.json": {
+      "get": {
+        "summary": "Get OpenAPI specification",
+        "responses": {
+          "200": {
+            "description": "OpenAPI JSON document"
+          },
+          "404": {
+            "description": "Spec not generated"
+          }
+        }
       }
     }
-  },
-  "security": [
-    {
-      "apiKey": []
-    }
-  ]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
+        "@asteasolutions/zod-to-openapi": "^8.4.0",
         "@sentry/node": "^8.0.0",
         "cors": "^2.8.5",
         "drizzle-orm": "^0.36.0",
         "express": "^4.21.0",
         "postgres": "^3.4.0",
-        "swagger-autogen": "^2.23.7"
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -47,6 +48,18 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.4.0.tgz",
+      "integrity": "sha512-Ckp971tmTw4pnv+o7iK85ldBHBKk6gxMaoNyLn3c2Th/fKoTG8G3jdYuOanpdGqwlDB0z01FOjry2d32lfTqrA==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -2591,12 +2604,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -2635,16 +2642,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -2730,12 +2727,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -2811,15 +2802,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -3350,12 +3332,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3428,27 +3404,6 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -3564,17 +3519,6 @@
         "module-details-from-path": "^1.0.3"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3662,18 +3606,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/magic-string": {
@@ -3783,18 +3715,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -3883,9 +3803,19 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openapi3-ts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
       }
     },
     "node_modules/parseurl": {
@@ -3895,15 +3825,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-parse": {
@@ -4517,30 +4438,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/swagger-autogen": {
-      "version": "2.23.7",
-      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.23.7.tgz",
-      "integrity": "sha512-vr7uRmuV0DCxWc0wokLJAwX3GwQFJ0jwN+AWk0hKxre2EZwusnkGSGdVFd82u7fQLgwSTnbWkxUL7HXuz5LTZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^7.4.1",
-        "deepmerge": "^4.2.2",
-        "glob": "^7.1.7",
-        "json5": "^2.2.3"
-      }
-    },
-    "node_modules/swagger-autogen/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/tinybench": {
@@ -5722,6 +5619,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/xtend": {
@@ -5731,6 +5629,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.73.0",
+    "@asteasolutions/zod-to-openapi": "^8.4.0",
     "@sentry/node": "^8.0.0",
     "cors": "^2.8.5",
     "drizzle-orm": "^0.36.0",
     "express": "^4.21.0",
     "postgres": "^3.4.0",
-    "swagger-autogen": "^2.23.7"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,10 @@ importers:
     dependencies:
       '@anthropic-ai/sdk':
         specifier: ^0.73.0
-        version: 0.73.0
+        version: 0.73.0(zod@4.3.6)
+      '@asteasolutions/zod-to-openapi':
+        specifier: ^8.4.0
+        version: 8.4.0(zod@4.3.6)
       '@sentry/node':
         specifier: ^8.0.0
         version: 8.55.0
@@ -26,9 +29,9 @@ importers:
       postgres:
         specifier: ^3.4.0
         version: 3.4.8
-      swagger-autogen:
-        specifier: ^2.23.7
-        version: 2.23.7
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/cors':
         specifier: ^2.8.17
@@ -44,7 +47,7 @@ importers:
         version: 6.0.3
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2))
       drizzle-kit:
         specifier: ^0.28.0
         version: 0.28.1
@@ -59,7 +62,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -71,6 +74,11 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@asteasolutions/zod-to-openapi@8.4.0':
+    resolution: {integrity: sha512-Ckp971tmTw4pnv+o7iK85ldBHBKk6gxMaoNyLn3c2Th/fKoTG8G3jdYuOanpdGqwlDB0z01FOjry2d32lfTqrA==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -1050,11 +1058,6 @@ packages:
     peerDependencies:
       acorn: ^8
 
-  acorn@7.4.1:
-    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -1076,15 +1079,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -1114,9 +1111,6 @@ packages:
 
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -1160,10 +1154,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  deepmerge@4.3.1:
-    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
-    engines: {node: '>=0.10.0'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1379,9 +1369,6 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1400,10 +1387,6 @@ packages:
 
   get-tsconfig@4.13.1:
     resolution: {integrity: sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==}
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1439,10 +1422,6 @@ packages:
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
 
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -1472,11 +1451,6 @@ packages:
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
-
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1521,9 +1495,6 @@ packages:
     engines: {node: '>=4.0.0'}
     hasBin: true
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
@@ -1560,13 +1531,12 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
-
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -1733,9 +1703,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  swagger-autogen@2.23.7:
-    resolution: {integrity: sha512-vr7uRmuV0DCxWc0wokLJAwX3GwQFJ0jwN+AWk0hKxre2EZwusnkGSGdVFd82u7fQLgwSTnbWkxUL7HXuz5LTZQ==}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1873,11 +1840,26 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
-  '@anthropic-ai/sdk@0.73.0':
+  '@anthropic-ai/sdk@0.73.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
+  '@asteasolutions/zod-to-openapi@8.4.0(zod@4.3.6)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 4.3.6
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -2669,7 +2651,7 @@ snapshots:
     dependencies:
       '@types/node': 20.19.31
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -2681,7 +2663,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -2692,13 +2674,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.31)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@20.19.31)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -2731,8 +2713,6 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn@7.4.1: {}
-
   acorn@8.15.0: {}
 
   array-flatten@1.1.1: {}
@@ -2748,8 +2728,6 @@ snapshots:
       js-tokens: 10.0.0
 
   asynckit@0.4.0: {}
-
-  balanced-match@1.0.2: {}
 
   body-parser@1.20.4:
     dependencies:
@@ -2767,11 +2745,6 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-
-  brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
 
   buffer-from@1.1.2: {}
 
@@ -2796,8 +2769,6 @@ snapshots:
       delayed-stream: 1.0.0
 
   component-emitter@1.3.1: {}
-
-  concat-map@0.0.1: {}
 
   content-disposition@0.5.4:
     dependencies:
@@ -2825,8 +2796,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  deepmerge@4.3.1: {}
 
   delayed-stream@1.0.0: {}
 
@@ -3052,8 +3021,6 @@ snapshots:
 
   fresh@0.5.2: {}
 
-  fs.realpath@1.0.0: {}
-
   fsevents@2.3.3:
     optional: true
 
@@ -3080,15 +3047,6 @@ snapshots:
   get-tsconfig@4.13.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
 
   gopd@1.2.0: {}
 
@@ -3125,11 +3083,6 @@ snapshots:
       cjs-module-lexer: 1.4.3
       module-details-from-path: 1.0.4
 
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-
   inherits@2.0.4: {}
 
   ipaddr.js@1.9.1: {}
@@ -3157,8 +3110,6 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.6
       ts-algebra: 2.0.0
-
-  json5@2.2.3: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -3192,10 +3143,6 @@ snapshots:
 
   mime@2.6.0: {}
 
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.12
-
   module-details-from-path@1.0.4: {}
 
   ms@2.0.0: {}
@@ -3220,9 +3167,11 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  parseurl@1.3.3: {}
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.2
 
-  path-is-absolute@1.0.1: {}
+  parseurl@1.3.3: {}
 
   path-parse@1.0.7: {}
 
@@ -3439,13 +3388,6 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swagger-autogen@2.23.7:
-    dependencies:
-      acorn: 7.4.1
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      json5: 2.2.3
-
   tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
@@ -3483,7 +3425,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.3.1(@types/node@20.19.31)(tsx@4.21.0):
+  vite@7.3.1(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3495,11 +3437,12 @@ snapshots:
       '@types/node': 20.19.31
       fsevents: 2.3.3
       tsx: 4.21.0
+      yaml: 2.8.2
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.31)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -3516,7 +3459,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@20.19.31)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -3542,3 +3485,7 @@ snapshots:
   wrappy@1.0.2: {}
 
   xtend@4.0.2: {}
+
+  yaml@2.8.2: {}
+
+  zod@4.3.6: {}

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -2,40 +2,19 @@ import { Router } from "express";
 import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
 import { pushLeads, pullNext } from "../lib/buffer.js";
 import { ensureOrganization, createRun, updateRun } from "../lib/runs-client.js";
+import { BufferPushRequestSchema, BufferNextRequestSchema } from "../schemas.js";
 
 const router = Router();
 
 router.post("/buffer/push", authenticate, async (req: AuthenticatedRequest, res) => {
-  /*
-    #swagger.summary = 'Push leads into the buffer'
-    #swagger.parameters['x-app-id'] = { in: 'header', required: true, type: 'string', description: 'Identifies the calling application, e.g. mcpfactory' }
-    #swagger.parameters['x-org-id'] = { in: 'header', required: true, type: 'string', description: 'External organization ID, e.g. Clerk org ID' }
-    #swagger.requestBody = {
-      required: true,
-      content: {
-        "application/json": {
-          schema: {
-            type: "object",
-            required: ["campaignId", "brandId", "leads"],
-            properties: {
-              campaignId: { type: "string" },
-              brandId: { type: "string" },
-              parentRunId: { type: "string" },
-              clerkUserId: { type: "string" },
-              leads: { type: "array", items: { type: "object" } }
-            }
-          }
-        }
-      }
-    }
-  */
-  try {
-    const { campaignId, brandId, parentRunId, clerkUserId, leads } = req.body;
-    const clerkOrgId = req.externalOrgId ?? null;
+  const parsed = BufferPushRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
+  }
 
-    if (!campaignId || !brandId || !Array.isArray(leads)) {
-      return res.status(400).json({ error: "campaignId, brandId, and leads[] required" });
-    }
+  try {
+    const { campaignId, brandId, parentRunId, clerkUserId, leads } = parsed.data;
+    const clerkOrgId = req.externalOrgId ?? null;
 
     // Create child run for traceability
     let pushRunId: string | null = null;
@@ -80,36 +59,14 @@ router.post("/buffer/push", authenticate, async (req: AuthenticatedRequest, res)
 });
 
 router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res) => {
-  /*
-    #swagger.summary = 'Pull the next lead from the buffer'
-    #swagger.parameters['x-app-id'] = { in: 'header', required: true, type: 'string', description: 'Identifies the calling application, e.g. mcpfactory' }
-    #swagger.parameters['x-org-id'] = { in: 'header', required: true, type: 'string', description: 'External organization ID, e.g. Clerk org ID' }
-    #swagger.requestBody = {
-      required: true,
-      content: {
-        "application/json": {
-          schema: {
-            type: "object",
-            required: ["campaignId", "brandId"],
-            properties: {
-              campaignId: { type: "string" },
-              brandId: { type: "string" },
-              parentRunId: { type: "string" },
-              searchParams: { type: "object" },
-              clerkUserId: { type: "string" }
-            }
-          }
-        }
-      }
-    }
-  */
-  try {
-    const { campaignId, brandId, parentRunId, searchParams, clerkUserId } = req.body;
-    const clerkOrgId = req.externalOrgId ?? null;
+  const parsed = BufferNextRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
+  }
 
-    if (!campaignId || !brandId) {
-      return res.status(400).json({ error: "campaignId and brandId required" });
-    }
+  try {
+    const { campaignId, brandId, parentRunId, searchParams, clerkUserId } = parsed.data;
+    const clerkOrgId = req.externalOrgId ?? null;
 
     // Create child run for traceability
     let serveRunId: string | null = null;

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -7,14 +7,6 @@ import { servedLeads, enrichments } from "../db/schema.js";
 const router = Router();
 
 router.get("/leads", authenticate, async (req: AuthenticatedRequest, res) => {
-  /*
-    #swagger.summary = 'List served leads with enrichment data'
-    #swagger.parameters['x-app-id'] = { in: 'header', required: true, type: 'string', description: 'Identifies the calling application, e.g. mcpfactory' }
-    #swagger.parameters['x-org-id'] = { in: 'header', required: true, type: 'string', description: 'External organization ID, e.g. Clerk org ID' }
-    #swagger.parameters['brandId'] = { in: 'query', type: 'string', required: false }
-    #swagger.parameters['clerkOrgId'] = { in: 'query', type: 'string', required: false }
-    #swagger.parameters['clerkUserId'] = { in: 'query', type: 'string', required: false }
-  */
   try {
     const { brandId, clerkOrgId, clerkUserId } = req.query;
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,0 +1,353 @@
+import { z } from "zod";
+import {
+  OpenAPIRegistry,
+  extendZodWithOpenApi,
+} from "@asteasolutions/zod-to-openapi";
+
+extendZodWithOpenApi(z);
+
+export const registry = new OpenAPIRegistry();
+
+// --- Common ---
+
+const ErrorResponseSchema = z
+  .object({ error: z.string() })
+  .openapi("ErrorResponse");
+
+const AuthHeaders = [
+  {
+    in: "header" as const,
+    name: "x-api-key",
+    required: true,
+    schema: { type: "string" as const },
+    description: "API key for authenticating requests",
+  },
+  {
+    in: "header" as const,
+    name: "x-app-id",
+    required: true,
+    schema: { type: "string" as const },
+    description: "Identifies the calling application, e.g. mcpfactory",
+  },
+  {
+    in: "header" as const,
+    name: "x-org-id",
+    required: true,
+    schema: { type: "string" as const },
+    description: "External organization ID, e.g. Clerk org ID",
+  },
+];
+
+// --- Health ---
+
+const HealthResponseSchema = z
+  .object({
+    status: z.string(),
+    service: z.string(),
+  })
+  .openapi("HealthResponse");
+
+// --- Buffer Push ---
+
+const LeadInputSchema = z.object({
+  email: z.string(),
+  externalId: z.string().nullish(),
+  data: z.unknown().optional(),
+});
+
+export const BufferPushRequestSchema = z
+  .object({
+    campaignId: z.string(),
+    brandId: z.string(),
+    parentRunId: z.string().optional(),
+    clerkUserId: z.string().optional(),
+    leads: z.array(LeadInputSchema),
+  })
+  .openapi("BufferPushRequest");
+
+const BufferPushResponseSchema = z
+  .object({
+    buffered: z.number(),
+    skippedAlreadyServed: z.number(),
+  })
+  .openapi("BufferPushResponse");
+
+// --- Buffer Next ---
+
+export const BufferNextRequestSchema = z
+  .object({
+    campaignId: z.string(),
+    brandId: z.string(),
+    parentRunId: z.string().optional(),
+    searchParams: z.record(z.string(), z.unknown()).optional(),
+    clerkUserId: z.string().optional(),
+  })
+  .openapi("BufferNextRequest");
+
+const ServedLeadSchema = z.object({
+  email: z.string(),
+  externalId: z.string().nullable(),
+  data: z.unknown(),
+  brandId: z.string(),
+  clerkOrgId: z.string().nullable(),
+  clerkUserId: z.string().nullable(),
+});
+
+const BufferNextResponseSchema = z
+  .object({
+    found: z.boolean(),
+    lead: ServedLeadSchema.optional(),
+  })
+  .openapi("BufferNextResponse");
+
+// --- Cursor ---
+
+export const CursorSetRequestSchema = z
+  .object({
+    state: z.unknown(),
+  })
+  .openapi("CursorSetRequest");
+
+const CursorGetResponseSchema = z
+  .object({
+    state: z.unknown(),
+  })
+  .openapi("CursorGetResponse");
+
+const CursorSetResponseSchema = z
+  .object({
+    ok: z.boolean(),
+  })
+  .openapi("CursorSetResponse");
+
+// --- Leads ---
+
+const LeadsResponseSchema = z
+  .object({
+    leads: z.array(z.record(z.string(), z.unknown())),
+  })
+  .openapi("LeadsResponse");
+
+// --- Stats ---
+
+const ApolloStatsSchema = z.object({
+  enrichedLeadsCount: z.number(),
+  searchCount: z.number(),
+  fetchedPeopleCount: z.number(),
+  totalMatchingPeople: z.number(),
+});
+
+const StatsResponseSchema = z
+  .object({
+    served: z.number(),
+    buffered: z.number(),
+    skipped: z.number(),
+    apollo: ApolloStatsSchema,
+  })
+  .openapi("StatsResponse");
+
+export const StatsPostRequestSchema = z
+  .object({
+    runIds: z.array(z.string()).optional(),
+    appId: z.string().optional(),
+    brandId: z.string().optional(),
+    campaignId: z.string().optional(),
+    clerkOrgId: z.string().optional(),
+  })
+  .openapi("StatsPostRequest");
+
+// --- Register Paths ---
+
+registry.registerPath({
+  method: "get",
+  path: "/health",
+  summary: "Health check",
+  responses: {
+    200: {
+      description: "Service is healthy",
+      content: { "application/json": { schema: HealthResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/buffer/push",
+  summary: "Push leads into the buffer",
+  request: {
+    params: z.object({}),
+    body: {
+      content: { "application/json": { schema: BufferPushRequestSchema } },
+    },
+  },
+  parameters: AuthHeaders,
+  responses: {
+    200: {
+      description: "Leads buffered successfully",
+      content: { "application/json": { schema: BufferPushResponseSchema } },
+    },
+    400: {
+      description: "Invalid request",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    401: { description: "Unauthorized" },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/buffer/next",
+  summary: "Pull the next lead from the buffer",
+  request: {
+    params: z.object({}),
+    body: {
+      content: { "application/json": { schema: BufferNextRequestSchema } },
+    },
+  },
+  parameters: AuthHeaders,
+  responses: {
+    200: {
+      description: "Next lead from buffer",
+      content: { "application/json": { schema: BufferNextResponseSchema } },
+    },
+    400: {
+      description: "Invalid request",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    401: { description: "Unauthorized" },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/cursor/{namespace}",
+  summary: "Get cursor state for a namespace",
+  request: {
+    params: z.object({ namespace: z.string() }),
+  },
+  parameters: AuthHeaders,
+  responses: {
+    200: {
+      description: "Cursor state",
+      content: { "application/json": { schema: CursorGetResponseSchema } },
+    },
+    401: { description: "Unauthorized" },
+  },
+});
+
+registry.registerPath({
+  method: "put",
+  path: "/cursor/{namespace}",
+  summary: "Set cursor state for a namespace",
+  request: {
+    params: z.object({ namespace: z.string() }),
+    body: {
+      content: { "application/json": { schema: CursorSetRequestSchema } },
+    },
+  },
+  parameters: AuthHeaders,
+  responses: {
+    200: {
+      description: "Cursor updated",
+      content: { "application/json": { schema: CursorSetResponseSchema } },
+    },
+    400: {
+      description: "Invalid request",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    401: { description: "Unauthorized" },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/leads",
+  summary: "List served leads with enrichment data",
+  parameters: [
+    ...AuthHeaders,
+    {
+      in: "query" as const,
+      name: "brandId",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
+      name: "clerkOrgId",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
+      name: "clerkUserId",
+      required: false,
+      schema: { type: "string" as const },
+    },
+  ],
+  responses: {
+    200: {
+      description: "List of served leads",
+      content: { "application/json": { schema: LeadsResponseSchema } },
+    },
+    401: { description: "Unauthorized" },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/stats",
+  summary: "Get lead stats by status",
+  description:
+    "Returns counts of leads by status: served (delivered with verified email), buffered (awaiting enrichment), and skipped (no email found).",
+  parameters: [
+    ...AuthHeaders,
+    {
+      in: "query" as const,
+      name: "brandId",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
+      name: "campaignId",
+      required: false,
+      schema: { type: "string" as const },
+    },
+  ],
+  responses: {
+    200: {
+      description: "Lead stats by status with Apollo metrics",
+      content: { "application/json": { schema: StatsResponseSchema } },
+    },
+    401: { description: "Unauthorized" },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/stats",
+  summary: "Get lead stats by status (internal)",
+  description:
+    "Service-to-service endpoint. Returns counts of leads by status.",
+  request: {
+    body: {
+      content: { "application/json": { schema: StatsPostRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Lead stats by status with Apollo metrics",
+      content: { "application/json": { schema: StatsResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/openapi.json",
+  summary: "Get OpenAPI specification",
+  responses: {
+    200: { description: "OpenAPI JSON document" },
+    404: { description: "Spec not generated" },
+  },
+});


### PR DESCRIPTION
## Summary
- Replaced `swagger-autogen` with `zod` + `@asteasolutions/zod-to-openapi` for OpenAPI spec generation
- Created `src/schemas.ts` as single source of truth: zod schemas with `.openapi()` names, `registry.registerPath()` for all 8 endpoints
- Route handlers now use `safeParse()` for runtime request validation on all POST/PUT endpoints (buffer/push, buffer/next, cursor PUT, stats POST)
- Rewrote `scripts/generate-openapi.ts` to use `OpenApiGeneratorV3` instead of swagger-autogen
- Removed all `#swagger.*` comment annotations from route files

## Test plan
- [x] `npm run build` compiles successfully and generates `openapi.json`
- [x] Unit tests pass (10/10)
- [x] Generated spec validated against existing API registry spec — covers all endpoints with richer schema definitions
- [ ] Deploy to staging and verify `/openapi.json` endpoint serves correct spec
- [ ] Verify request validation returns 400 with details on malformed POST bodies

🤖 Generated with [Claude Code](https://claude.com/claude-code)