### PR TITLE
Fix lead names/titles not displaying on dashboard

### DIFF
--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -2,9 +2,26 @@ import { Router } from "express";
 import { eq, and, type SQL } from "drizzle-orm";
 import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
 import { db } from "../db/index.js";
-import { servedLeads, enrichments } from "../db/schema.js";
+import { servedLeads } from "../db/schema.js";
 
 const router = Router();
+
+function extractEnrichment(metadata: unknown): Record<string, unknown> | null {
+  if (!metadata || typeof metadata !== "object") return null;
+  const m = metadata as Record<string, unknown>;
+  // Only return enrichment if at least one person field exists
+  if (!m.firstName && !m.lastName && !m.email) return null;
+  return {
+    firstName: m.firstName ?? null,
+    lastName: m.lastName ?? null,
+    title: m.title ?? null,
+    linkedinUrl: m.linkedinUrl ?? m.linkedin_url ?? null,
+    organizationName: m.organizationName ?? m.organization_name ?? null,
+    organizationDomain: m.organizationDomain ?? m.organization_domain ?? null,
+    organizationIndustry: m.organizationIndustry ?? m.organization_industry ?? null,
+    organizationSize: m.organizationSize ?? m.organization_size ?? null,
+  };
+}
 
 router.get("/leads", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
@@ -31,23 +48,10 @@ router.get("/leads", authenticate, async (req: AuthenticatedRequest, res) => {
       where: and(...conditions),
     });
 
-    // Get enrichment data for all leads
-    const emails = leads.map((l) => l.email.toLowerCase());
-    const enrichmentData = emails.length > 0
-      ? await db.query.enrichments.findMany({
-          where: (table, { inArray }) => inArray(table.email, emails),
-        })
-      : [];
-
-    // Create email -> enrichment map
-    const enrichmentMap = new Map(
-      enrichmentData.map((e) => [e.email.toLowerCase(), e])
-    );
-
-    // Join leads with enrichments
+    // Extract enrichment from metadata (Apollo data is stored in servedLeads.metadata)
     const enrichedLeads = leads.map((lead) => ({
       ...lead,
-      enrichment: enrichmentMap.get(lead.email.toLowerCase()) ?? null,
+      enrichment: extractEnrichment(lead.metadata),
     }));
 
     res.json({ leads: enrichedLeads });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -124,9 +124,6 @@ const CursorSetResponseSchema = z
 
 const EnrichmentSchema = z
   .object({
-    id: z.string().uuid(),
-    email: z.string(),
-    apolloPersonId: z.string().nullable(),
     firstName: z.string().nullable(),
     lastName: z.string().nullable(),
     title: z.string().nullable(),
@@ -135,8 +132,6 @@ const EnrichmentSchema = z
     organizationDomain: z.string().nullable(),
     organizationIndustry: z.string().nullable(),
     organizationSize: z.string().nullable(),
-    responseRaw: z.unknown().nullable(),
-    enrichedAt: z.string(),
   })
   .openapi("Enrichment");
 


### PR DESCRIPTION
## Summary
- **Root cause**: `GET /leads` queried the `enrichments` table to get firstName/lastName/title, but this table was never populated. Apollo data is actually stored in `servedLeads.metadata` via `markServed()`.
- **Fix**: Read enrichment fields directly from `metadata` JSONB column instead of joining with the empty `enrichments` table.
- **Schema**: Removed DB-specific fields (`id`, `email`, `apolloPersonId`, `responseRaw`, `enrichedAt`) from `EnrichmentSchema` since enrichment is now extracted from metadata.

## Test plan
- [x] TypeScript type check passes
- [x] Unit tests pass (10/10)
- [ ] Verify on dashboard that lead names and titles display after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)