### PR TITLE
Make parentRunId mandatory and always forward downstream

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -98,6 +98,7 @@
         "required": [
           "campaignId",
           "brandId",
+          "parentRunId",
           "leads"
         ]
       },
@@ -169,7 +170,8 @@
         },
         "required": [
           "campaignId",
-          "brandId"
+          "brandId",
+          "parentRunId"
         ]
       },
       "CursorGetResponse": {
@@ -258,7 +260,7 @@
           "skipped",
           "apollo"
         ]
-      },
+      }
     },
     "parameters": {},
     "securitySchemes": {
@@ -685,32 +687,32 @@
             }
           },
           {
+            "in": "query",
             "name": "clerkOrgId",
-            "in": "query",
             "required": false,
             "schema": {
               "type": "string"
             }
           },
           {
+            "in": "query",
             "name": "clerkUserId",
-            "in": "query",
             "required": false,
             "schema": {
               "type": "string"
             }
           },
           {
+            "in": "query",
             "name": "appId",
-            "in": "query",
             "required": false,
             "schema": {
               "type": "string"
             }
           },
           {
-            "name": "runIds",
             "in": "query",
+            "name": "runIds",
             "required": false,
             "description": "Comma-separated list of run IDs",
             "schema": {

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -69,7 +69,7 @@ interface ApolloSearchRawResponse {
 export async function apolloSearch(
   params: ApolloSearchParams,
   page: number = 1,
-  options?: { runId?: string | null; clerkOrgId?: string | null }
+  options?: { runId?: string | null; clerkOrgId?: string | null; appId?: string; brandId?: string; campaignId?: string }
 ): Promise<ApolloSearchResult | null> {
   try {
     const headers: Record<string, string> = {};
@@ -77,7 +77,14 @@ export async function apolloSearch(
 
     const raw = await callApolloService<ApolloSearchRawResponse>("/search", {
       method: "POST",
-      body: { ...params, page, ...(options?.runId ? { runId: options.runId } : {}) },
+      body: {
+        ...params,
+        page,
+        ...(options?.runId ? { runId: options.runId } : {}),
+        ...(options?.appId ? { appId: options.appId } : {}),
+        ...(options?.brandId ? { brandId: options.brandId } : {}),
+        ...(options?.campaignId ? { campaignId: options.campaignId } : {}),
+      },
       headers,
     });
 
@@ -215,7 +222,7 @@ export interface ApolloEnrichResult {
 
 export async function apolloEnrich(
   personId: string,
-  options?: { runId?: string | null; clerkOrgId?: string | null }
+  options?: { runId?: string | null; clerkOrgId?: string | null; appId?: string; brandId?: string; campaignId?: string }
 ): Promise<ApolloEnrichResult | null> {
   try {
     const headers: Record<string, string> = {};
@@ -223,7 +230,13 @@ export async function apolloEnrich(
 
     const result = await callApolloService<ApolloEnrichResult>("/enrich", {
       method: "POST",
-      body: { apolloPersonId: personId, ...(options?.runId ? { runId: options.runId } : {}) },
+      body: {
+        apolloPersonId: personId,
+        ...(options?.runId ? { runId: options.runId } : {}),
+        ...(options?.appId ? { appId: options.appId } : {}),
+        ...(options?.brandId ? { brandId: options.brandId } : {}),
+        ...(options?.campaignId ? { campaignId: options.campaignId } : {}),
+      },
       headers,
     });
 

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -98,6 +98,7 @@ async function fillBufferFromSearch(params: {
   pushRunId?: string | null;
   clerkOrgId?: string | null;
   clerkUserId?: string | null;
+  appId?: string;
 }): Promise<{ filled: number; exhausted: boolean }> {
   const cursor = await getCursor(params.organizationId, params.campaignId);
 
@@ -115,6 +116,9 @@ async function fillBufferFromSearch(params: {
   const result = await apolloSearch(validatedParams, cursor.page, {
     runId: params.pushRunId,
     clerkOrgId: params.clerkOrgId,
+    appId: params.appId,
+    brandId: params.brandId,
+    campaignId: params.campaignId,
   });
 
   if (!result) {
@@ -180,6 +184,7 @@ export async function pullNext(params: {
   searchParams?: ApolloSearchParams;
   clerkOrgId?: string | null;
   clerkUserId?: string | null;
+  appId?: string;
 }): Promise<{
   found: boolean;
   lead?: {
@@ -222,6 +227,7 @@ export async function pullNext(params: {
           pushRunId: params.runId,
           clerkOrgId: params.clerkOrgId,
           clerkUserId: params.clerkUserId,
+          appId: params.appId,
         });
 
         if (filled > 0) {
@@ -252,6 +258,9 @@ export async function pullNext(params: {
       const enrichResult = await apolloEnrich(row.externalId, {
         runId: params.runId,
         clerkOrgId: params.clerkOrgId,
+        appId: params.appId,
+        brandId: params.brandId,
+        campaignId: params.campaignId,
       });
 
       if (!enrichResult?.person?.email) {

--- a/src/lib/search-transform.ts
+++ b/src/lib/search-transform.ts
@@ -34,25 +34,26 @@ function buildSystemPrompt(
 ): string {
   return `You transform search parameters into Apollo API search format.
 
-Output ONLY valid JSON matching ApolloSearchParams. No explanation, no markdown.
+Output ONLY valid JSON matching the Apollo search schema. No explanation, no markdown.
 
-ApolloSearchParams fields:
+Apollo search fields:
 - personTitles: string[] — job titles (e.g. ["VP Sales", "Head of Marketing"])
 - organizationLocations: string[] — locations (e.g. ["San Francisco, California, United States"])
-- organizationIndustries: string[] — industry tag IDs from the list below
+- qOrganizationIndustryTagIds: string[] — industry tag IDs from the list below
 - organizationNumEmployeesRanges: string[] — exact enum values from the list below
-- keywords: string[] — additional search keywords
+- qOrganizationKeywordTags: string[] — keyword tags for organization search
+- qKeywords: string — free-text keyword search query
 
 Valid employee ranges:
 ${employeeRanges.map((r) => `- "${r.value}" (${r.label})`).join("\n")}
 
-Valid industry IDs (use the id, not the name):
-${industries.map((i) => `- "${i.id}" (${i.name})`).join("\n")}
+Valid industry names (use the name as the tag ID):
+${industries.map((i) => `- "${i.name}"`).join("\n")}
 
 Rules:
 - Only include fields that are relevant to the input
 - Use exact enum values for employee ranges
-- Use industry IDs (not names) for organizationIndustries
+- Use industry names for qOrganizationIndustryTagIds
 - Output raw JSON only, no wrapping`;
 }
 

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -94,6 +94,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       searchParams: searchParams ?? undefined,
       clerkOrgId,
       clerkUserId: clerkUserId ?? null,
+      appId: req.appId,
     });
 
     if (serveRunId) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -59,7 +59,7 @@ export const BufferPushRequestSchema = z
   .object({
     campaignId: z.string(),
     brandId: z.string(),
-    parentRunId: z.string().optional(),
+    parentRunId: z.string(),
     clerkUserId: z.string().optional(),
     leads: z.array(LeadInputSchema),
   })
@@ -78,7 +78,7 @@ export const BufferNextRequestSchema = z
   .object({
     campaignId: z.string(),
     brandId: z.string(),
-    parentRunId: z.string().optional(),
+    parentRunId: z.string(),
     searchParams: z.record(z.string(), z.unknown()).optional(),
     clerkUserId: z.string().optional(),
   })


### PR DESCRIPTION
## Summary
- `parentRunId` is now required in both `/buffer/push` and `/buffer/next` request schemas
- Route handlers always create child runs (removed conditional guards)
- `runId` is always forwarded downstream to Apollo `/search` and `/enrich` calls

## Test plan
- [ ] Verify callers send `parentRunId` on every request
- [ ] Confirm child runs are created and visible in the Runs service