### PR TITLE
Align with apollo-service: send keySource instead of anthropicKeySource

### DIFF
--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -236,7 +236,7 @@ export async function apolloSearchParams(options: {
     method: "POST",
     body: {
       context: options.context,
-      anthropicKeySource: options.keySource,
+      keySource: options.keySource,
       runId: options.runId,
       appId: options.appId,
       brandId: options.brandId,


### PR DESCRIPTION
## Summary
- Apollo-service PR #31 renamed `anthropicKeySource` → `keySource` on `POST /search/params`
- Updates the outgoing HTTP body in `apollo-client.ts` to send `keySource` instead of `anthropicKeySource`
- 1-line change, no logic changes

## Test plan
- [x] All 31 unit tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)