### PR TITLE
Make email required in email-gateway contract

### DIFF
--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -23,14 +23,14 @@ export async function checkDelivered(
 
   if (statusResponse) {
     for (const sr of statusResponse.results) {
-      if (sr.email) result.set(sr.email, isDelivered(sr));
+      result.set(sr.email, isDelivered(sr));
     }
   } else {
     console.warn(
       "[dedup] email-gateway unreachable, proceeding without delivery check"
     );
     for (const item of items) {
-      if (item.email) result.set(item.email, false);
+      result.set(item.email, false);
     }
   }
 

--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -5,7 +5,7 @@ const EMAIL_GATEWAY_SERVICE_API_KEY =
 
 export interface DeliveryStatusItem {
   leadId: string;
-  email?: string;
+  email: string;
 }
 
 export interface LeadDeliveryStatus {
@@ -40,7 +40,7 @@ export interface ProviderStatus {
 
 export interface StatusResult {
   leadId: string;
-  email?: string;
+  email: string;
   broadcast?: ProviderStatus;
   transactional?: ProviderStatus;
 }


### PR DESCRIPTION
## Summary
- Makes `email` required (not optional) in `DeliveryStatusItem` and `StatusResult` interfaces to match Email Gateway Service's real `POST /status` contract (validated with `.email()`)
- Removes unnecessary `if (sr.email)` / `if (item.email)` guards in `dedup.ts` since email is now guaranteed present

## Context
Email Gateway Service confirmed that `email` is required in their v3 contract — sending an item without email returns a 400. Our types previously had `email?: string` which was incorrect.

## Test plan
- [x] `npm run build` passes
- [x] All 49 unit tests pass
- [x] All 18 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)