### PR TITLE
Fix integration test FK cleanup order

### DIFF
--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -41,7 +41,8 @@ export async function cleanupTestData(): Promise<void> {
     await db.delete(cursors).where(eq(cursors.organizationId, testOrgUuid));
     await db.delete(leadBuffer).where(eq(leadBuffer.organizationId, testOrgUuid));
     await db.delete(servedLeads).where(eq(servedLeads.organizationId, testOrgUuid));
-    // Clean up leadEmails and leads (global tables, clean all test-created rows)
+    // Clean up global tables in FK-safe order: served_leads → lead_emails → leads
+    await sql`DELETE FROM served_leads WHERE lead_id IN (SELECT id FROM leads)`;
     await sql`DELETE FROM lead_emails WHERE lead_id IN (SELECT id FROM leads)`;
     await sql`DELETE FROM leads`;
     await db.delete(organizations).where(eq(organizations.id, testOrgUuid));


### PR DESCRIPTION
## Summary
- `cleanupTestData()` now deletes stale `served_leads` referencing `leads` rows before deleting `leads`
- Previous order caused FK violation when stale data from crashed CI runs existed across org boundaries

## Test plan
- [x] Unit tests pass (59/59)
- [x] Fix verified against the FK error from CI run #22350390593

🤖 Generated with [Claude Code](https://claude.com/claude-code)