### PR TITLE
Fix workflow crash: default organization to {} in lead data

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -317,12 +317,19 @@ export async function pullNext(params: {
 
     console.log(`[pullNext] Served lead: ${email}`);
 
+    // Ensure nested `organization` object exists so downstream consumers
+    // (e.g. Windmill workflows) can safely access organization.primary_domain etc.
+    const normalizedData =
+      typeof enrichedData === "object" && enrichedData !== null
+        ? { organization: {}, ...(enrichedData as Record<string, unknown>) }
+        : enrichedData;
+
     return {
       found: true,
       lead: {
         email,
         externalId: row.externalId,
-        data: enrichedData,
+        data: normalizedData,
         brandId: params.brandId,
         clerkOrgId: row.clerkOrgId,
         clerkUserId: row.clerkUserId,

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -140,7 +140,93 @@ describe("buffer", () => {
       expect(result.found).toBe(true);
       expect(result.lead?.email).toBe("alice@acme.com");
       expect(result.lead?.externalId).toBe("e-1");
-      expect(result.lead?.data).toEqual({ name: "Alice" });
+      expect(result.lead?.data).toEqual({ organization: {}, name: "Alice" });
+    });
+
+    it("defaults organization to {} when missing from lead data", async () => {
+      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValue({
+        id: "buf-1",
+        organizationId: "org-1",
+        namespace: "campaign-1",
+        campaignId: "campaign-1",
+        email: "svitlana@hashtagweb3.com",
+        externalId: "e-1",
+        data: { first_name: "Svitlana", organization_name: "HashtagWeb3" },
+        status: "buffered",
+        pushRunId: null,
+        brandId: "brand-1",
+        clerkOrgId: null,
+        clerkUserId: null,
+        createdAt: new Date(),
+      });
+
+      vi.mocked(db.query.servedLeads.findFirst).mockResolvedValue(undefined);
+
+      const returningMock = vi.fn().mockResolvedValue([{ id: "served-1" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      const result = await pullNext({
+        organizationId: "org-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
+      });
+
+      expect(result.found).toBe(true);
+      const data = result.lead?.data as Record<string, unknown>;
+      // organization must always be an object so workflows can access organization.primary_domain
+      expect(data.organization).toEqual({});
+      expect(data.first_name).toBe("Svitlana");
+    });
+
+    it("preserves existing organization object in lead data", async () => {
+      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValue({
+        id: "buf-1",
+        organizationId: "org-1",
+        namespace: "campaign-1",
+        campaignId: "campaign-1",
+        email: "alice@acme.com",
+        externalId: "e-1",
+        data: {
+          first_name: "Alice",
+          organization: { primary_domain: "acme.com", industry: "Software" },
+        },
+        status: "buffered",
+        pushRunId: null,
+        brandId: "brand-1",
+        clerkOrgId: null,
+        clerkUserId: null,
+        createdAt: new Date(),
+      });
+
+      vi.mocked(db.query.servedLeads.findFirst).mockResolvedValue(undefined);
+
+      const returningMock = vi.fn().mockResolvedValue([{ id: "served-1" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      const result = await pullNext({
+        organizationId: "org-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
+      });
+
+      expect(result.found).toBe(true);
+      const data = result.lead?.data as Record<string, unknown>;
+      // Existing organization data should be preserved, not overwritten with {}
+      expect(data.organization).toEqual({ primary_domain: "acme.com", industry: "Software" });
     });
 
     it("skips already-served buffer rows and tries next", async () => {


### PR DESCRIPTION
## Summary
- Leads without an Apollo `organization` nested object caused Windmill workflows to crash with `cannot read property 'primary_domain' of undefined`
- `pullNext()` now defaults `data.organization` to `{}` when missing, so downstream consumers can safely access `organization.primary_domain` etc. (returns `undefined` instead of crashing)
- Existing `organization` objects are preserved as-is

## Test plan
- [x] Unit test: `organization` defaults to `{}` when missing from lead data
- [x] Unit test: existing `organization` object is preserved
- [x] All 28 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)