### PR TITLE
Revert 404 on empty buffer, remove organization fallback

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -506,16 +506,6 @@
           },
           "401": {
             "description": "Unauthorized"
-          },
-          "404": {
-            "description": "No lead available in buffer",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BufferNextResponse"
-                }
-              }
-            }
           }
         }
       }

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -317,19 +317,12 @@ export async function pullNext(params: {
 
     console.log(`[pullNext] Served lead: ${email}`);
 
-    // Ensure nested `organization` object exists so downstream consumers
-    // (e.g. Windmill workflows) can safely access organization.primary_domain etc.
-    const normalizedData =
-      typeof enrichedData === "object" && enrichedData !== null
-        ? { organization: {}, ...(enrichedData as Record<string, unknown>) }
-        : enrichedData;
-
     return {
       found: true,
       lead: {
         email,
         externalId: row.externalId,
-        data: normalizedData,
+        data: enrichedData,
         brandId: params.brandId,
         clerkOrgId: row.clerkOrgId,
         clerkUserId: row.clerkUserId,

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -88,8 +88,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       });
       if (cached) {
         console.log(`[buffer/next] Idempotency hit for key=${idempotencyKey}`);
-        const cachedResult = cached.response as { found?: boolean };
-        return res.status(cachedResult.found ? 200 : 404).json(cached.response);
+        return res.json(cached.response);
       }
     }
 
@@ -139,7 +138,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       console.error("[buffer/next] Failed to update run:", err);
     }
 
-    res.status(result.found ? 200 : 404).json(result);
+    res.json(result);
   } catch (error) {
     console.error("[buffer/next] Error:", error);
     res.status(500).json({ error: "Internal server error" });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -231,10 +231,6 @@ registry.registerPath({
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
     401: { description: "Unauthorized" },
-    404: {
-      description: "No lead available in buffer",
-      content: { "application/json": { schema: BufferNextResponseSchema } },
-    },
   },
 });
 

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -131,13 +131,13 @@ describe("API Integration Tests", () => {
       expect(res.body.lead.email).toBe("charlie@example.com");
     });
 
-    it("returns 404 with found: false when buffer empty", async () => {
+    it("returns found: false when buffer empty", async () => {
       const res = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
         .send({ campaignId: "campaign-empty", brandId: "brand-empty", parentRunId: "test-run-next-empty" });
 
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(200);
       expect(res.body.found).toBe(false);
     });
 
@@ -184,13 +184,12 @@ describe("API Integration Tests", () => {
 
       expect(pushAgain.body.skippedAlreadyServed).toBe(1);
 
-      // Pull again — should find nothing (404)
+      // Pull again — should find nothing
       const second = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
         .send({ campaignId: "campaign-c", brandId: "brand-c", parentRunId: "test-run-next-c2" });
 
-      expect(second.status).toBe(404);
       expect(second.body.found).toBe(false);
     }, 10000); // Increased timeout for CI database latency
   });
@@ -306,7 +305,6 @@ describe("API Integration Tests", () => {
           idempotencyKey: "run-idem-empty",
         });
 
-      expect(first.status).toBe(404);
       expect(first.body.found).toBe(false);
 
       // Now push a lead to that campaign
@@ -320,7 +318,7 @@ describe("API Integration Tests", () => {
           leads: [{ email: "late@example.com" }],
         });
 
-      // Retry with same key — should still return cached found: false (404)
+      // Retry with same key — should still return cached found: false
       const retry = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
@@ -331,7 +329,6 @@ describe("API Integration Tests", () => {
           idempotencyKey: "run-idem-empty",
         });
 
-      expect(retry.status).toBe(404);
       expect(retry.body.found).toBe(false);
     });
 


### PR DESCRIPTION
## Summary
- **Reverts the 404 on empty buffer** from PR #47. `POST /buffer/next` returns 200 with `{ found: false }` — it's the caller's responsibility to handle the empty case
- **Removes the `organization: {}` fallback** from PR #46. Apollo data is flat camelCase (`organizationDomain`, `organizationName`), not a nested `organization` object. The workflow crash on `organization.primary_domain` is a client-side bug — the workflow should use `organizationDomain`. The fallback was masking this.

## Test plan
- [x] Unit tests pass (27/27) — data passes through as-is, no transformation
- [ ] Integration tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)