### PR TITLE
Rename clerkOrgId/clerkUserId to orgId/userId

### DIFF
--- a/drizzle/0007_rename_clerk_to_org_user.sql
+++ b/drizzle/0007_rename_clerk_to_org_user.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "lead_buffer" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "lead_buffer" RENAME COLUMN "clerk_user_id" TO "user_id";--> statement-breakpoint
+ALTER TABLE "served_leads" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "served_leads" RENAME COLUMN "clerk_user_id" TO "user_id";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_served_clerk_org";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_served_clerk_user";--> statement-breakpoint
+CREATE INDEX "idx_served_org_id" ON "served_leads" USING btree ("org_id");--> statement-breakpoint
+CREATE INDEX "idx_served_user_id" ON "served_leads" USING btree ("user_id");

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,945 @@
+{
+  "id": "b7c4e2a1-9f3d-4a5b-8c6e-1d2f3a4b5c6d",
+  "prevId": "8a16f3f3-df34-4657-955c-0d167a183245",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.cursors": {
+      "name": "cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cursors_org_ns": {
+          "name": "idx_cursors_org_ns",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cursors_organization_id_organizations_id_fk": {
+          "name": "cursors_organization_id_organizations_id_fk",
+          "tableFrom": "cursors",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichments": {
+      "name": "enrichments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apollo_person_id": {
+          "name": "apollo_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_url": {
+          "name": "linkedin_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_name": {
+          "name": "organization_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_domain": {
+          "name": "organization_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_industry": {
+          "name": "organization_industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_size": {
+          "name": "organization_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_raw": {
+          "name": "response_raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enriched_at": {
+          "name": "enriched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_enrichments_email": {
+          "name": "idx_enrichments_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_enrichments_apollo_person_id": {
+          "name": "idx_enrichments_apollo_person_id",
+          "columns": [
+            {
+              "expression": "apollo_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_cache": {
+      "name": "idempotency_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_idempotency_key": {
+          "name": "idx_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_cache_organization_id_organizations_id_fk": {
+          "name": "idempotency_cache_organization_id_organizations_id_fk",
+          "tableFrom": "idempotency_cache",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_buffer": {
+      "name": "lead_buffer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'buffered'"
+        },
+        "push_run_id": {
+          "name": "push_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_buffer_org_ns_status": {
+          "name": "idx_buffer_org_ns_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_buffer_organization_id_organizations_id_fk": {
+          "name": "lead_buffer_organization_id_organizations_id_fk",
+          "tableFrom": "lead_buffer",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_emails": {
+      "name": "lead_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_lead_emails_lead_email": {
+          "name": "idx_lead_emails_lead_email",
+          "columns": [
+            {
+              "expression": "lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_lead_emails_email": {
+          "name": "idx_lead_emails_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lead_emails_lead_id_leads_id_fk": {
+          "name": "lead_emails_lead_id_leads_id_fk",
+          "tableFrom": "lead_emails",
+          "tableTo": "leads",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leads": {
+      "name": "leads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "apollo_person_id": {
+          "name": "apollo_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_leads_apollo_person_id": {
+          "name": "idx_leads_apollo_person_id",
+          "columns": [
+            {
+              "expression": "apollo_person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orgs_app_external": {
+          "name": "idx_orgs_app_external",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.served_leads": {
+      "name": "served_leads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_id": {
+          "name": "lead_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_run_id": {
+          "name": "parent_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "served_at": {
+          "name": "served_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_served_org_brand_email": {
+          "name": "idx_served_org_brand_email",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_served_org": {
+          "name": "idx_served_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_served_brand": {
+          "name": "idx_served_brand",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_served_campaign": {
+          "name": "idx_served_campaign",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_served_org_id": {
+          "name": "idx_served_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_served_user_id": {
+          "name": "idx_served_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "served_leads_organization_id_organizations_id_fk": {
+          "name": "served_leads_organization_id_organizations_id_fk",
+          "tableFrom": "served_leads",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "served_leads_lead_id_leads_id_fk": {
+          "name": "served_leads_lead_id_leads_id_fk",
+          "tableFrom": "served_leads",
+          "tableTo": "leads",
+          "columnsFrom": [
+            "lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_org_external": {
+          "name": "idx_users_org_external",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_organization_id_organizations_id_fk": {
+          "name": "users_organization_id_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1771914700973,
       "tag": "0006_loose_phil_sheldon",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1772064000000,
+      "tag": "0007_rename_clerk_to_org_user",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -58,11 +58,11 @@
               "brandId": {
                 "type": "string"
               },
-              "clerkOrgId": {
+              "orgId": {
                 "type": "string",
                 "nullable": true
               },
-              "clerkUserId": {
+              "userId": {
                 "type": "string",
                 "nullable": true
               }
@@ -73,8 +73,8 @@
               "externalId",
               "data",
               "brandId",
-              "clerkOrgId",
-              "clerkUserId"
+              "orgId",
+              "userId"
             ]
           }
         },
@@ -463,7 +463,7 @@
               "nullable": true
             }
           },
-          "clerkUserId": {
+          "userId": {
             "type": "string"
           },
           "workflowName": {
@@ -565,11 +565,11 @@
           "campaignId": {
             "type": "string"
           },
-          "clerkOrgId": {
+          "orgId": {
             "type": "string",
             "nullable": true
           },
-          "clerkUserId": {
+          "userId": {
             "type": "string",
             "nullable": true
           },
@@ -592,8 +592,8 @@
           "runId",
           "brandId",
           "campaignId",
-          "clerkOrgId",
-          "clerkUserId",
+          "orgId",
+          "userId",
           "servedAt",
           "enrichment"
         ]
@@ -699,7 +699,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID, e.g. Clerk org ID"
+            "description": "External organization ID"
           }
         ],
         "requestBody": {
@@ -767,7 +767,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID, e.g. Clerk org ID"
+            "description": "External organization ID"
           },
           {
             "schema": {
@@ -822,7 +822,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID, e.g. Clerk org ID"
+            "description": "External organization ID"
           },
           {
             "schema": {
@@ -898,7 +898,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID, e.g. Clerk org ID"
+            "description": "External organization ID"
           },
           {
             "in": "query",
@@ -918,7 +918,7 @@
           },
           {
             "in": "query",
-            "name": "clerkOrgId",
+            "name": "orgId",
             "required": false,
             "schema": {
               "type": "string"
@@ -926,7 +926,7 @@
           },
           {
             "in": "query",
-            "name": "clerkUserId",
+            "name": "userId",
             "required": false,
             "schema": {
               "type": "string"
@@ -980,7 +980,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID, e.g. Clerk org ID"
+            "description": "External organization ID"
           },
           {
             "in": "query",
@@ -1000,7 +1000,7 @@
           },
           {
             "in": "query",
-            "name": "clerkOrgId",
+            "name": "orgId",
             "required": false,
             "schema": {
               "type": "string"
@@ -1008,7 +1008,7 @@
           },
           {
             "in": "query",
-            "name": "clerkUserId",
+            "name": "userId",
             "required": false,
             "schema": {
               "type": "string"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,6 +1,6 @@
 import { pgTable, uuid, text, timestamp, uniqueIndex, index, jsonb } from "drizzle-orm/pg-core";
 
-// Organizations — maps external org IDs (e.g., Clerk) to internal UUIDs
+// Organizations — maps external org IDs to internal UUIDs
 export const organizations = pgTable(
   "organizations",
   {
@@ -78,8 +78,8 @@ export const servedLeads = pgTable(
     runId: text("run_id"),
     brandId: text("brand_id").notNull(),
     campaignId: text("campaign_id").notNull(),
-    clerkOrgId: text("clerk_org_id"),
-    clerkUserId: text("clerk_user_id"),
+    orgId: text("org_id"),
+    userId: text("user_id"),
     servedAt: timestamp("served_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
@@ -87,8 +87,8 @@ export const servedLeads = pgTable(
     index("idx_served_org").on(table.organizationId),
     index("idx_served_brand").on(table.brandId),
     index("idx_served_campaign").on(table.campaignId),
-    index("idx_served_clerk_org").on(table.clerkOrgId),
-    index("idx_served_clerk_user").on(table.clerkUserId),
+    index("idx_served_org_id").on(table.orgId),
+    index("idx_served_user_id").on(table.userId),
   ]
 );
 
@@ -108,8 +108,8 @@ export const leadBuffer = pgTable(
     status: text("status").notNull().default("buffered"),
     pushRunId: text("push_run_id"),
     brandId: text("brand_id"),
-    clerkOrgId: text("clerk_org_id"),
-    clerkUserId: text("clerk_user_id"),
+    orgId: text("org_id"),
+    userId: text("user_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -139,11 +139,11 @@ interface ApolloSearchRawResponse {
 export async function apolloSearch(
   params: ApolloSearchParams,
   page: number = 1,
-  options?: { runId?: string | null; clerkOrgId?: string | null; appId?: string; brandId?: string; campaignId?: string; workflowName?: string }
+  options?: { runId?: string | null; orgId?: string | null; appId?: string; brandId?: string; campaignId?: string; workflowName?: string }
 ): Promise<ApolloSearchResult | null> {
   try {
     const headers: Record<string, string> = {};
-    if (options?.clerkOrgId) headers["x-clerk-org-id"] = options.clerkOrgId;
+    if (options?.orgId) headers["x-clerk-org-id"] = options.orgId;
 
     const raw = await callApolloService<ApolloSearchRawResponse>("/search", {
       method: "POST",
@@ -188,12 +188,12 @@ export async function apolloSearchNext(options: {
   appId: string;
   searchParams?: ApolloSearchParams;
   runId?: string | null;
-  clerkOrgId?: string | null;
+  orgId?: string | null;
   workflowName?: string;
 }): Promise<ApolloSearchNextResult | null> {
   try {
     const headers: Record<string, string> = {};
-    if (options.clerkOrgId) headers["x-clerk-org-id"] = options.clerkOrgId;
+    if (options.orgId) headers["x-clerk-org-id"] = options.orgId;
 
     const body: Record<string, unknown> = {
       campaignId: options.campaignId,
@@ -230,11 +230,11 @@ export async function apolloSearchParams(options: {
   appId: string;
   brandId: string;
   campaignId: string;
-  clerkOrgId?: string | null;
+  orgId?: string | null;
   workflowName?: string;
 }): Promise<ApolloSearchParamsResult> {
   const headers: Record<string, string> = {};
-  if (options.clerkOrgId) headers["x-clerk-org-id"] = options.clerkOrgId;
+  if (options.orgId) headers["x-clerk-org-id"] = options.orgId;
 
   return callApolloService<ApolloSearchParamsResult>("/search/params", {
     method: "POST",
@@ -262,11 +262,11 @@ export interface ApolloStats {
 
 export async function fetchApolloStats(
   filters: { runIds?: string[]; appId?: string; brandId?: string; campaignId?: string },
-  clerkOrgId?: string | null
+  orgId?: string | null
 ): Promise<ApolloStats> {
   try {
     const headers: Record<string, string> = {};
-    if (clerkOrgId) headers["x-clerk-org-id"] = clerkOrgId;
+    if (orgId) headers["x-clerk-org-id"] = orgId;
 
     const result = await callApolloService<{ stats: ApolloStats }>("/stats", {
       method: "POST",
@@ -289,11 +289,11 @@ export interface ApolloEnrichResult {
 
 export async function apolloEnrich(
   personId: string,
-  options?: { runId?: string | null; clerkOrgId?: string | null; appId?: string; brandId?: string; campaignId?: string; workflowName?: string }
+  options?: { runId?: string | null; orgId?: string | null; appId?: string; brandId?: string; campaignId?: string; workflowName?: string }
 ): Promise<ApolloEnrichResult | null> {
   try {
     const headers: Record<string, string> = {};
-    if (options?.clerkOrgId) headers["x-clerk-org-id"] = options.clerkOrgId;
+    if (options?.orgId) headers["x-clerk-org-id"] = options.orgId;
 
     const result = await callApolloService<ApolloEnrichResult>("/enrich", {
       method: "POST",

--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -14,17 +14,18 @@ export interface BrandDetails {
 
 export async function fetchBrand(
   brandId: string,
-  clerkOrgId?: string | null
+  orgId?: string | null
 ): Promise<BrandDetails | null> {
   try {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       "X-API-Key": BRAND_SERVICE_API_KEY,
     };
-    if (clerkOrgId) headers["x-clerk-org-id"] = clerkOrgId;
+    // TODO: rename header + query param when brand-service is migrated
+    if (orgId) headers["x-clerk-org-id"] = orgId;
 
     const url = new URL(`${BRAND_SERVICE_URL}/brands/${brandId}`);
-    if (clerkOrgId) url.searchParams.set("clerkOrgId", clerkOrgId);
+    if (orgId) url.searchParams.set("clerkOrgId", orgId);
 
     const response = await fetch(url.toString(), { headers });
 

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -27,15 +27,15 @@ async function fillBufferFromSearch(params: {
   searchParams: ApolloSearchParams;
   keySource: "byok" | "app";
   pushRunId?: string | null;
-  clerkOrgId?: string | null;
-  clerkUserId?: string | null;
+  orgId?: string | null;
+  userId?: string | null;
   appId?: string;
   workflowName?: string;
 }): Promise<{ filled: number }> {
   // Fetch campaign + brand details in parallel for rich LLM context
   const [campaign, brand] = await Promise.all([
-    fetchCampaign(params.campaignId, params.clerkOrgId),
-    fetchBrand(params.brandId, params.clerkOrgId),
+    fetchCampaign(params.campaignId, params.orgId),
+    fetchBrand(params.brandId, params.orgId),
   ]);
 
   // Build rich context string from campaign, brand, and raw searchParams
@@ -67,7 +67,7 @@ async function fillBufferFromSearch(params: {
     appId: params.appId ?? "",
     brandId: params.brandId,
     campaignId: params.campaignId,
-    clerkOrgId: params.clerkOrgId,
+    orgId: params.orgId,
     workflowName: params.workflowName,
   });
 
@@ -81,7 +81,7 @@ async function fillBufferFromSearch(params: {
       appId: params.appId ?? "",
       searchParams: validatedParams,
       runId: params.pushRunId,
-      clerkOrgId: params.clerkOrgId,
+      orgId: params.orgId,
       workflowName: params.workflowName,
     });
 
@@ -166,8 +166,8 @@ async function fillBufferFromSearch(params: {
         status: "buffered",
         pushRunId: params.pushRunId ?? null,
         brandId: params.brandId,
-        clerkOrgId: params.clerkOrgId ?? null,
-        clerkUserId: params.clerkUserId ?? null,
+        orgId: params.orgId ?? null,
+        userId: params.userId ?? null,
       });
       pageFilled++;
     }
@@ -200,8 +200,8 @@ export async function pullNext(params: {
   runId?: string | null;
   keySource?: "byok" | "app";
   searchParams?: ApolloSearchParams;
-  clerkOrgId?: string | null;
-  clerkUserId?: string | null;
+  orgId?: string | null;
+  userId?: string | null;
   appId?: string;
   workflowName?: string;
 }): Promise<{
@@ -212,8 +212,8 @@ export async function pullNext(params: {
     externalId: string | null;
     data: unknown;
     brandId: string;
-    clerkOrgId: string | null;
-    clerkUserId: string | null;
+    orgId: string | null;
+    userId: string | null;
   };
 }> {
   const MAX_ITERATIONS = 100;
@@ -244,8 +244,8 @@ export async function pullNext(params: {
           searchParams: params.searchParams,
           keySource: params.keySource,
           pushRunId: params.runId,
-          clerkOrgId: params.clerkOrgId,
-          clerkUserId: params.clerkUserId,
+          orgId: params.orgId,
+          userId: params.userId,
           appId: params.appId,
           workflowName: params.workflowName,
         });
@@ -285,7 +285,7 @@ export async function pullNext(params: {
       } else {
         const enrichResult = await apolloEnrich(row.externalId, {
           runId: params.runId,
-          clerkOrgId: params.clerkOrgId,
+          orgId: params.orgId,
           appId: params.appId,
           brandId: params.brandId,
           campaignId: params.campaignId,
@@ -382,8 +382,8 @@ export async function pullNext(params: {
       metadata: enrichedData,
       parentRunId: params.parentRunId ?? null,
       runId: params.runId ?? null,
-      clerkOrgId: row.clerkOrgId,
-      clerkUserId: row.clerkUserId,
+      orgId: row.orgId,
+      userId: row.userId,
     });
 
     await db
@@ -407,8 +407,8 @@ export async function pullNext(params: {
         externalId: row.externalId,
         data: finalData,
         brandId: params.brandId,
-        clerkOrgId: row.clerkOrgId,
-        clerkUserId: row.clerkUserId,
+        orgId: row.orgId,
+        userId: row.userId,
       },
     };
   }

--- a/src/lib/campaign-client.ts
+++ b/src/lib/campaign-client.ts
@@ -11,14 +11,15 @@ export interface CampaignDetails {
 
 export async function fetchCampaign(
   campaignId: string,
-  clerkOrgId?: string | null
+  orgId?: string | null
 ): Promise<CampaignDetails | null> {
   try {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       "X-API-Key": CAMPAIGN_SERVICE_API_KEY,
     };
-    if (clerkOrgId) headers["x-clerk-org-id"] = clerkOrgId;
+    // TODO: rename header when campaign-service is migrated
+    if (orgId) headers["x-clerk-org-id"] = orgId;
 
     const response = await fetch(`${CAMPAIGN_SERVICE_URL}/campaigns/${campaignId}`, {
       headers,

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -52,8 +52,8 @@ export async function markServed(params: {
   metadata?: unknown;
   parentRunId?: string | null;
   runId?: string | null;
-  clerkOrgId?: string | null;
-  clerkUserId?: string | null;
+  orgId?: string | null;
+  userId?: string | null;
 }): Promise<{ inserted: boolean }> {
   const result = await db
     .insert(servedLeads)
@@ -68,8 +68,8 @@ export async function markServed(params: {
       runId: params.runId ?? null,
       brandId: params.brandId,
       campaignId: params.campaignId,
-      clerkOrgId: params.clerkOrgId ?? null,
-      clerkUserId: params.clerkUserId ?? null,
+      orgId: params.orgId ?? null,
+      userId: params.userId ?? null,
     })
     .onConflictDoNothing()
     .returning();

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -25,19 +25,30 @@ async function callRunsService(path: string, options: {
 }
 
 export async function createRun(params: {
-  clerkOrgId: string;
+  orgId: string;
   appId: string;
   serviceName: string;
   taskName: string;
   parentRunId?: string;
-  clerkUserId?: string;
+  userId?: string;
   brandId?: string;
   campaignId?: string;
   workflowName?: string;
 }): Promise<{ id: string }> {
+  // TODO: rename body fields when runs-service is migrated
   return callRunsService("/runs", {
     method: "POST",
-    body: params,
+    body: {
+      clerkOrgId: params.orgId,
+      appId: params.appId,
+      serviceName: params.serviceName,
+      taskName: params.taskName,
+      parentRunId: params.parentRunId,
+      clerkUserId: params.userId,
+      brandId: params.brandId,
+      campaignId: params.campaignId,
+      workflowName: params.workflowName,
+    },
   }) as Promise<{ id: string }>;
 }
 

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -32,8 +32,8 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
   }
 
   try {
-    const { campaignId, brandId, parentRunId, keySource, searchParams, clerkUserId, workflowName, idempotencyKey } = parsed.data;
-    const clerkOrgId = req.externalOrgId ?? null;
+    const { campaignId, brandId, parentRunId, keySource, searchParams, userId, workflowName, idempotencyKey } = parsed.data;
+    const orgId = req.externalOrgId ?? null;
 
     // Idempotency: return cached response if this key was already processed
     if (idempotencyKey) {
@@ -48,12 +48,12 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
 
     // Create child run for traceability
     const childRun = await createRun({
-      clerkOrgId: req.externalOrgId!,
+      orgId: req.externalOrgId!,
       appId: req.appId || "mcpfactory",
       serviceName: "lead-service",
       taskName: "lead-serve",
       parentRunId,
-      clerkUserId,
+      userId,
       brandId,
       campaignId,
       workflowName,
@@ -68,8 +68,8 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       runId: serveRunId,
       keySource,
       searchParams: searchParams ?? undefined,
-      clerkOrgId,
-      clerkUserId: clerkUserId ?? null,
+      orgId,
+      userId: userId ?? null,
       appId: req.appId,
       workflowName,
     });

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -17,7 +17,7 @@ export function extractEnrichment(metadata: unknown): Record<string, unknown> | 
 
 router.get("/leads", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
-    const { brandId, campaignId, clerkOrgId, clerkUserId } = req.query;
+    const { brandId, campaignId, orgId, userId } = req.query;
 
     // Build filter conditions
     const conditions: SQL[] = [eq(servedLeads.organizationId, req.organizationId!)];
@@ -28,11 +28,11 @@ router.get("/leads", authenticate, async (req: AuthenticatedRequest, res) => {
     if (campaignId && typeof campaignId === "string") {
       conditions.push(eq(servedLeads.campaignId, campaignId));
     }
-    if (clerkOrgId && typeof clerkOrgId === "string") {
-      conditions.push(eq(servedLeads.clerkOrgId, clerkOrgId));
+    if (orgId && typeof orgId === "string") {
+      conditions.push(eq(servedLeads.orgId, orgId));
     }
-    if (clerkUserId && typeof clerkUserId === "string") {
-      conditions.push(eq(servedLeads.clerkUserId, clerkUserId));
+    if (userId && typeof userId === "string") {
+      conditions.push(eq(servedLeads.userId, userId));
     }
 
     // Get served leads

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -9,12 +9,12 @@ const router = Router();
 
 router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
-    const { brandId, campaignId, clerkOrgId, clerkUserId, appId, runIds } = req.query;
+    const { brandId, campaignId, orgId, userId, appId, runIds } = req.query;
     const str = (v: unknown): string | undefined => typeof v === "string" ? v : undefined;
     const brandIdStr = str(brandId);
     const campaignIdStr = str(campaignId);
-    const clerkOrgIdStr = str(clerkOrgId);
-    const clerkUserIdStr = str(clerkUserId);
+    const orgIdStr = str(orgId);
+    const userIdStr = str(userId);
     const appIdStr = str(appId);
     const runIdList = typeof runIds === "string" ? runIds.split(",").filter(Boolean) : [];
 
@@ -29,13 +29,13 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
       servedConditions.push(eq(servedLeads.campaignId, campaignIdStr));
       bufferConditions.push(eq(leadBuffer.campaignId, campaignIdStr));
     }
-    if (clerkOrgIdStr) {
-      servedConditions.push(eq(servedLeads.clerkOrgId, clerkOrgIdStr));
-      bufferConditions.push(eq(leadBuffer.clerkOrgId, clerkOrgIdStr));
+    if (orgIdStr) {
+      servedConditions.push(eq(servedLeads.orgId, orgIdStr));
+      bufferConditions.push(eq(leadBuffer.orgId, orgIdStr));
     }
-    if (clerkUserIdStr) {
-      servedConditions.push(eq(servedLeads.clerkUserId, clerkUserIdStr));
-      bufferConditions.push(eq(leadBuffer.clerkUserId, clerkUserIdStr));
+    if (userIdStr) {
+      servedConditions.push(eq(servedLeads.userId, userIdStr));
+      bufferConditions.push(eq(leadBuffer.userId, userIdStr));
     }
     if (appIdStr) {
       const orgs = await db.query.organizations.findMany({
@@ -69,7 +69,7 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
     const [servedResult, bufferRows, apollo] = await Promise.all([
       db.select({ count: count() }).from(servedLeads).where(and(...servedConditions)).then(([r]) => r),
       db.select({ status: leadBuffer.status, count: count() }).from(leadBuffer).where(and(...bufferConditions)).groupBy(leadBuffer.status),
-      fetchApolloStats(apolloFilters as Parameters<typeof fetchApolloStats>[0], clerkOrgIdStr ?? req.externalOrgId),
+      fetchApolloStats(apolloFilters as Parameters<typeof fetchApolloStats>[0], orgIdStr ?? req.externalOrgId),
     ]);
 
     const bufferByStatus = Object.fromEntries(bufferRows.map((r) => [r.status, r.count]));

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -34,7 +34,7 @@ const AuthHeaders = [
     name: "x-org-id",
     required: true,
     schema: { type: "string" as const },
-    description: "External organization ID, e.g. Clerk org ID",
+    description: "External organization ID",
   },
 ];
 
@@ -157,7 +157,7 @@ export const BufferNextRequestSchema = z
       description: "How downstream services resolve API keys: 'byok' = use the org's own keys via key-service, 'app' = use platform keys.",
     }),
     searchParams: z.record(z.string(), z.unknown()).optional(),
-    clerkUserId: z.string().optional(),
+    userId: z.string().optional(),
     workflowName: z.string().optional(),
     idempotencyKey: z.string().min(1).optional(),
   })
@@ -169,8 +169,8 @@ const ServedLeadSchema = z.object({
   externalId: z.string().nullable(),
   data: ApolloPersonDataSchema.nullable(),
   brandId: z.string(),
-  clerkOrgId: z.string().nullable(),
-  clerkUserId: z.string().nullable(),
+  orgId: z.string().nullable(),
+  userId: z.string().nullable(),
 });
 
 const BufferNextResponseSchema = z
@@ -215,8 +215,8 @@ const LeadDetailSchema = z
     runId: z.string().nullable(),
     brandId: z.string(),
     campaignId: z.string(),
-    clerkOrgId: z.string().nullable(),
-    clerkUserId: z.string().nullable(),
+    orgId: z.string().nullable(),
+    userId: z.string().nullable(),
     servedAt: z.string(),
     enrichment: ApolloPersonDataSchema.nullable(),
   })
@@ -345,13 +345,13 @@ registry.registerPath({
     },
     {
       in: "query" as const,
-      name: "clerkOrgId",
+      name: "orgId",
       required: false,
       schema: { type: "string" as const },
     },
     {
       in: "query" as const,
-      name: "clerkUserId",
+      name: "userId",
       required: false,
       schema: { type: "string" as const },
     },
@@ -387,13 +387,13 @@ registry.registerPath({
     },
     {
       in: "query" as const,
-      name: "clerkOrgId",
+      name: "orgId",
       required: false,
       schema: { type: "string" as const },
     },
     {
       in: "query" as const,
-      name: "clerkUserId",
+      name: "userId",
       required: false,
       schema: { type: "string" as const },
     },

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -80,8 +80,8 @@ export async function seedBuffer(params: {
       status: "buffered",
       pushRunId: null,
       brandId: params.brandId,
-      clerkOrgId: TEST_ORG_ID,
-      clerkUserId: null,
+      orgId: TEST_ORG_ID,
+      userId: null,
     });
   }
 }

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -85,8 +85,8 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        clerkOrgId: null,
-        clerkUserId: null,
+        orgId: null,
+        userId: null,
         createdAt: new Date(),
       });
 
@@ -141,8 +141,8 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        clerkOrgId: null,
-        clerkUserId: null,
+        orgId: null,
+        userId: null,
         createdAt: new Date(),
       });
 
@@ -182,8 +182,8 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          clerkOrgId: null,
-          clerkUserId: null,
+          orgId: null,
+          userId: null,
           createdAt: new Date(),
         })
         .mockResolvedValueOnce({
@@ -197,8 +197,8 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          clerkOrgId: null,
-          clerkUserId: null,
+          orgId: null,
+          userId: null,
           createdAt: new Date(),
         });
 
@@ -260,8 +260,8 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        clerkOrgId: null,
-        clerkUserId: null,
+        orgId: null,
+        userId: null,
         createdAt: new Date(),
       };
 
@@ -329,8 +329,8 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        clerkOrgId: null,
-        clerkUserId: null,
+        orgId: null,
+        userId: null,
         createdAt: new Date(),
       };
 
@@ -435,8 +435,8 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        clerkOrgId: null,
-        clerkUserId: null,
+        orgId: null,
+        userId: null,
         createdAt: new Date(),
       });
 
@@ -494,8 +494,8 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          clerkOrgId: null,
-          clerkUserId: null,
+          orgId: null,
+          userId: null,
           createdAt: new Date(),
         })
         .mockResolvedValueOnce({
@@ -509,8 +509,8 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          clerkOrgId: null,
-          clerkUserId: null,
+          orgId: null,
+          userId: null,
           createdAt: new Date(),
         });
 
@@ -557,8 +557,8 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        clerkOrgId: null,
-        clerkUserId: null,
+        orgId: null,
+        userId: null,
         createdAt: new Date(),
       };
 
@@ -632,8 +632,8 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        clerkOrgId: null,
-        clerkUserId: null,
+        orgId: null,
+        userId: null,
         createdAt: new Date(),
       });
 
@@ -677,8 +677,8 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          clerkOrgId: null,
-          clerkUserId: null,
+          orgId: null,
+          userId: null,
           createdAt: new Date(),
         })
         .mockResolvedValueOnce(undefined); // no more rows
@@ -712,8 +712,8 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          clerkOrgId: null,
-          clerkUserId: null,
+          orgId: null,
+          userId: null,
           createdAt: new Date(),
         })
         .mockResolvedValueOnce({
@@ -727,8 +727,8 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          clerkOrgId: null,
-          clerkUserId: null,
+          orgId: null,
+          userId: null,
           createdAt: new Date(),
         });
 
@@ -772,8 +772,8 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        clerkOrgId: null,
-        clerkUserId: null,
+        orgId: null,
+        userId: null,
         createdAt: new Date(),
       });
 


### PR DESCRIPTION
## Summary
- Renames all `clerkOrgId`/`clerkUserId` references to `orgId`/`userId` — DB columns, Zod schemas, API query params, route handlers, lib functions, and tests
- Adds Drizzle migration `0007` with `ALTER TABLE ... RENAME COLUMN` (data-preserving)
- Outgoing calls to downstream services (apollo, campaign, brand, runs) still use old names (`x-clerk-org-id`, `clerkOrgId`) with TODO comments until those services migrate

## Test plan
- [x] `npm run build` — TypeScript compiles clean
- [x] `npm run test:unit` — all 61 unit tests pass
- [x] `openapi.json` has zero `clerk` references
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)