### PR TITLE
Fix migration: remove duplicate ADD COLUMN

### DIFF
--- a/drizzle/0003_furry_the_stranger.sql
+++ b/drizzle/0003_furry_the_stranger.sql
@@ -8,8 +8,6 @@ CREATE TABLE IF NOT EXISTS "idempotency_cache" (
 --> statement-breakpoint
 DROP INDEX IF EXISTS "idx_served_org_ns_email";--> statement-breakpoint
 ALTER TABLE "served_leads" ALTER COLUMN "brand_id" SET NOT NULL;--> statement-breakpoint
-ALTER TABLE "lead_buffer" ADD COLUMN "campaign_id" text NOT NULL;--> statement-breakpoint
-ALTER TABLE "served_leads" ADD COLUMN "campaign_id" text NOT NULL;--> statement-breakpoint
 DO $$ BEGIN
  ALTER TABLE "idempotency_cache" ADD CONSTRAINT "idempotency_cache_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
 EXCEPTION


### PR DESCRIPTION
## Summary

- Removes two `ALTER TABLE ... ADD COLUMN campaign_id` statements from migration 0003
- These columns already existed in production (applied via `db:push`), causing the migration to crash with `column "campaign_id" of relation "lead_buffer" already exists`

## Test plan

- [x] Build passes
- [x] Deploys without migration error

🤖 Generated with [Claude Code](https://claude.com/claude-code)