### PR TITLE
Replace servedLeads dedup with email-gateway delivery check + lead identity registry

### DIFF
--- a/drizzle/0006_loose_phil_sheldon.sql
+++ b/drizzle/0006_loose_phil_sheldon.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS "lead_emails" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"lead_id" uuid NOT NULL,
+	"email" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "leads" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"apollo_person_id" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "served_leads" ADD COLUMN "lead_id" uuid;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "lead_emails" ADD CONSTRAINT "lead_emails_lead_id_leads_id_fk" FOREIGN KEY ("lead_id") REFERENCES "public"."leads"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_lead_emails_lead_email" ON "lead_emails" USING btree ("lead_id","email");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_lead_emails_email" ON "lead_emails" USING btree ("email");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_leads_apollo_person_id" ON "leads" USING btree ("apollo_person_id");--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "served_leads" ADD CONSTRAINT "served_leads_lead_id_leads_id_fk" FOREIGN KEY ("lead_id") REFERENCES "public"."leads"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,945 @@
+{
+  "id": "8a16f3f3-df34-4657-955c-0d167a183245",
+  "prevId": "82c378c4-16d6-4be3-b90b-667667114309",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.cursors": {
+      "name": "cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cursors_org_ns": {
+          "name": "idx_cursors_org_ns",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cursors_organization_id_organizations_id_fk": {
+          "name": "cursors_organization_id_organizations_id_fk",
+          "tableFrom": "cursors",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichments": {
+      "name": "enrichments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apollo_person_id": {
+          "name": "apollo_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_url": {
+          "name": "linkedin_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_name": {
+          "name": "organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_domain": {
+          "name": "organization_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_industry": {
+          "name": "organization_industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_size": {
+          "name": "organization_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_raw": {
+          "name": "response_raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enriched_at": {
+          "name": "enriched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_enrichments_email": {
+          "name": "idx_enrichments_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_enrichments_apollo_person_id": {
+          "name": "idx_enrichments_apollo_person_id",
+          "columns": [
+            {
+              "expression": "apollo_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_cache": {
+      "name": "idempotency_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_idempotency_key": {
+          "name": "idx_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_cache_organization_id_organizations_id_fk": {
+          "name": "idempotency_cache_organization_id_organizations_id_fk",
+          "tableFrom": "idempotency_cache",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_buffer": {
+      "name": "lead_buffer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'buffered'"
+        },
+        "push_run_id": {
+          "name": "push_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_buffer_org_ns_status": {
+          "name": "idx_buffer_org_ns_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_buffer_organization_id_organizations_id_fk": {
+          "name": "lead_buffer_organization_id_organizations_id_fk",
+          "tableFrom": "lead_buffer",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_emails": {
+      "name": "lead_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_lead_emails_lead_email": {
+          "name": "idx_lead_emails_lead_email",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_lead_emails_email": {
+          "name": "idx_lead_emails_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_emails_lead_id_leads_id_fk": {
+          "name": "lead_emails_lead_id_leads_id_fk",
+          "tableFrom": "lead_emails",
+          "tableTo": "leads",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leads": {
+      "name": "leads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "apollo_person_id": {
+          "name": "apollo_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_leads_apollo_person_id": {
+          "name": "idx_leads_apollo_person_id",
+          "columns": [
+            {
+              "expression": "apollo_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orgs_app_external": {
+          "name": "idx_orgs_app_external",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.served_leads": {
+      "name": "served_leads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_run_id": {
+          "name": "parent_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "served_at": {
+          "name": "served_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_served_org_brand_email": {
+          "name": "idx_served_org_brand_email",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_served_org": {
+          "name": "idx_served_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_served_brand": {
+          "name": "idx_served_brand",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_served_campaign": {
+          "name": "idx_served_campaign",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_served_clerk_org": {
+          "name": "idx_served_clerk_org",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_served_clerk_user": {
+          "name": "idx_served_clerk_user",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "served_leads_organization_id_organizations_id_fk": {
+          "name": "served_leads_organization_id_organizations_id_fk",
+          "tableFrom": "served_leads",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "served_leads_lead_id_leads_id_fk": {
+          "name": "served_leads_lead_id_leads_id_fk",
+          "tableFrom": "served_leads",
+          "tableTo": "leads",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_org_external": {
+          "name": "idx_users_org_external",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_organization_id_organizations_id_fk": {
+          "name": "users_organization_id_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1771464312612,
       "tag": "0005_public_klaw",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1771914700973,
+      "tag": "0006_loose_phil_sheldon",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -117,6 +117,10 @@
           "lead": {
             "type": "object",
             "properties": {
+              "leadId": {
+                "type": "string",
+                "format": "uuid"
+              },
               "email": {
                 "type": "string"
               },
@@ -140,6 +144,7 @@
               }
             },
             "required": [
+              "leadId",
               "email",
               "externalId",
               "data",
@@ -587,6 +592,11 @@
             "type": "string",
             "format": "uuid"
           },
+          "leadId": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
+          },
           "organizationId": {
             "type": "string",
             "format": "uuid"
@@ -635,6 +645,7 @@
         },
         "required": [
           "id",
+          "leadId",
           "organizationId",
           "namespace",
           "email",

--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -1,0 +1,93 @@
+const EMAIL_GATEWAY_SERVICE_URL =
+  process.env.EMAIL_GATEWAY_SERVICE_URL || "http://localhost:3009";
+const EMAIL_GATEWAY_SERVICE_API_KEY =
+  process.env.EMAIL_GATEWAY_SERVICE_API_KEY || "";
+
+export interface DeliveryStatusItem {
+  leadId?: string;
+  email: string;
+}
+
+export interface LeadDeliveryStatus {
+  contacted: boolean;
+  delivered: boolean;
+  replied: boolean;
+  lastDeliveredAt: string | null;
+}
+
+export interface EmailDeliveryStatus {
+  contacted: boolean;
+  delivered: boolean;
+  bounced: boolean;
+  unsubscribed: boolean;
+  lastDeliveredAt: string | null;
+}
+
+export interface StatusScope {
+  lead: LeadDeliveryStatus;
+  email: EmailDeliveryStatus;
+}
+
+export interface ProviderStatus {
+  campaign: StatusScope;
+  global: StatusScope;
+}
+
+export interface StatusResult {
+  leadId?: string;
+  email: string;
+  broadcast?: ProviderStatus;
+  transactional?: ProviderStatus;
+}
+
+export interface DeliveryStatusResponse {
+  results: StatusResult[];
+}
+
+export async function checkDeliveryStatus(
+  campaignId: string,
+  items: DeliveryStatusItem[]
+): Promise<DeliveryStatusResponse | null> {
+  try {
+    const response = await fetch(`${EMAIL_GATEWAY_SERVICE_URL}/status`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": EMAIL_GATEWAY_SERVICE_API_KEY,
+      },
+      body: JSON.stringify({ campaignId, items }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error(
+        `[email-gateway-client] Status check failed: ${response.status} - ${error}`
+      );
+      return null;
+    }
+
+    return (await response.json()) as DeliveryStatusResponse;
+  } catch (error) {
+    console.error("[email-gateway-client] Status check error:", error);
+    return null;
+  }
+}
+
+/**
+ * Check if a status result indicates the lead/email has been delivered
+ * via any provider (broadcast or transactional) at any scope (campaign or global).
+ */
+export function isDelivered(result: StatusResult): boolean {
+  const bc = result.broadcast;
+  const tx = result.transactional;
+  return !!(
+    bc?.campaign.lead.contacted ||
+    bc?.campaign.email.contacted ||
+    bc?.global.lead.contacted ||
+    bc?.global.email.contacted ||
+    tx?.campaign.lead.contacted ||
+    tx?.campaign.email.contacted ||
+    tx?.global.lead.contacted ||
+    tx?.global.email.contacted
+  );
+}

--- a/src/lib/leads-registry.ts
+++ b/src/lib/leads-registry.ts
@@ -1,0 +1,116 @@
+import { eq } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { leads, leadEmails } from "../db/schema.js";
+
+export interface ResolvedLead {
+  leadId: string;
+  isNew: boolean;
+}
+
+/**
+ * Find or create a lead by apolloPersonId, and ensure the email is associated.
+ * Lookup priority: apolloPersonId first, then email.
+ */
+export async function resolveOrCreateLead(params: {
+  apolloPersonId?: string | null;
+  email: string;
+  metadata?: unknown;
+}): Promise<ResolvedLead> {
+  // 1. Try to find by apolloPersonId (strongest identity signal)
+  if (params.apolloPersonId) {
+    const existing = await db.query.leads.findFirst({
+      where: eq(leads.apolloPersonId, params.apolloPersonId),
+    });
+
+    if (existing) {
+      // Ensure this email is linked to the lead
+      await db
+        .insert(leadEmails)
+        .values({ leadId: existing.id, email: params.email })
+        .onConflictDoNothing();
+
+      return { leadId: existing.id, isNew: false };
+    }
+  }
+
+  // 2. Try to find by email
+  const existingByEmail = await db.query.leadEmails.findFirst({
+    where: eq(leadEmails.email, params.email),
+  });
+
+  if (existingByEmail) {
+    // If we now have an apolloPersonId, update the lead record
+    if (params.apolloPersonId) {
+      await db
+        .update(leads)
+        .set({
+          apolloPersonId: params.apolloPersonId,
+          ...(params.metadata !== undefined ? { metadata: params.metadata } : {}),
+        })
+        .where(eq(leads.id, existingByEmail.leadId));
+    }
+
+    return { leadId: existingByEmail.leadId, isNew: false };
+  }
+
+  // 3. Create new lead + email
+  const [newLead] = await db
+    .insert(leads)
+    .values({
+      apolloPersonId: params.apolloPersonId ?? null,
+      metadata: params.metadata ?? null,
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  if (newLead) {
+    await db
+      .insert(leadEmails)
+      .values({ leadId: newLead.id, email: params.email })
+      .onConflictDoNothing();
+
+    return { leadId: newLead.id, isNew: true };
+  }
+
+  // Race condition: apolloPersonId was inserted by another request
+  if (params.apolloPersonId) {
+    const racedLead = await db.query.leads.findFirst({
+      where: eq(leads.apolloPersonId, params.apolloPersonId),
+    });
+    if (racedLead) {
+      await db
+        .insert(leadEmails)
+        .values({ leadId: racedLead.id, email: params.email })
+        .onConflictDoNothing();
+      return { leadId: racedLead.id, isNew: false };
+    }
+  }
+
+  throw new Error(
+    `Failed to resolve or create lead for email=${params.email}`
+  );
+}
+
+/**
+ * Find leadId by apolloPersonId.
+ */
+export async function findLeadByApolloPersonId(
+  apolloPersonId: string
+): Promise<string | null> {
+  const lead = await db.query.leads.findFirst({
+    where: eq(leads.apolloPersonId, apolloPersonId),
+  });
+  return lead?.id ?? null;
+}
+
+/**
+ * Find leadId by email.
+ */
+export async function findLeadByEmail(
+  email: string
+): Promise<string | null> {
+  const row = await db.query.leadEmails.findFirst({
+    where: eq(leadEmails.email, email),
+  });
+  return row?.leadId ?? null;
+}

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -43,6 +43,7 @@ router.get("/leads", authenticate, async (req: AuthenticatedRequest, res) => {
     // Extract enrichment from metadata (Apollo data is stored in servedLeads.metadata)
     const enrichedLeads = leads.map((lead) => ({
       ...lead,
+      leadId: lead.leadId ?? null,
       enrichment: extractEnrichment(lead.metadata),
     }));
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -190,6 +190,7 @@ export const BufferNextRequestSchema = z
   .openapi("BufferNextRequest");
 
 const ServedLeadSchema = z.object({
+  leadId: z.string().uuid(),
   email: z.string(),
   externalId: z.string().nullable(),
   data: ApolloPersonDataSchema.nullable(),
@@ -230,6 +231,7 @@ const CursorSetResponseSchema = z
 const LeadDetailSchema = z
   .object({
     id: z.string().uuid(),
+    leadId: z.string().uuid().nullable(),
     organizationId: z.string().uuid(),
     namespace: z.string(),
     email: z.string(),

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,5 +1,5 @@
 import { db, sql } from "../../src/db/index.js";
-import { organizations, servedLeads, leadBuffer, cursors, idempotencyCache } from "../../src/db/schema.js";
+import { organizations, servedLeads, leadBuffer, cursors, idempotencyCache, leadEmails, leads } from "../../src/db/schema.js";
 import { eq } from "drizzle-orm";
 
 export const TEST_API_KEY = "test-api-key-12345";
@@ -28,6 +28,9 @@ export async function cleanupTestData(): Promise<void> {
     await db.delete(cursors).where(eq(cursors.organizationId, testOrgUuid));
     await db.delete(leadBuffer).where(eq(leadBuffer.organizationId, testOrgUuid));
     await db.delete(servedLeads).where(eq(servedLeads.organizationId, testOrgUuid));
+    // Clean up leadEmails and leads (global tables, clean all test-created rows)
+    await sql`DELETE FROM lead_emails WHERE lead_id IN (SELECT id FROM leads)`;
+    await sql`DELETE FROM leads`;
     await db.delete(organizations).where(eq(organizations.id, testOrgUuid));
     testOrgUuid = null;
   }

--- a/tests/unit/dedup.test.ts
+++ b/tests/unit/dedup.test.ts
@@ -3,56 +3,107 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Mock the db module
 vi.mock("../../src/db/index.js", () => ({
   db: {
-    query: {
-      servedLeads: {
-        findFirst: vi.fn(),
-      },
-    },
     insert: vi.fn(),
   },
 }));
 
+// Mock the email-gateway-client module
+vi.mock("../../src/lib/email-gateway-client.js", () => ({
+  checkDeliveryStatus: vi.fn(),
+  isDelivered: vi.fn(),
+}));
+
 import { db } from "../../src/db/index.js";
-import { isServed, markServed } from "../../src/lib/dedup.js";
+import { checkDelivered, markServed } from "../../src/lib/dedup.js";
+import {
+  checkDeliveryStatus,
+  isDelivered,
+} from "../../src/lib/email-gateway-client.js";
 
 describe("dedup", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe("isServed", () => {
-    it("returns true when email already served for org+brand", async () => {
-      vi.mocked(db.query.servedLeads.findFirst).mockResolvedValue({
-        id: "uuid-1",
-        organizationId: "org-1",
-        namespace: "campaign-1",
-        email: "alice@acme.com",
-        externalId: null,
-        metadata: null,
-        parentRunId: null,
-        runId: null,
-        brandId: "brand-1",
-        campaignId: "campaign-1",
-        servedAt: new Date(),
+  describe("checkDelivered", () => {
+    it("returns delivered=true for emails that email-gateway reports as delivered", async () => {
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({
+        results: [
+          { email: "alice@acme.com", lead: null, emailResult: null } as never,
+        ],
       });
+      vi.mocked(isDelivered).mockReturnValue(true);
 
-      const result = await isServed("org-1", "brand-1", "alice@acme.com");
-      expect(result).toBe(true);
+      const result = await checkDelivered("campaign-1", [
+        { email: "alice@acme.com" },
+      ]);
+
+      expect(result.get("alice@acme.com")).toBe(true);
+      expect(checkDeliveryStatus).toHaveBeenCalledWith("campaign-1", [
+        { email: "alice@acme.com" },
+      ]);
     });
 
-    it("returns false when email not served", async () => {
-      vi.mocked(db.query.servedLeads.findFirst).mockResolvedValue(undefined);
+    it("returns delivered=false for emails not yet delivered", async () => {
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({
+        results: [
+          { email: "bob@acme.com", lead: null, emailResult: null } as never,
+        ],
+      });
+      vi.mocked(isDelivered).mockReturnValue(false);
 
-      const result = await isServed("org-1", "brand-1", "alice@acme.com");
-      expect(result).toBe(false);
+      const result = await checkDelivered("campaign-1", [
+        { email: "bob@acme.com" },
+      ]);
+
+      expect(result.get("bob@acme.com")).toBe(false);
     });
 
-    it("scopes by brand — same email in different brand is not served", async () => {
-      vi.mocked(db.query.servedLeads.findFirst).mockResolvedValue(undefined);
+    it("returns all-false when email-gateway is unreachable (null response)", async () => {
+      vi.mocked(checkDeliveryStatus).mockResolvedValue(null);
 
-      const result = await isServed("org-1", "brand-2", "alice@acme.com");
-      expect(result).toBe(false);
-      expect(db.query.servedLeads.findFirst).toHaveBeenCalledOnce();
+      const result = await checkDelivered("campaign-1", [
+        { email: "alice@acme.com" },
+        { email: "bob@acme.com" },
+      ]);
+
+      expect(result.get("alice@acme.com")).toBe(false);
+      expect(result.get("bob@acme.com")).toBe(false);
+    });
+
+    it("handles batch of multiple emails with mixed results", async () => {
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({
+        results: [
+          { email: "alice@acme.com" } as never,
+          { email: "bob@acme.com" } as never,
+        ],
+      });
+      vi.mocked(isDelivered)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+
+      const result = await checkDelivered("campaign-1", [
+        { email: "alice@acme.com" },
+        { email: "bob@acme.com" },
+      ]);
+
+      expect(result.get("alice@acme.com")).toBe(true);
+      expect(result.get("bob@acme.com")).toBe(false);
+    });
+
+    it("passes leadId when provided in items", async () => {
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({
+        results: [{ email: "alice@acme.com" } as never],
+      });
+      vi.mocked(isDelivered).mockReturnValue(false);
+
+      await checkDelivered("campaign-1", [
+        { email: "alice@acme.com", leadId: "lead-uuid-1" },
+      ]);
+
+      expect(checkDeliveryStatus).toHaveBeenCalledWith("campaign-1", [
+        { email: "alice@acme.com", leadId: "lead-uuid-1" },
+      ]);
     });
   });
 
@@ -69,6 +120,7 @@ describe("dedup", () => {
         brandId: "brand-1",
         campaignId: "campaign-1",
         email: "alice@acme.com",
+        leadId: "lead-uuid-1",
         externalId: "enrich-123",
         parentRunId: "run-1",
         runId: "child-run-1",
@@ -92,6 +144,26 @@ describe("dedup", () => {
       });
 
       expect(result).toEqual({ inserted: false });
+    });
+
+    it("passes leadId to the insert when provided", async () => {
+      const returningMock = vi.fn().mockResolvedValue([{ id: "uuid-1" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      await markServed({
+        organizationId: "org-1",
+        namespace: "campaign-1",
+        brandId: "brand-1",
+        campaignId: "campaign-1",
+        email: "alice@acme.com",
+        leadId: "lead-uuid-1",
+      });
+
+      expect(valuesMock).toHaveBeenCalledWith(
+        expect.objectContaining({ leadId: "lead-uuid-1" })
+      );
     });
   });
 });

--- a/tests/unit/email-gateway-client.test.ts
+++ b/tests/unit/email-gateway-client.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  checkDeliveryStatus,
+  isDelivered,
+  type StatusResult,
+  type ProviderStatus,
+} from "../../src/lib/email-gateway-client.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("email-gateway-client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("checkDeliveryStatus", () => {
+    it("returns status results on success", async () => {
+      const responseBody = {
+        results: [
+          {
+            email: "alice@acme.com",
+            broadcast: {
+              campaign: {
+                lead: { contacted: true, delivered: true, replied: false, lastDeliveredAt: "2024-01-01" },
+                email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
+              },
+              global: {
+                lead: { contacted: true, delivered: true, replied: false, lastDeliveredAt: "2024-01-01" },
+                email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
+              },
+            },
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(responseBody),
+      });
+
+      const result = await checkDeliveryStatus("campaign-1", [
+        { email: "alice@acme.com" },
+      ]);
+
+      expect(result).toEqual(responseBody);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/status"),
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            campaignId: "campaign-1",
+            items: [{ email: "alice@acme.com" }],
+          }),
+        })
+      );
+    });
+
+    it("returns null on non-200 response", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("Internal server error"),
+      });
+
+      const result = await checkDeliveryStatus("campaign-1", [
+        { email: "alice@acme.com" },
+      ]);
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null on network error", async () => {
+      mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const result = await checkDeliveryStatus("campaign-1", [
+        { email: "alice@acme.com" },
+      ]);
+
+      expect(result).toBeNull();
+    });
+
+    it("passes leadId when provided", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      });
+
+      await checkDeliveryStatus("campaign-1", [
+        { leadId: "lead-123", email: "alice@acme.com" },
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: JSON.stringify({
+            campaignId: "campaign-1",
+            items: [{ leadId: "lead-123", email: "alice@acme.com" }],
+          }),
+        })
+      );
+    });
+  });
+
+  describe("isDelivered", () => {
+    const emptyScope: ProviderStatus = {
+      campaign: {
+        lead: { contacted: false, delivered: false, replied: false, lastDeliveredAt: null },
+        email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+      },
+      global: {
+        lead: { contacted: false, delivered: false, replied: false, lastDeliveredAt: null },
+        email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+      },
+    };
+
+    it("returns false when nothing is contacted", () => {
+      const result: StatusResult = {
+        email: "alice@acme.com",
+        broadcast: emptyScope,
+        transactional: emptyScope,
+      };
+      expect(isDelivered(result)).toBe(false);
+    });
+
+    it("returns false when no providers present", () => {
+      const result: StatusResult = { email: "alice@acme.com" };
+      expect(isDelivered(result)).toBe(false);
+    });
+
+    it("returns true when broadcast campaign lead is contacted", () => {
+      const result: StatusResult = {
+        email: "alice@acme.com",
+        broadcast: {
+          ...emptyScope,
+          campaign: {
+            ...emptyScope.campaign,
+            lead: { contacted: true, delivered: true, replied: false, lastDeliveredAt: "2024-01-01" },
+          },
+        },
+      };
+      expect(isDelivered(result)).toBe(true);
+    });
+
+    it("returns true when transactional global email is contacted", () => {
+      const result: StatusResult = {
+        email: "alice@acme.com",
+        transactional: {
+          ...emptyScope,
+          global: {
+            ...emptyScope.global,
+            email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
+          },
+        },
+      };
+      expect(isDelivered(result)).toBe(true);
+    });
+  });
+});

--- a/tests/unit/leads-registry.test.ts
+++ b/tests/unit/leads-registry.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    query: {
+      leads: { findFirst: vi.fn() },
+      leadEmails: { findFirst: vi.fn() },
+    },
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+import { db } from "../../src/db/index.js";
+import {
+  resolveOrCreateLead,
+  findLeadByApolloPersonId,
+  findLeadByEmail,
+} from "../../src/lib/leads-registry.js";
+
+describe("leads-registry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("resolveOrCreateLead", () => {
+    it("finds existing lead by apolloPersonId and links email", async () => {
+      vi.mocked(db.query.leads.findFirst).mockResolvedValue({
+        id: "lead-1",
+        apolloPersonId: "apollo-1",
+        metadata: null,
+        createdAt: new Date(),
+      });
+
+      const onConflictMock = vi.fn().mockResolvedValue(undefined);
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const result = await resolveOrCreateLead({
+        apolloPersonId: "apollo-1",
+        email: "alice@acme.com",
+      });
+
+      expect(result).toEqual({ leadId: "lead-1", isNew: false });
+      // Should insert email link
+      expect(db.insert).toHaveBeenCalled();
+    });
+
+    it("finds existing lead by email when apolloPersonId not found", async () => {
+      // No lead by apolloPersonId
+      vi.mocked(db.query.leads.findFirst).mockResolvedValue(undefined);
+      // Found by email
+      vi.mocked(db.query.leadEmails.findFirst).mockResolvedValue({
+        id: "le-1",
+        leadId: "lead-2",
+        email: "bob@acme.com",
+        createdAt: new Date(),
+      });
+
+      // Update lead with apolloPersonId
+      const whereMock = vi.fn().mockResolvedValue(undefined);
+      const setMock = vi.fn().mockReturnValue({ where: whereMock });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      const result = await resolveOrCreateLead({
+        apolloPersonId: "apollo-2",
+        email: "bob@acme.com",
+      });
+
+      expect(result).toEqual({ leadId: "lead-2", isNew: false });
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it("creates new lead when neither apolloPersonId nor email found", async () => {
+      vi.mocked(db.query.leads.findFirst).mockResolvedValue(undefined);
+      vi.mocked(db.query.leadEmails.findFirst).mockResolvedValue(undefined);
+
+      // Insert lead
+      const returningMock = vi.fn().mockResolvedValue([{ id: "lead-new", apolloPersonId: "apollo-3", metadata: null, createdAt: new Date() }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const result = await resolveOrCreateLead({
+        apolloPersonId: "apollo-3",
+        email: "charlie@acme.com",
+        metadata: { firstName: "Charlie" },
+      });
+
+      expect(result).toEqual({ leadId: "lead-new", isNew: true });
+      // Should insert both lead and email
+      expect(db.insert).toHaveBeenCalledTimes(2);
+    });
+
+    it("handles race condition on apolloPersonId conflict", async () => {
+      vi.mocked(db.query.leads.findFirst)
+        .mockResolvedValueOnce(undefined) // First check: not found
+        .mockResolvedValueOnce({ id: "lead-raced", apolloPersonId: "apollo-4", metadata: null, createdAt: new Date() }); // Race recovery
+      vi.mocked(db.query.leadEmails.findFirst).mockResolvedValue(undefined);
+
+      // Insert returns empty (conflict)
+      const returningMock = vi.fn().mockResolvedValue([]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const result = await resolveOrCreateLead({
+        apolloPersonId: "apollo-4",
+        email: "race@acme.com",
+      });
+
+      expect(result).toEqual({ leadId: "lead-raced", isNew: false });
+    });
+  });
+
+  describe("findLeadByApolloPersonId", () => {
+    it("returns leadId when found", async () => {
+      vi.mocked(db.query.leads.findFirst).mockResolvedValue({
+        id: "lead-1",
+        apolloPersonId: "apollo-1",
+        metadata: null,
+        createdAt: new Date(),
+      });
+
+      const result = await findLeadByApolloPersonId("apollo-1");
+      expect(result).toBe("lead-1");
+    });
+
+    it("returns null when not found", async () => {
+      vi.mocked(db.query.leads.findFirst).mockResolvedValue(undefined);
+
+      const result = await findLeadByApolloPersonId("nonexistent");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("findLeadByEmail", () => {
+    it("returns leadId when found", async () => {
+      vi.mocked(db.query.leadEmails.findFirst).mockResolvedValue({
+        id: "le-1",
+        leadId: "lead-1",
+        email: "alice@acme.com",
+        createdAt: new Date(),
+      });
+
+      const result = await findLeadByEmail("alice@acme.com");
+      expect(result).toBe("lead-1");
+    });
+
+    it("returns null when not found", async () => {
+      vi.mocked(db.query.leadEmails.findFirst).mockResolvedValue(undefined);
+
+      const result = await findLeadByEmail("nonexistent@acme.com");
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Lead identity registry**: Added global `leads` + `leadEmails` tables (no org/brand/campaign scoping) to track real-world people across the system. Each lead gets a stable `leadId` linked to `apolloPersonId` and their email(s).
- **Dedup via email-gateway**: Replaced local `isServed()` (which checked if a lead was *pulled*, not *delivered*) with `checkDelivered()` that calls the email-gateway `POST /status` endpoint to check actual delivery status. Falls back to "not delivered" if email-gateway is unreachable (downstream `/send` has its own idempotency).
- **`leadId` in responses**: `POST /buffer/next` and `GET /leads` now return `leadId` so downstream services (content-generation, email-gateway) can track it.
- `servedLeads` table stays as an audit log but no longer drives dedup decisions.

## Test plan
- [x] Unit tests: 56 passing (email-gateway-client, leads-registry, dedup, buffer, leads, schemas)
- [x] TypeScript build compiles cleanly
- [x] OpenAPI spec regenerated with `leadId` fields
- [ ] Integration tests pass in CI (require `LEAD_SERVICE_DATABASE_URL`)
- [ ] Deploy and verify `POST /buffer/next` returns `leadId`
- [ ] Verify `GET /leads` returns `leadId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)