### PR TITLE
Add CLAUDE.md and conductor.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# Project: lead-service
+
+Single source of truth for lead management — buffering, deduplication, enrichment caching, and lead retrieval.
+
+## Commands
+
+- `npm test` — run all tests (Vitest)
+- `npm run test:unit` — run unit tests only
+- `npm run test:integration` — run integration tests only
+- `npm run build` — compile TypeScript + generate OpenAPI spec
+- `npm run dev` — local dev server with hot reload
+- `npm run generate:openapi` — regenerate openapi.json from Zod schemas
+- `npm run db:generate` — generate Drizzle migrations
+- `npm run db:migrate` — run Drizzle migrations
+- `npm run db:push` — push schema directly (dev only)
+
+## Architecture
+
+- `src/schemas.ts` — Zod schemas (source of truth for validation + OpenAPI)
+- `src/routes/` — Express route handlers (buffer, leads, cursor, health, stats)
+- `src/middleware/auth.ts` — API key + multi-tenant header auth
+- `src/lib/buffer.ts` — pushLeads(), pullNext() buffer logic
+- `src/lib/dedup.ts` — isServed(), markServed() deduplication
+- `src/lib/apollo-client.ts` — Apollo enrichment service integration
+- `src/lib/runs-client.ts` — Runs service client for distributed tracing
+- `src/lib/search-transform.ts` — LLM search query transforms
+- `src/db/schema.ts` — Drizzle ORM table definitions (PostgreSQL)
+- `src/db/index.ts` — Database connection
+- `src/config.ts` — Environment config
+- `src/instrument.ts` — Sentry instrumentation
+- `tests/` — Test files (`*.test.ts`)
+- `openapi.json` — Auto-generated from Zod schemas, do NOT edit manually

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "setup": "npm install",
+    "run": "npm test"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with project description, available commands, and architecture overview for agent context
- Add `conductor.json` with setup and run scripts for Conductor workspaces

## Test plan
- [x] Verify CLAUDE.md content matches actual project structure
- [x] Verify conductor.json scripts are valid (`npm install`, `npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)