### PR TITLE
Add 'platform' to keySource enum validation

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -452,10 +452,11 @@
           "keySource": {
             "type": "string",
             "enum": [
-              "byok",
-              "app"
+              "platform",
+              "app",
+              "byok"
             ],
-            "description": "How downstream services resolve API keys: 'byok' = use the org's own keys via key-service, 'app' = use platform keys."
+            "description": "How downstream services resolve API keys: 'platform' = platform-owned keys (no appId needed), 'app' = client app keys (per appId), 'byok' = end user's own keys (per orgId/userId)."
           },
           "searchParams": {
             "type": "object",

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -225,7 +225,7 @@ export interface ApolloSearchParamsResult {
 
 export async function apolloSearchParams(options: {
   context: string;
-  keySource: "byok" | "app";
+  keySource: "platform" | "app" | "byok";
   runId: string;
   appId: string;
   brandId: string;

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -25,7 +25,7 @@ async function fillBufferFromSearch(params: {
   campaignId: string;
   brandId: string;
   searchParams: ApolloSearchParams;
-  keySource: "byok" | "app";
+  keySource: "platform" | "app" | "byok";
   pushRunId?: string | null;
   orgId?: string | null;
   userId?: string | null;
@@ -198,7 +198,7 @@ export async function pullNext(params: {
   brandId: string;
   parentRunId?: string | null;
   runId?: string | null;
-  keySource?: "byok" | "app";
+  keySource?: "platform" | "app" | "byok";
   searchParams?: ApolloSearchParams;
   orgId?: string | null;
   userId?: string | null;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -153,8 +153,8 @@ export const BufferNextRequestSchema = z
     campaignId: z.string().min(1),
     brandId: z.string().min(1),
     parentRunId: z.string().min(1),
-    keySource: z.enum(["byok", "app"]).openapi({
-      description: "How downstream services resolve API keys: 'byok' = use the org's own keys via key-service, 'app' = use platform keys.",
+    keySource: z.enum(["platform", "app", "byok"]).openapi({
+      description: "How downstream services resolve API keys: 'platform' = platform-owned keys (no appId needed), 'app' = client app keys (per appId), 'byok' = end user's own keys (per orgId/userId).",
     }),
     searchParams: z.record(z.string(), z.unknown()).optional(),
     userId: z.string().optional(),

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -91,6 +91,19 @@ describe("schema validation", () => {
         expect(result.data.workflowName).toBeUndefined();
       }
     });
+
+    it("accepts keySource 'platform'", () => {
+      const result = BufferNextRequestSchema.safeParse({
+        campaignId: "c1",
+        brandId: "b1",
+        parentRunId: "r1",
+        keySource: "platform",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.keySource).toBe("platform");
+      }
+    });
   });
 
   describe("ApolloPersonDataSchema", () => {


### PR DESCRIPTION
## Summary
- Adds `"platform"` to the `keySource` Zod enum (`z.enum(["platform", "app", "byok"])`) in `src/schemas.ts`
- Updates TypeScript type annotations in `src/lib/buffer.ts` and `src/lib/apollo-client.ts`
- Regenerates `openapi.json` to reflect the new enum value
- Adds test case for `keySource: "platform"` in schema tests

## Context
key-service already supports platform keys via `POST /internal/platform-keys` (PR #16). api-service sends `keySource: "platform"` for trial/payg billing modes, but lead-service was rejecting it with `Invalid enum value. Expected 'app' | 'byok', received 'platform'`.

## Test plan
- [x] Unit tests pass (62/62), including new `keySource: "platform"` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)