### PR TITLE
Document Apollo person data schema in OpenAPI

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -122,7 +122,7 @@
                 "nullable": true
               },
               "data": {
-                "nullable": true
+                "$ref": "#/components/schemas/ApolloPersonData"
               },
               "brandId": {
                 "type": "string"
@@ -139,6 +139,7 @@
             "required": [
               "email",
               "externalId",
+              "data",
               "brandId",
               "clerkOrgId",
               "clerkUserId"
@@ -148,6 +149,345 @@
         "required": [
           "found"
         ]
+      },
+      "ApolloPersonData": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailStatus": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "linkedinUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "photoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "headline": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "state": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "seniority": {
+            "type": "string",
+            "nullable": true
+          },
+          "departments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "subdepartments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "functions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "twitterUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "githubUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "facebookUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "employmentHistory": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "organizationName": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "startDate": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "endDate": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "current": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "organizationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationDomain": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationIndustry": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationSize": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationRevenueUsd": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationWebsiteUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationLogoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationShortDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationSeoDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationLinkedinUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationTwitterUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationFacebookUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationBlogUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationCrunchbaseUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationAngellistUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationFoundedYear": {
+            "type": "number",
+            "nullable": true
+          },
+          "organizationPrimaryPhone": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationPubliclyTradedSymbol": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationPubliclyTradedExchange": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationAnnualRevenuePrinted": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationTotalFunding": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationTotalFundingPrinted": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationLatestFundingRoundDate": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationLatestFundingStage": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationFundingEvents": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "date": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "type": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "investors": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "amount": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "nullable": true
+                    }
+                  ]
+                },
+                "currency": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "news_url": {
+                  "type": "string",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "organizationCity": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationState": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationCountry": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationStreetAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationPostalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "organizationTechnologyNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "organizationCurrentTechnologies": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "uid": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "name": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "category": {
+                  "type": "string",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "organizationKeywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "organizationIndustries": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "organizationSecondaryIndustries": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "organizationNumSuborganizations": {
+            "type": "number",
+            "nullable": true
+          },
+          "organizationRetailLocationCount": {
+            "type": "number",
+            "nullable": true
+          },
+          "organizationAlexaRanking": {
+            "type": "number",
+            "nullable": true
+          }
+        },
+        "additionalProperties": {
+          "nullable": true
+        },
+        "description": "Apollo person + organization data in flat camelCase format. Organization fields are prefixed with 'organization' (e.g. organizationDomain, organizationName) — there is NO nested 'organization' object. Additional fields from Apollo may be present."
       },
       "BufferNextRequest": {
         "type": "object",
@@ -247,7 +587,7 @@
             "nullable": true
           },
           "metadata": {
-            "nullable": true
+            "$ref": "#/components/schemas/ApolloPersonData"
           },
           "parentRunId": {
             "type": "string",
@@ -275,7 +615,7 @@
             "type": "string"
           },
           "enrichment": {
-            "$ref": "#/components/schemas/Enrichment"
+            "$ref": "#/components/schemas/ApolloPersonData"
           }
         },
         "required": [
@@ -284,6 +624,7 @@
           "namespace",
           "email",
           "externalId",
+          "metadata",
           "parentRunId",
           "runId",
           "brandId",
@@ -293,14 +634,6 @@
           "servedAt",
           "enrichment"
         ]
-      },
-      "Enrichment": {
-        "type": "object",
-        "nullable": true,
-        "additionalProperties": {
-          "nullable": true
-        },
-        "description": "All enrichment data from Apollo — passthrough, no filtering"
       },
       "StatsResponse": {
         "type": "object",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -72,6 +72,105 @@ const BufferPushResponseSchema = z
   })
   .openapi("BufferPushResponse");
 
+// --- Apollo Person Data (flat camelCase — matches Apollo enrichment API) ---
+
+const EmploymentHistorySchema = z.object({
+  title: z.string().nullable().optional(),
+  organizationName: z.string().nullable().optional(),
+  startDate: z.string().nullable().optional(),
+  endDate: z.string().nullable().optional(),
+  description: z.string().nullable().optional(),
+  current: z.boolean().optional(),
+});
+
+const FundingEventSchema = z.object({
+  id: z.string().nullable().optional(),
+  date: z.string().nullable().optional(),
+  type: z.string().nullable().optional(),
+  investors: z.string().nullable().optional(),
+  amount: z.union([z.number(), z.string()]).nullable().optional(),
+  currency: z.string().nullable().optional(),
+  news_url: z.string().nullable().optional(),
+});
+
+const TechnologySchema = z.object({
+  uid: z.string().nullable().optional(),
+  name: z.string().nullable().optional(),
+  category: z.string().nullable().optional(),
+});
+
+const ApolloPersonDataSchema = z
+  .object({
+    // Person identifiers
+    id: z.string().optional(),
+    email: z.string().nullable().optional(),
+    emailStatus: z.string().nullable().optional(),
+    firstName: z.string().nullable().optional(),
+    lastName: z.string().nullable().optional(),
+    title: z.string().nullable().optional(),
+    linkedinUrl: z.string().nullable().optional(),
+    // Person details
+    photoUrl: z.string().nullable().optional(),
+    headline: z.string().nullable().optional(),
+    city: z.string().nullable().optional(),
+    state: z.string().nullable().optional(),
+    country: z.string().nullable().optional(),
+    seniority: z.string().nullable().optional(),
+    departments: z.array(z.string()).optional(),
+    subdepartments: z.array(z.string()).optional(),
+    functions: z.array(z.string()).optional(),
+    twitterUrl: z.string().nullable().optional(),
+    githubUrl: z.string().nullable().optional(),
+    facebookUrl: z.string().nullable().optional(),
+    employmentHistory: z.array(EmploymentHistorySchema).optional(),
+    // Organization details (flat, NOT nested)
+    organizationName: z.string().nullable().optional(),
+    organizationDomain: z.string().nullable().optional(),
+    organizationIndustry: z.string().nullable().optional(),
+    organizationSize: z.string().nullable().optional(),
+    organizationRevenueUsd: z.string().nullable().optional(),
+    organizationWebsiteUrl: z.string().nullable().optional(),
+    organizationLogoUrl: z.string().nullable().optional(),
+    organizationShortDescription: z.string().nullable().optional(),
+    organizationSeoDescription: z.string().nullable().optional(),
+    organizationLinkedinUrl: z.string().nullable().optional(),
+    organizationTwitterUrl: z.string().nullable().optional(),
+    organizationFacebookUrl: z.string().nullable().optional(),
+    organizationBlogUrl: z.string().nullable().optional(),
+    organizationCrunchbaseUrl: z.string().nullable().optional(),
+    organizationAngellistUrl: z.string().nullable().optional(),
+    organizationFoundedYear: z.number().nullable().optional(),
+    organizationPrimaryPhone: z.string().nullable().optional(),
+    organizationPubliclyTradedSymbol: z.string().nullable().optional(),
+    organizationPubliclyTradedExchange: z.string().nullable().optional(),
+    organizationAnnualRevenuePrinted: z.string().nullable().optional(),
+    organizationTotalFunding: z.string().nullable().optional(),
+    organizationTotalFundingPrinted: z.string().nullable().optional(),
+    organizationLatestFundingRoundDate: z.string().nullable().optional(),
+    organizationLatestFundingStage: z.string().nullable().optional(),
+    organizationFundingEvents: z.array(FundingEventSchema).optional(),
+    organizationCity: z.string().nullable().optional(),
+    organizationState: z.string().nullable().optional(),
+    organizationCountry: z.string().nullable().optional(),
+    organizationStreetAddress: z.string().nullable().optional(),
+    organizationPostalCode: z.string().nullable().optional(),
+    organizationTechnologyNames: z.array(z.string()).optional(),
+    organizationCurrentTechnologies: z.array(TechnologySchema).optional(),
+    organizationKeywords: z.array(z.string()).optional(),
+    organizationIndustries: z.array(z.string()).optional(),
+    organizationSecondaryIndustries: z.array(z.string()).optional(),
+    organizationNumSuborganizations: z.number().nullable().optional(),
+    organizationRetailLocationCount: z.number().nullable().optional(),
+    organizationAlexaRanking: z.number().nullable().optional(),
+  })
+  .passthrough()
+  .openapi("ApolloPersonData", {
+    description:
+      "Apollo person + organization data in flat camelCase format. " +
+      "Organization fields are prefixed with 'organization' (e.g. organizationDomain, organizationName) — " +
+      "there is NO nested 'organization' object. Additional fields from Apollo may be present.",
+  });
+
 // --- Buffer Next ---
 
 export const BufferNextRequestSchema = z
@@ -88,7 +187,7 @@ export const BufferNextRequestSchema = z
 const ServedLeadSchema = z.object({
   email: z.string(),
   externalId: z.string().nullable(),
-  data: z.unknown(),
+  data: ApolloPersonDataSchema.nullable(),
   brandId: z.string(),
   clerkOrgId: z.string().nullable(),
   clerkUserId: z.string().nullable(),
@@ -123,12 +222,6 @@ const CursorSetResponseSchema = z
 
 // --- Leads ---
 
-const EnrichmentSchema = z
-  .record(z.string(), z.unknown())
-  .openapi("Enrichment", {
-    description: "All enrichment data from Apollo — passthrough, no filtering",
-  });
-
 const LeadDetailSchema = z
   .object({
     id: z.string().uuid(),
@@ -136,7 +229,7 @@ const LeadDetailSchema = z
     namespace: z.string(),
     email: z.string(),
     externalId: z.string().nullable(),
-    metadata: z.unknown().nullable(),
+    metadata: ApolloPersonDataSchema.nullable(),
     parentRunId: z.string().nullable(),
     runId: z.string().nullable(),
     brandId: z.string(),
@@ -144,7 +237,7 @@ const LeadDetailSchema = z
     clerkOrgId: z.string().nullable(),
     clerkUserId: z.string().nullable(),
     servedAt: z.string(),
-    enrichment: EnrichmentSchema.nullable(),
+    enrichment: ApolloPersonDataSchema.nullable(),
   })
   .openapi("LeadDetail");
 


### PR DESCRIPTION
## Summary
- Replace `z.unknown()` with full `ApolloPersonDataSchema` listing all 57 Apollo fields in flat camelCase format
- Clients reading the spec via API Registry now see exact field names (`organizationDomain`, `organizationName`, etc.)
- Description explicitly states: **there is NO nested `organization` object**
- Applied to `ServedLeadSchema.data`, `LeadDetailSchema.metadata`, and `LeadDetailSchema.enrichment`
- `.passthrough()` allows additional fields from Apollo without breaking validation

## Test plan
- [x] Unit tests pass (27/27)
- [x] Build + OpenAPI generation succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)