### PR TITLE
Require keySource on POST /buffer/next, rename from anthropicKeySource

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -504,13 +504,13 @@
             "type": "string",
             "minLength": 1
           },
-          "anthropicKeySource": {
+          "keySource": {
             "type": "string",
             "enum": [
               "byok",
               "app"
             ],
-            "description": "How Apollo service should resolve the Anthropic API key: 'byok' = use the org's own key via key-service, 'app' = use the platform's key."
+            "description": "How downstream services resolve API keys: 'byok' = use the org's own keys via key-service, 'app' = use platform keys."
           },
           "searchParams": {
             "type": "object",
@@ -530,7 +530,7 @@
           "campaignId",
           "brandId",
           "parentRunId",
-          "anthropicKeySource"
+          "keySource"
         ]
       },
       "CursorGetResponse": {

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -222,7 +222,7 @@ export interface ApolloSearchParamsResult {
 
 export async function apolloSearchParams(options: {
   context: string;
-  anthropicKeySource: "byok" | "app";
+  keySource: "byok" | "app";
   runId: string;
   appId: string;
   brandId: string;
@@ -236,7 +236,7 @@ export async function apolloSearchParams(options: {
     method: "POST",
     body: {
       context: options.context,
-      anthropicKeySource: options.anthropicKeySource,
+      anthropicKeySource: options.keySource,
       runId: options.runId,
       appId: options.appId,
       brandId: options.brandId,

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -72,7 +72,7 @@ async function fillBufferFromSearch(params: {
   campaignId: string;
   brandId: string;
   searchParams: ApolloSearchParams;
-  anthropicKeySource: "byok" | "app";
+  keySource: "byok" | "app";
   pushRunId?: string | null;
   clerkOrgId?: string | null;
   clerkUserId?: string | null;
@@ -108,7 +108,7 @@ async function fillBufferFromSearch(params: {
 
   const { searchParams: validatedParams } = await apolloSearchParams({
     context,
-    anthropicKeySource: params.anthropicKeySource,
+    keySource: params.keySource,
     runId: params.pushRunId ?? "",
     appId: params.appId ?? "",
     brandId: params.brandId,
@@ -203,7 +203,7 @@ export async function pullNext(params: {
   brandId: string;
   parentRunId?: string | null;
   runId?: string | null;
-  anthropicKeySource?: "byok" | "app";
+  keySource?: "byok" | "app";
   searchParams?: ApolloSearchParams;
   clerkOrgId?: string | null;
   clerkUserId?: string | null;
@@ -239,13 +239,13 @@ export async function pullNext(params: {
 
     if (!row) {
       // Buffer empty - try to fill from search if searchParams provided
-      if (params.searchParams && params.anthropicKeySource) {
+      if (params.searchParams && params.keySource) {
         const { filled } = await fillBufferFromSearch({
           organizationId: params.organizationId,
           campaignId: params.campaignId,
           brandId: params.brandId,
           searchParams: params.searchParams,
-          anthropicKeySource: params.anthropicKeySource,
+          keySource: params.keySource,
           pushRunId: params.runId,
           clerkOrgId: params.clerkOrgId,
           clerkUserId: params.clerkUserId,

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -78,7 +78,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
   }
 
   try {
-    const { campaignId, brandId, parentRunId, anthropicKeySource, searchParams, clerkUserId, idempotencyKey } = parsed.data;
+    const { campaignId, brandId, parentRunId, keySource, searchParams, clerkUserId, idempotencyKey } = parsed.data;
     const clerkOrgId = req.externalOrgId ?? null;
 
     // Idempotency: return cached response if this key was already processed
@@ -111,7 +111,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       brandId,
       parentRunId,
       runId: serveRunId,
-      anthropicKeySource,
+      keySource,
       searchParams: searchParams ?? undefined,
       clerkOrgId,
       clerkUserId: clerkUserId ?? null,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -178,8 +178,8 @@ export const BufferNextRequestSchema = z
     campaignId: z.string().min(1),
     brandId: z.string().min(1),
     parentRunId: z.string().min(1),
-    anthropicKeySource: z.enum(["byok", "app"]).openapi({
-      description: "How Apollo service should resolve the Anthropic API key: 'byok' = use the org's own key via key-service, 'app' = use the platform's key.",
+    keySource: z.enum(["byok", "app"]).openapi({
+      description: "How downstream services resolve API keys: 'byok' = use the org's own keys via key-service, 'app' = use platform keys.",
     }),
     searchParams: z.record(z.string(), z.unknown()).optional(),
     clerkUserId: z.string().optional(),

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -338,7 +338,7 @@ describe("buffer", () => {
         organizationId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-        anthropicKeySource: "byok",
+        keySource: "byok",
         searchParams: { description: "tech CEOs" },
         appId: "my-app",
       });
@@ -445,7 +445,7 @@ describe("buffer", () => {
         organizationId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-        anthropicKeySource: "byok",
+        keySource: "byok",
         searchParams: { description: "tech CEOs" },
         appId: "my-app",
       });
@@ -473,7 +473,7 @@ describe("buffer", () => {
         organizationId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-        anthropicKeySource: "byok",
+        keySource: "byok",
         searchParams: { description: "impossible search" },
         appId: "my-app",
       });
@@ -497,7 +497,7 @@ describe("buffer", () => {
         organizationId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-        anthropicKeySource: "byok",
+        keySource: "byok",
         searchParams: { description: "tech CEOs" },
         appId: "my-app",
       });
@@ -551,7 +551,7 @@ describe("buffer", () => {
         organizationId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-        anthropicKeySource: "byok",
+        keySource: "byok",
         searchParams: { description: "tech CEOs" },
         appId: "my-app",
       });

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -85,7 +85,7 @@ describe("schema validation", () => {
         campaignId: "c1",
         brandId: "b1",
         parentRunId: "r1",
-        anthropicKeySource: "byok",
+        keySource: "byok",
       });
       expect(result.success).toBe(true);
     });
@@ -95,7 +95,7 @@ describe("schema validation", () => {
         campaignId: "c1",
         brandId: "b1",
         parentRunId: "r1",
-        anthropicKeySource: "byok",
+        keySource: "byok",
         idempotencyKey: "run-123",
       });
       expect(result.success).toBe(true);


### PR DESCRIPTION
## Summary
- **BREAKING CHANGE**: `POST /buffer/next` now requires `keySource` (enum: `"byok"` | `"app"`) in the request body
- Renamed from `anthropicKeySource` → `keySource` — this is a generic key mode that controls how ALL downstream services resolve API keys, not just Anthropic's
- `"byok"` = org uses their own keys via key-service, `"app"` = use platform keys
- Threaded through the full chain: schema → route → `pullNext` → `fillBufferFromSearch` → `apolloSearchParams`
- Maps to `anthropicKeySource` when calling apollo-service's `/search/params` (apollo-service's API unchanged)

## Breaking change for campaign-service

Campaign-service calls `POST /buffer/next` and must now include `keySource`:

```json
{
  "campaignId": "...",
  "brandId": "...",
  "parentRunId": "...",
  "keySource": "byok",
  "searchParams": { ... }
}
```

## Test plan
- [x] All 31 unit tests pass
- [x] TypeScript compiles cleanly
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)