### PR TITLE
Add campaignId filter and consolidate stats endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -259,29 +259,6 @@
           "apollo"
         ]
       },
-      "StatsPostRequest": {
-        "type": "object",
-        "properties": {
-          "runIds": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "appId": {
-            "type": "string"
-          },
-          "brandId": {
-            "type": "string"
-          },
-          "campaignId": {
-            "type": "string"
-          },
-          "clerkOrgId": {
-            "type": "string"
-          }
-        }
-      }
     },
     "parameters": {},
     "securitySchemes": {
@@ -619,6 +596,14 @@
           },
           {
             "in": "query",
+            "name": "campaignId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "clerkOrgId",
             "required": false,
             "schema": {
@@ -698,6 +683,39 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "clerkOrgId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "clerkUserId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "appId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "runIds",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of run IDs",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -713,31 +731,6 @@
           },
           "401": {
             "description": "Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "summary": "Get lead stats by status (internal)",
-        "description": "Service-to-service endpoint. Returns counts of leads by status.",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StatsPostRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Lead stats by status with Apollo metrics",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StatsResponse"
-                }
-              }
-            }
           }
         }
       }

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -8,13 +8,16 @@ const router = Router();
 
 router.get("/leads", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
-    const { brandId, clerkOrgId, clerkUserId } = req.query;
+    const { brandId, campaignId, clerkOrgId, clerkUserId } = req.query;
 
     // Build filter conditions
     const conditions: SQL[] = [eq(servedLeads.organizationId, req.organizationId!)];
 
     if (brandId && typeof brandId === "string") {
       conditions.push(eq(servedLeads.brandId, brandId));
+    }
+    if (campaignId && typeof campaignId === "string") {
+      conditions.push(eq(servedLeads.campaignId, campaignId));
     }
     if (clerkOrgId && typeof clerkOrgId === "string") {
       conditions.push(eq(servedLeads.clerkOrgId, clerkOrgId));

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -4,15 +4,19 @@ import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
 import { db } from "../db/index.js";
 import { servedLeads, leadBuffer, organizations } from "../db/schema.js";
 import { fetchApolloStats } from "../lib/apollo-client.js";
-import { StatsPostRequestSchema } from "../schemas.js";
 
 const router = Router();
 
 router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
-    const { brandId, campaignId } = req.query;
-    const brandIdStr = typeof brandId === "string" ? brandId : undefined;
-    const campaignIdStr = typeof campaignId === "string" ? campaignId : undefined;
+    const { brandId, campaignId, clerkOrgId, clerkUserId, appId, runIds } = req.query;
+    const str = (v: unknown): string | undefined => typeof v === "string" ? v : undefined;
+    const brandIdStr = str(brandId);
+    const campaignIdStr = str(campaignId);
+    const clerkOrgIdStr = str(clerkOrgId);
+    const clerkUserIdStr = str(clerkUserId);
+    const appIdStr = str(appId);
+    const runIdList = typeof runIds === "string" ? runIds.split(",").filter(Boolean) : [];
 
     const servedConditions: SQL[] = [eq(servedLeads.organizationId, req.organizationId!)];
     const bufferConditions: SQL[] = [eq(leadBuffer.organizationId, req.organizationId!)];
@@ -25,63 +29,17 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
       servedConditions.push(eq(servedLeads.campaignId, campaignIdStr));
       bufferConditions.push(eq(leadBuffer.campaignId, campaignIdStr));
     }
-
-    const [servedResult, bufferRows, apollo] = await Promise.all([
-      db.select({ count: count() }).from(servedLeads).where(and(...servedConditions)).then(([r]) => r),
-      db.select({ status: leadBuffer.status, count: count() }).from(leadBuffer).where(and(...bufferConditions)).groupBy(leadBuffer.status),
-      fetchApolloStats({ brandId: brandIdStr, campaignId: campaignIdStr }, req.externalOrgId),
-    ]);
-
-    const bufferByStatus = Object.fromEntries(bufferRows.map((r) => [r.status, r.count]));
-
-    res.json({
-      served: servedResult?.count ?? 0,
-      buffered: bufferByStatus["buffered"] ?? 0,
-      skipped: bufferByStatus["skipped"] ?? 0,
-      apollo,
-    });
-  } catch (error) {
-    console.error("[stats] Error:", error);
-    res.status(500).json({ error: "Internal server error" });
-  }
-});
-
-router.post("/stats", async (req, res) => {
-  const parsed = StatsPostRequestSchema.safeParse(req.body);
-  if (!parsed.success) {
-    return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
-  }
-
-  try {
-    const { runIds, appId, brandId, campaignId, clerkOrgId } = parsed.data;
-
-    const servedConditions: SQL[] = [];
-    const bufferConditions: SQL[] = [];
-
-    if (runIds && runIds.length > 0) {
-      servedConditions.push(
-        or(
-          inArray(servedLeads.parentRunId, runIds),
-          inArray(servedLeads.runId, runIds)
-        )!
-      );
-      bufferConditions.push(inArray(leadBuffer.pushRunId, runIds));
+    if (clerkOrgIdStr) {
+      servedConditions.push(eq(servedLeads.clerkOrgId, clerkOrgIdStr));
+      bufferConditions.push(eq(leadBuffer.clerkOrgId, clerkOrgIdStr));
     }
-    if (brandId) {
-      servedConditions.push(eq(servedLeads.brandId, brandId));
-      bufferConditions.push(eq(leadBuffer.brandId, brandId));
+    if (clerkUserIdStr) {
+      servedConditions.push(eq(servedLeads.clerkUserId, clerkUserIdStr));
+      bufferConditions.push(eq(leadBuffer.clerkUserId, clerkUserIdStr));
     }
-    if (campaignId) {
-      servedConditions.push(eq(servedLeads.campaignId, campaignId));
-      bufferConditions.push(eq(leadBuffer.campaignId, campaignId));
-    }
-    if (clerkOrgId) {
-      servedConditions.push(eq(servedLeads.clerkOrgId, clerkOrgId));
-      bufferConditions.push(eq(leadBuffer.clerkOrgId, clerkOrgId));
-    }
-    if (appId) {
+    if (appIdStr) {
       const orgs = await db.query.organizations.findMany({
-        where: eq(organizations.appId, appId),
+        where: eq(organizations.appId, appIdStr),
       });
       if (orgs.length > 0) {
         const orgIds = orgs.map((o) => o.id);
@@ -92,20 +50,26 @@ router.post("/stats", async (req, res) => {
         return res.json({ served: 0, buffered: 0, skipped: 0, apollo: emptyApollo });
       }
     }
-
-    const servedWhere = servedConditions.length > 0 ? and(...servedConditions) : undefined;
-    const bufferWhere = bufferConditions.length > 0 ? and(...bufferConditions) : undefined;
+    if (runIdList.length > 0) {
+      servedConditions.push(
+        or(
+          inArray(servedLeads.parentRunId, runIdList),
+          inArray(servedLeads.runId, runIdList)
+        )!
+      );
+      bufferConditions.push(inArray(leadBuffer.pushRunId, runIdList));
+    }
 
     const apolloFilters: Record<string, unknown> = {};
-    if (runIds) apolloFilters.runIds = runIds;
-    if (appId) apolloFilters.appId = appId;
-    if (brandId) apolloFilters.brandId = brandId;
-    if (campaignId) apolloFilters.campaignId = campaignId;
+    if (brandIdStr) apolloFilters.brandId = brandIdStr;
+    if (campaignIdStr) apolloFilters.campaignId = campaignIdStr;
+    if (appIdStr) apolloFilters.appId = appIdStr;
+    if (runIdList.length > 0) apolloFilters.runIds = runIdList;
 
     const [servedResult, bufferRows, apollo] = await Promise.all([
-      db.select({ count: count() }).from(servedLeads).where(servedWhere).then(([r]) => r),
-      db.select({ status: leadBuffer.status, count: count() }).from(leadBuffer).where(bufferWhere).groupBy(leadBuffer.status),
-      fetchApolloStats(apolloFilters as Parameters<typeof fetchApolloStats>[0], clerkOrgId),
+      db.select({ count: count() }).from(servedLeads).where(and(...servedConditions)).then(([r]) => r),
+      db.select({ status: leadBuffer.status, count: count() }).from(leadBuffer).where(and(...bufferConditions)).groupBy(leadBuffer.status),
+      fetchApolloStats(apolloFilters as Parameters<typeof fetchApolloStats>[0], clerkOrgIdStr ?? req.externalOrgId),
     ]);
 
     const bufferByStatus = Object.fromEntries(bufferRows.map((r) => [r.status, r.count]));

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -146,16 +146,6 @@ const StatsResponseSchema = z
   })
   .openapi("StatsResponse");
 
-export const StatsPostRequestSchema = z
-  .object({
-    runIds: z.array(z.string()).optional(),
-    appId: z.string().optional(),
-    brandId: z.string().optional(),
-    campaignId: z.string().optional(),
-    clerkOrgId: z.string().optional(),
-  })
-  .openapi("StatsPostRequest");
-
 // --- Register Paths ---
 
 registry.registerPath({
@@ -273,6 +263,12 @@ registry.registerPath({
     },
     {
       in: "query" as const,
+      name: "campaignId",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
       name: "clerkOrgId",
       required: false,
       schema: { type: "string" as const },
@@ -313,6 +309,31 @@ registry.registerPath({
       required: false,
       schema: { type: "string" as const },
     },
+    {
+      in: "query" as const,
+      name: "clerkOrgId",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
+      name: "clerkUserId",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
+      name: "appId",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
+      name: "runIds",
+      required: false,
+      description: "Comma-separated list of run IDs",
+      schema: { type: "string" as const },
+    },
   ],
   responses: {
     200: {
@@ -320,25 +341,6 @@ registry.registerPath({
       content: { "application/json": { schema: StatsResponseSchema } },
     },
     401: { description: "Unauthorized" },
-  },
-});
-
-registry.registerPath({
-  method: "post",
-  path: "/stats",
-  summary: "Get lead stats by status (internal)",
-  description:
-    "Service-to-service endpoint. Returns counts of leads by status.",
-  request: {
-    body: {
-      content: { "application/json": { schema: StatsPostRequestSchema } },
-    },
-  },
-  responses: {
-    200: {
-      description: "Lead stats by status with Apollo metrics",
-      content: { "application/json": { schema: StatsResponseSchema } },
-    },
   },
 });
 


### PR DESCRIPTION
## Summary
- Added `campaignId` query param to GET /leads for filtering served leads by campaign
- Consolidated POST /stats into GET /stats by adding all missing filters (clerkOrgId, clerkUserId, appId, runIds)
- Deleted redundant POST /stats endpoint—all functionality now available via authenticated GET with query params

## Details
GET /leads now supports filtering by campaignId alongside existing brandId, clerkOrgId, clerkUserId.
GET /stats now accepts all six optional filters: brandId, campaignId, clerkOrgId, clerkUserId, appId, and runIds (comma-separated).
All endpoints remain API key protected via authenticate middleware.

## Test Plan
- [x] TypeScript compiles without errors
- [x] All 10 unit tests pass
- [x] No breaking changes to GET /leads (campaignId is optional)
- [x] GET /stats consolidation preserves all filtering logic from deleted POST endpoint