### PR TITLE
Update RunsService endpoints to match API changes

### DIFF
--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -1,8 +1,6 @@
 const RUNS_SERVICE_URL = process.env.RUNS_SERVICE_URL || "https://runs.mcpfactory.org";
 const RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY || "";
 
-const orgCache = new Map<string, string>();
-
 async function callRunsService(path: string, options: {
   method?: string;
   body?: unknown;
@@ -26,24 +24,15 @@ async function callRunsService(path: string, options: {
   return response.json();
 }
 
-export async function ensureOrganization(externalOrgId: string): Promise<string> {
-  const cached = orgCache.get(externalOrgId);
-  if (cached) return cached;
-
-  const result = await callRunsService("/organizations", {
-    method: "POST",
-    body: { externalId: externalOrgId },
-  }) as { id: string };
-
-  orgCache.set(externalOrgId, result.id);
-  return result.id;
-}
-
 export async function createRun(params: {
-  organizationId: string;
+  clerkOrgId: string;
+  appId: string;
   serviceName: string;
   taskName: string;
   parentRunId?: string;
+  clerkUserId?: string;
+  brandId?: string;
+  campaignId?: string;
 }): Promise<{ id: string }> {
   return callRunsService("/runs", {
     method: "POST",

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
 import { pushLeads, pullNext } from "../lib/buffer.js";
-import { ensureOrganization, createRun, updateRun } from "../lib/runs-client.js";
+import { createRun, updateRun } from "../lib/runs-client.js";
 import { BufferPushRequestSchema, BufferNextRequestSchema } from "../schemas.js";
 
 const router = Router();
@@ -17,12 +17,15 @@ router.post("/buffer/push", authenticate, async (req: AuthenticatedRequest, res)
     const clerkOrgId = req.externalOrgId ?? null;
 
     // Create child run for traceability
-    const runsOrgId = await ensureOrganization(req.externalOrgId!);
     const childRun = await createRun({
-      organizationId: runsOrgId,
+      clerkOrgId: req.externalOrgId!,
+      appId: req.appId || "mcpfactory",
       serviceName: "lead-service",
       taskName: "buffer-push",
       parentRunId,
+      clerkUserId,
+      brandId,
+      campaignId,
     });
     const pushRunId = childRun.id;
 
@@ -60,12 +63,15 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
     const clerkOrgId = req.externalOrgId ?? null;
 
     // Create child run for traceability
-    const runsOrgId = await ensureOrganization(req.externalOrgId!);
     const childRun = await createRun({
-      organizationId: runsOrgId,
+      clerkOrgId: req.externalOrgId!,
+      appId: req.appId || "mcpfactory",
       serviceName: "lead-service",
       taskName: "lead-serve",
       parentRunId,
+      clerkUserId,
+      brandId,
+      campaignId,
     });
     const serveRunId = childRun.id;
 


### PR DESCRIPTION
Aligns the runs-client with the updated RunsService API:
- Removes ensureOrganization() endpoint (no longer exists)
- Updates createRun() to pass clerkOrgId and appId directly
- Includes all optional fields (clerkUserId, brandId, campaignId)
- Eliminates two-step organization resolution from buffer routes