### PR TITLE
Make anthropicKeySource a required input on POST /buffer/next

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -504,6 +504,14 @@
             "type": "string",
             "minLength": 1
           },
+          "anthropicKeySource": {
+            "type": "string",
+            "enum": [
+              "byok",
+              "app"
+            ],
+            "description": "How Apollo service should resolve the Anthropic API key: 'byok' = use the org's own key via key-service, 'app' = use the platform's key."
+          },
           "searchParams": {
             "type": "object",
             "additionalProperties": {
@@ -521,7 +529,8 @@
         "required": [
           "campaignId",
           "brandId",
-          "parentRunId"
+          "parentRunId",
+          "anthropicKeySource"
         ]
       },
       "CursorGetResponse": {

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -222,7 +222,7 @@ export interface ApolloSearchParamsResult {
 
 export async function apolloSearchParams(options: {
   context: string;
-  anthropicKeySource?: "byok" | "app";
+  anthropicKeySource: "byok" | "app";
   runId: string;
   appId: string;
   brandId: string;
@@ -236,7 +236,7 @@ export async function apolloSearchParams(options: {
     method: "POST",
     body: {
       context: options.context,
-      anthropicKeySource: options.anthropicKeySource ?? "app",
+      anthropicKeySource: options.anthropicKeySource,
       runId: options.runId,
       appId: options.appId,
       brandId: options.brandId,

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -72,6 +72,7 @@ async function fillBufferFromSearch(params: {
   campaignId: string;
   brandId: string;
   searchParams: ApolloSearchParams;
+  anthropicKeySource: "byok" | "app";
   pushRunId?: string | null;
   clerkOrgId?: string | null;
   clerkUserId?: string | null;
@@ -107,6 +108,7 @@ async function fillBufferFromSearch(params: {
 
   const { searchParams: validatedParams } = await apolloSearchParams({
     context,
+    anthropicKeySource: params.anthropicKeySource,
     runId: params.pushRunId ?? "",
     appId: params.appId ?? "",
     brandId: params.brandId,
@@ -201,6 +203,7 @@ export async function pullNext(params: {
   brandId: string;
   parentRunId?: string | null;
   runId?: string | null;
+  anthropicKeySource?: "byok" | "app";
   searchParams?: ApolloSearchParams;
   clerkOrgId?: string | null;
   clerkUserId?: string | null;
@@ -236,12 +239,13 @@ export async function pullNext(params: {
 
     if (!row) {
       // Buffer empty - try to fill from search if searchParams provided
-      if (params.searchParams) {
+      if (params.searchParams && params.anthropicKeySource) {
         const { filled } = await fillBufferFromSearch({
           organizationId: params.organizationId,
           campaignId: params.campaignId,
           brandId: params.brandId,
           searchParams: params.searchParams,
+          anthropicKeySource: params.anthropicKeySource,
           pushRunId: params.runId,
           clerkOrgId: params.clerkOrgId,
           clerkUserId: params.clerkUserId,

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -78,7 +78,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
   }
 
   try {
-    const { campaignId, brandId, parentRunId, searchParams, clerkUserId, idempotencyKey } = parsed.data;
+    const { campaignId, brandId, parentRunId, anthropicKeySource, searchParams, clerkUserId, idempotencyKey } = parsed.data;
     const clerkOrgId = req.externalOrgId ?? null;
 
     // Idempotency: return cached response if this key was already processed
@@ -111,6 +111,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       brandId,
       parentRunId,
       runId: serveRunId,
+      anthropicKeySource,
       searchParams: searchParams ?? undefined,
       clerkOrgId,
       clerkUserId: clerkUserId ?? null,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -178,6 +178,9 @@ export const BufferNextRequestSchema = z
     campaignId: z.string().min(1),
     brandId: z.string().min(1),
     parentRunId: z.string().min(1),
+    anthropicKeySource: z.enum(["byok", "app"]).openapi({
+      description: "How Apollo service should resolve the Anthropic API key: 'byok' = use the org's own key via key-service, 'app' = use the platform's key.",
+    }),
     searchParams: z.record(z.string(), z.unknown()).optional(),
     clerkUserId: z.string().optional(),
     idempotencyKey: z.string().min(1).optional(),

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -338,6 +338,7 @@ describe("buffer", () => {
         organizationId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        anthropicKeySource: "byok",
         searchParams: { description: "tech CEOs" },
         appId: "my-app",
       });
@@ -444,6 +445,7 @@ describe("buffer", () => {
         organizationId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        anthropicKeySource: "byok",
         searchParams: { description: "tech CEOs" },
         appId: "my-app",
       });
@@ -471,6 +473,7 @@ describe("buffer", () => {
         organizationId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        anthropicKeySource: "byok",
         searchParams: { description: "impossible search" },
         appId: "my-app",
       });
@@ -494,6 +497,7 @@ describe("buffer", () => {
         organizationId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        anthropicKeySource: "byok",
         searchParams: { description: "tech CEOs" },
         appId: "my-app",
       });
@@ -547,6 +551,7 @@ describe("buffer", () => {
         organizationId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        anthropicKeySource: "byok",
         searchParams: { description: "tech CEOs" },
         appId: "my-app",
       });

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -85,6 +85,7 @@ describe("schema validation", () => {
         campaignId: "c1",
         brandId: "b1",
         parentRunId: "r1",
+        anthropicKeySource: "byok",
       });
       expect(result.success).toBe(true);
     });
@@ -94,6 +95,7 @@ describe("schema validation", () => {
         campaignId: "c1",
         brandId: "b1",
         parentRunId: "r1",
+        anthropicKeySource: "byok",
         idempotencyKey: "run-123",
       });
       expect(result.success).toBe(true);


### PR DESCRIPTION
## Summary
- **BREAKING CHANGE**: `POST /buffer/next` now requires `anthropicKeySource` (enum: `"byok"` | `"app"`) in the request body
- Previously hardcoded to `"app"`, which caused production failures when apollo-service couldn't find a platform Anthropic key
- Threaded through the full call chain: schema → route → `pullNext` → `fillBufferFromSearch` → `apolloSearchParams`
- Removed the `?? "app"` default from `apolloSearchParams()` — callers must now provide it explicitly
- Updated OpenAPI spec (`openapi.json`) to reflect the new required field

## Breaking change for campaign-service

Campaign-service calls `POST /buffer/next` and must now include `anthropicKeySource` in the request body. Example:

```json
{
  "campaignId": "...",
  "brandId": "...",
  "parentRunId": "...",
  "anthropicKeySource": "byok",
  "searchParams": { ... }
}
```

The field accepts `"byok"` (use org's own Anthropic key via key-service) or `"app"` (use platform key). In production, `"byok"` should be the default.

See the updated OpenAPI spec for full schema details.

## Test plan
- [x] All 31 unit tests pass
- [x] TypeScript compiles cleanly
- [x] OpenAPI spec regenerated from Zod schemas
- [x] Schema tests updated for new required field

🤖 Generated with [Claude Code](https://claude.com/claude-code)