### PR TITLE
Return 404 when POST /buffer/next finds no lead

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -506,6 +506,16 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "404": {
+            "description": "No lead available in buffer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BufferNextResponse"
+                }
+              }
+            }
           }
         }
       }

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -88,7 +88,8 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       });
       if (cached) {
         console.log(`[buffer/next] Idempotency hit for key=${idempotencyKey}`);
-        return res.json(cached.response);
+        const cachedResult = cached.response as { found?: boolean };
+        return res.status(cachedResult.found ? 200 : 404).json(cached.response);
       }
     }
 
@@ -138,7 +139,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       console.error("[buffer/next] Failed to update run:", err);
     }
 
-    res.json(result);
+    res.status(result.found ? 200 : 404).json(result);
   } catch (error) {
     console.error("[buffer/next] Error:", error);
     res.status(500).json({ error: "Internal server error" });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -231,6 +231,10 @@ registry.registerPath({
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
     401: { description: "Unauthorized" },
+    404: {
+      description: "No lead available in buffer",
+      content: { "application/json": { schema: BufferNextResponseSchema } },
+    },
   },
 });
 

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -131,13 +131,13 @@ describe("API Integration Tests", () => {
       expect(res.body.lead.email).toBe("charlie@example.com");
     });
 
-    it("returns found: false when buffer empty", async () => {
+    it("returns 404 with found: false when buffer empty", async () => {
       const res = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
         .send({ campaignId: "campaign-empty", brandId: "brand-empty", parentRunId: "test-run-next-empty" });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(404);
       expect(res.body.found).toBe(false);
     });
 
@@ -184,12 +184,13 @@ describe("API Integration Tests", () => {
 
       expect(pushAgain.body.skippedAlreadyServed).toBe(1);
 
-      // Pull again — should find nothing
+      // Pull again — should find nothing (404)
       const second = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
         .send({ campaignId: "campaign-c", brandId: "brand-c", parentRunId: "test-run-next-c2" });
 
+      expect(second.status).toBe(404);
       expect(second.body.found).toBe(false);
     }, 10000); // Increased timeout for CI database latency
   });
@@ -305,6 +306,7 @@ describe("API Integration Tests", () => {
           idempotencyKey: "run-idem-empty",
         });
 
+      expect(first.status).toBe(404);
       expect(first.body.found).toBe(false);
 
       // Now push a lead to that campaign
@@ -318,7 +320,7 @@ describe("API Integration Tests", () => {
           leads: [{ email: "late@example.com" }],
         });
 
-      // Retry with same key — should still return cached found: false
+      // Retry with same key — should still return cached found: false (404)
       const retry = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
@@ -329,6 +331,7 @@ describe("API Integration Tests", () => {
           idempotencyKey: "run-idem-empty",
         });
 
+      expect(retry.status).toBe(404);
       expect(retry.body.found).toBe(false);
     });
 


### PR DESCRIPTION
## Summary
- Windmill workflows crash with `cannot read property 'externalId' of undefined` when `POST /buffer/next` returns `{ found: false }` with HTTP 200 — the workflow expression assumes `lead` data exists
- Changed `POST /buffer/next` to return **404** when no lead is found (both fresh and idempotency-cached responses), so the Windmill step fails cleanly via HTTP error handling instead of crashing in expression evaluation
- Updated OpenAPI spec to document the 404 response

## Test plan
- [x] Unit tests pass (28/28)
- [ ] Integration tests pass in CI (require `LEAD_SERVICE_DATABASE_URL`)
- [ ] Verify Windmill workflows handle the 404 gracefully (step failure → end_run with `success=false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)