### PR TITLE
Fix LeadsResponse schema to define lead field types

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -207,15 +207,150 @@
           "leads": {
             "type": "array",
             "items": {
-              "type": "object",
-              "additionalProperties": {
-                "nullable": true
-              }
+              "$ref": "#/components/schemas/LeadDetail"
             }
           }
         },
         "required": [
           "leads"
+        ]
+      },
+      "LeadDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "organizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "externalId": {
+            "type": "string",
+            "nullable": true
+          },
+          "metadata": {
+            "nullable": true
+          },
+          "parentRunId": {
+            "type": "string",
+            "nullable": true
+          },
+          "runId": {
+            "type": "string",
+            "nullable": true
+          },
+          "brandId": {
+            "type": "string"
+          },
+          "campaignId": {
+            "type": "string"
+          },
+          "clerkOrgId": {
+            "type": "string",
+            "nullable": true
+          },
+          "clerkUserId": {
+            "type": "string",
+            "nullable": true
+          },
+          "servedAt": {
+            "type": "string"
+          },
+          "enrichment": {
+            "$ref": "#/components/schemas/Enrichment"
+          }
+        },
+        "required": [
+          "id",
+          "organizationId",
+          "namespace",
+          "email",
+          "externalId",
+          "parentRunId",
+          "runId",
+          "brandId",
+          "campaignId",
+          "clerkOrgId",
+          "clerkUserId",
+          "servedAt",
+          "enrichment"
+        ]
+      },
+      "Enrichment": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "type": "string"
+          },
+          "apolloPersonId": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "linkedinUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationDomain": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationIndustry": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationSize": {
+            "type": "string",
+            "nullable": true
+          },
+          "responseRaw": {
+            "nullable": true
+          },
+          "enrichedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "email",
+          "apolloPersonId",
+          "firstName",
+          "lastName",
+          "title",
+          "linkedinUrl",
+          "organizationName",
+          "organizationDomain",
+          "organizationIndustry",
+          "organizationSize",
+          "enrichedAt"
         ]
       },
       "StatsResponse": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -122,9 +122,46 @@ const CursorSetResponseSchema = z
 
 // --- Leads ---
 
+const EnrichmentSchema = z
+  .object({
+    id: z.string().uuid(),
+    email: z.string(),
+    apolloPersonId: z.string().nullable(),
+    firstName: z.string().nullable(),
+    lastName: z.string().nullable(),
+    title: z.string().nullable(),
+    linkedinUrl: z.string().nullable(),
+    organizationName: z.string().nullable(),
+    organizationDomain: z.string().nullable(),
+    organizationIndustry: z.string().nullable(),
+    organizationSize: z.string().nullable(),
+    responseRaw: z.unknown().nullable(),
+    enrichedAt: z.string(),
+  })
+  .openapi("Enrichment");
+
+const LeadDetailSchema = z
+  .object({
+    id: z.string().uuid(),
+    organizationId: z.string().uuid(),
+    namespace: z.string(),
+    email: z.string(),
+    externalId: z.string().nullable(),
+    metadata: z.unknown().nullable(),
+    parentRunId: z.string().nullable(),
+    runId: z.string().nullable(),
+    brandId: z.string(),
+    campaignId: z.string(),
+    clerkOrgId: z.string().nullable(),
+    clerkUserId: z.string().nullable(),
+    servedAt: z.string(),
+    enrichment: EnrichmentSchema.nullable(),
+  })
+  .openapi("LeadDetail");
+
 const LeadsResponseSchema = z
   .object({
-    leads: z.array(z.record(z.string(), z.unknown())),
+    leads: z.array(LeadDetailSchema),
   })
   .openapi("LeadsResponse");
 

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
 import request from "supertest";
 import app from "../../src/index.js";
 import {
@@ -8,6 +8,13 @@ import {
   getAuthHeaders,
   TEST_API_KEY,
 } from "./setup.js";
+
+vi.mock("../../src/lib/runs-client.js", () => ({
+  ensureOrganization: vi.fn().mockResolvedValue("mock-org-id"),
+  createRun: vi.fn().mockResolvedValue({ id: "mock-run-id" }),
+  updateRun: vi.fn().mockResolvedValue(undefined),
+  addCosts: vi.fn().mockResolvedValue(undefined),
+}));
 
 describe("API Integration Tests", () => {
   beforeAll(async () => {

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -49,6 +49,7 @@ describe("API Integration Tests", () => {
         .send({
           campaignId: "campaign-a",
           brandId: "brand-a",
+          parentRunId: "test-run-push-a",
           leads: [
             { email: "alice@example.com", externalId: "e1", data: { name: "Alice" } },
             { email: "bob@example.com", externalId: "e2", data: { name: "Bob" } },
@@ -79,6 +80,7 @@ describe("API Integration Tests", () => {
         .send({
           campaignId: "campaign-b",
           brandId: "brand-b",
+          parentRunId: "test-run-push-b",
           leads: [{ email: "charlie@example.com", data: { name: "Charlie" } }],
         });
 
@@ -86,7 +88,7 @@ describe("API Integration Tests", () => {
       const res = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-b", brandId: "brand-b" });
+        .send({ campaignId: "campaign-b", brandId: "brand-b", parentRunId: "test-run-next-b" });
 
       expect(res.status).toBe(200);
       expect(res.body.found).toBe(true);
@@ -97,7 +99,7 @@ describe("API Integration Tests", () => {
       const res = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-empty", brandId: "brand-empty" });
+        .send({ campaignId: "campaign-empty", brandId: "brand-empty", parentRunId: "test-run-next-empty" });
 
       expect(res.status).toBe(200);
       expect(res.body.found).toBe(false);
@@ -111,6 +113,7 @@ describe("API Integration Tests", () => {
         .send({
           campaignId: "campaign-c",
           brandId: "brand-c",
+          parentRunId: "test-run-push-c1",
           leads: [{ email: "dedup@example.com" }],
         });
 
@@ -118,7 +121,7 @@ describe("API Integration Tests", () => {
       const first = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-c", brandId: "brand-c" });
+        .send({ campaignId: "campaign-c", brandId: "brand-c", parentRunId: "test-run-next-c1" });
 
       expect(first.body.found).toBe(true);
 
@@ -129,6 +132,7 @@ describe("API Integration Tests", () => {
         .send({
           campaignId: "campaign-c",
           brandId: "brand-c",
+          parentRunId: "test-run-push-c2",
           leads: [{ email: "dedup@example.com" }],
         });
 
@@ -138,7 +142,7 @@ describe("API Integration Tests", () => {
       const second = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-c", brandId: "brand-c" });
+        .send({ campaignId: "campaign-c", brandId: "brand-c", parentRunId: "test-run-next-c2" });
 
       expect(second.body.found).toBe(false);
     }, 10000); // Increased timeout for CI database latency


### PR DESCRIPTION
The LeadsResponse schema was previously using an untyped record, resulting in `{ leads: object[] }` in the OpenAPI spec with no field definitions for API consumers.

This PR adds properly typed `LeadDetail` and `Enrichment` schemas that match the actual API response structure, including all enrichment fields like firstName, lastName, title, linkedinUrl, and organization details.

API clients can now generate strongly-typed code from the OpenAPI spec and understand the response structure.