### PR TITLE
Downgrade no-email log from warn to info

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -321,7 +321,7 @@ export async function pullNext(params: {
         });
 
         if (!enrichResult?.person?.email) {
-          console.warn(`[pullNext] Enrichment returned no email for personId=${row.externalId}`);
+          console.log(`[pullNext] Enrichment returned no email for personId=${row.externalId}`);
           // Cache the no-email result to avoid re-enriching this person
           await db.insert(enrichments).values({
             email: null,


### PR DESCRIPTION
## Summary
- Changed `console.warn` → `console.log` for the "Enrichment returned no email" message in `pullNext`
- This is expected behavior (not all contacts have emails), so it shouldn't show as red/warning in Railway logs

## Test plan
- [x] All 43 unit tests pass
- [x] No test asserts on the log level, so no test changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)