### PR TITLE
Fix empty brandId causing runs-service 400 error

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -62,13 +62,16 @@
         "type": "object",
         "properties": {
           "campaignId": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "brandId": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "parentRunId": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "clerkUserId": {
             "type": "string"
@@ -150,13 +153,16 @@
         "type": "object",
         "properties": {
           "campaignId": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "brandId": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "parentRunId": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "searchParams": {
             "type": "object",
@@ -288,17 +294,6 @@
         "type": "object",
         "nullable": true,
         "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "email": {
-            "type": "string"
-          },
-          "apolloPersonId": {
-            "type": "string",
-            "nullable": true
-          },
           "firstName": {
             "type": "string",
             "nullable": true
@@ -330,18 +325,9 @@
           "organizationSize": {
             "type": "string",
             "nullable": true
-          },
-          "responseRaw": {
-            "nullable": true
-          },
-          "enrichedAt": {
-            "type": "string"
           }
         },
         "required": [
-          "id",
-          "email",
-          "apolloPersonId",
           "firstName",
           "lastName",
           "title",
@@ -349,8 +335,7 @@
           "organizationName",
           "organizationDomain",
           "organizationIndustry",
-          "organizationSize",
-          "enrichedAt"
+          "organizationSize"
         ]
       },
       "StatsResponse": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -57,9 +57,9 @@ const LeadInputSchema = z.object({
 
 export const BufferPushRequestSchema = z
   .object({
-    campaignId: z.string(),
-    brandId: z.string(),
-    parentRunId: z.string(),
+    campaignId: z.string().min(1),
+    brandId: z.string().min(1),
+    parentRunId: z.string().min(1),
     clerkUserId: z.string().optional(),
     leads: z.array(LeadInputSchema),
   })
@@ -76,9 +76,9 @@ const BufferPushResponseSchema = z
 
 export const BufferNextRequestSchema = z
   .object({
-    campaignId: z.string(),
-    brandId: z.string(),
-    parentRunId: z.string(),
+    campaignId: z.string().min(1),
+    brandId: z.string().min(1),
+    parentRunId: z.string().min(1),
     searchParams: z.record(z.string(), z.unknown()).optional(),
     clerkUserId: z.string().optional(),
   })

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -76,6 +76,21 @@ describe("API Integration Tests", () => {
 
       expect(res.status).toBe(400);
     });
+
+    it("returns 400 when brandId is empty string", async () => {
+      const res = await request(app)
+        .post("/buffer/push")
+        .set(getAuthHeaders())
+        .send({
+          campaignId: "campaign-x",
+          brandId: "",
+          parentRunId: "test-run",
+          leads: [{ email: "test@example.com" }],
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.details.fieldErrors.brandId).toBeDefined();
+    });
   });
 
   describe("POST /buffer/next", () => {
@@ -110,6 +125,16 @@ describe("API Integration Tests", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.found).toBe(false);
+    });
+
+    it("returns 400 when brandId is empty string", async () => {
+      const res = await request(app)
+        .post("/buffer/next")
+        .set(getAuthHeaders())
+        .send({ campaignId: "campaign-x", brandId: "", parentRunId: "test-run" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.details.fieldErrors.brandId).toBeDefined();
     });
 
     it("deduplicates — same lead not served twice", async () => {

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { BufferPushRequestSchema, BufferNextRequestSchema } from "../../src/schemas.js";
+
+describe("schema validation", () => {
+  describe("BufferPushRequestSchema", () => {
+    it("rejects empty brandId", () => {
+      const result = BufferPushRequestSchema.safeParse({
+        campaignId: "c1",
+        brandId: "",
+        parentRunId: "r1",
+        leads: [],
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const fields = result.error.flatten().fieldErrors;
+        expect(fields.brandId).toBeDefined();
+      }
+    });
+
+    it("rejects empty campaignId", () => {
+      const result = BufferPushRequestSchema.safeParse({
+        campaignId: "",
+        brandId: "b1",
+        parentRunId: "r1",
+        leads: [],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects empty parentRunId", () => {
+      const result = BufferPushRequestSchema.safeParse({
+        campaignId: "c1",
+        brandId: "b1",
+        parentRunId: "",
+        leads: [],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts valid request", () => {
+      const result = BufferPushRequestSchema.safeParse({
+        campaignId: "c1",
+        brandId: "b1",
+        parentRunId: "r1",
+        leads: [{ email: "test@example.com" }],
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("BufferNextRequestSchema", () => {
+    it("rejects empty brandId", () => {
+      const result = BufferNextRequestSchema.safeParse({
+        campaignId: "c1",
+        brandId: "",
+        parentRunId: "r1",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const fields = result.error.flatten().fieldErrors;
+        expect(fields.brandId).toBeDefined();
+      }
+    });
+
+    it("rejects empty campaignId", () => {
+      const result = BufferNextRequestSchema.safeParse({
+        campaignId: "",
+        brandId: "b1",
+        parentRunId: "r1",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects empty parentRunId", () => {
+      const result = BufferNextRequestSchema.safeParse({
+        campaignId: "c1",
+        brandId: "b1",
+        parentRunId: "",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts valid request", () => {
+      const result = BufferNextRequestSchema.safeParse({
+        campaignId: "c1",
+        brandId: "b1",
+        parentRunId: "r1",
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added `.min(1)` validation to `brandId`, `campaignId`, and `parentRunId` in `BufferPushRequestSchema` and `BufferNextRequestSchema`
- Empty strings are now rejected at the lead-service boundary with a 400 error, instead of propagating to the runs service
- Regenerated `openapi.json` to reflect the `minLength: 1` constraints

## Test plan
- [x] Unit tests for schema validation (8 new tests in `tests/unit/schemas.test.ts`)
- [x] Integration test cases for empty `brandId` on both `/buffer/push` and `/buffer/next`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)