### PR TITLE
Fix: rename stale x-clerk-org-id to x-org-id in service clients

### DIFF
--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -143,7 +143,7 @@ export async function apolloSearch(
 ): Promise<ApolloSearchResult | null> {
   try {
     const headers: Record<string, string> = {};
-    if (options?.orgId) headers["x-clerk-org-id"] = options.orgId;
+    if (options?.orgId) headers["x-org-id"] = options.orgId;
 
     const raw = await callApolloService<ApolloSearchRawResponse>("/search", {
       method: "POST",
@@ -193,7 +193,7 @@ export async function apolloSearchNext(options: {
 }): Promise<ApolloSearchNextResult | null> {
   try {
     const headers: Record<string, string> = {};
-    if (options.orgId) headers["x-clerk-org-id"] = options.orgId;
+    if (options.orgId) headers["x-org-id"] = options.orgId;
 
     const body: Record<string, unknown> = {
       campaignId: options.campaignId,
@@ -234,7 +234,7 @@ export async function apolloSearchParams(options: {
   workflowName?: string;
 }): Promise<ApolloSearchParamsResult> {
   const headers: Record<string, string> = {};
-  if (options.orgId) headers["x-clerk-org-id"] = options.orgId;
+  if (options.orgId) headers["x-org-id"] = options.orgId;
 
   return callApolloService<ApolloSearchParamsResult>("/search/params", {
     method: "POST",
@@ -266,7 +266,7 @@ export async function fetchApolloStats(
 ): Promise<ApolloStats> {
   try {
     const headers: Record<string, string> = {};
-    if (orgId) headers["x-clerk-org-id"] = orgId;
+    if (orgId) headers["x-org-id"] = orgId;
 
     const result = await callApolloService<{ stats: ApolloStats }>("/stats", {
       method: "POST",
@@ -293,7 +293,7 @@ export async function apolloEnrich(
 ): Promise<ApolloEnrichResult | null> {
   try {
     const headers: Record<string, string> = {};
-    if (options?.orgId) headers["x-clerk-org-id"] = options.orgId;
+    if (options?.orgId) headers["x-org-id"] = options.orgId;
 
     const result = await callApolloService<ApolloEnrichResult>("/enrich", {
       method: "POST",

--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -21,11 +21,10 @@ export async function fetchBrand(
       "Content-Type": "application/json",
       "X-API-Key": BRAND_SERVICE_API_KEY,
     };
-    // TODO: rename header + query param when brand-service is migrated
-    if (orgId) headers["x-clerk-org-id"] = orgId;
+    if (orgId) headers["x-org-id"] = orgId;
 
     const url = new URL(`${BRAND_SERVICE_URL}/brands/${brandId}`);
-    if (orgId) url.searchParams.set("clerkOrgId", orgId);
+    if (orgId) url.searchParams.set("orgId", orgId);
 
     const response = await fetch(url.toString(), { headers });
 

--- a/src/lib/campaign-client.ts
+++ b/src/lib/campaign-client.ts
@@ -18,8 +18,7 @@ export async function fetchCampaign(
       "Content-Type": "application/json",
       "X-API-Key": CAMPAIGN_SERVICE_API_KEY,
     };
-    // TODO: rename header when campaign-service is migrated
-    if (orgId) headers["x-clerk-org-id"] = orgId;
+    if (orgId) headers["x-org-id"] = orgId;
 
     const response = await fetch(`${CAMPAIGN_SERVICE_URL}/campaigns/${campaignId}`, {
       headers,

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -35,16 +35,15 @@ export async function createRun(params: {
   campaignId?: string;
   workflowName?: string;
 }): Promise<{ id: string }> {
-  // TODO: rename body fields when runs-service is migrated
   return callRunsService("/runs", {
     method: "POST",
     body: {
-      clerkOrgId: params.orgId,
+      orgId: params.orgId,
       appId: params.appId,
       serviceName: params.serviceName,
       taskName: params.taskName,
       parentRunId: params.parentRunId,
-      clerkUserId: params.userId,
+      userId: params.userId,
       brandId: params.brandId,
       campaignId: params.campaignId,
       workflowName: params.workflowName,

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Stub global fetch
+const fetchSpy = vi.fn();
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+describe("service client headers", () => {
+  describe("apollo-client", () => {
+    it("sends x-org-id header (not x-clerk-org-id) for fetchApolloStats", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({ stats: { enrichedLeadsCount: 0, searchCount: 0, fetchedPeopleCount: 0, totalMatchingPeople: 0 } })
+      );
+
+      const { fetchApolloStats } = await import("../../src/lib/apollo-client.js");
+      await fetchApolloStats({}, "org-uuid-123");
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-org-id"]).toBe("org-uuid-123");
+      expect(opts.headers).not.toHaveProperty("x-clerk-org-id");
+    });
+
+    it("sends x-org-id header for apolloSearch", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ people: [], pagination: { page: 1, totalPages: 1, totalEntries: 0 } }));
+
+      const { apolloSearch } = await import("../../src/lib/apollo-client.js");
+      await apolloSearch({ personTitles: ["CEO"] }, 1, { orgId: "org-uuid-456" });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-org-id"]).toBe("org-uuid-456");
+      expect(opts.headers).not.toHaveProperty("x-clerk-org-id");
+    });
+
+    it("sends x-org-id header for apolloEnrich", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ person: { id: "p1" } }));
+
+      const { apolloEnrich } = await import("../../src/lib/apollo-client.js");
+      await apolloEnrich("person-123", { orgId: "org-uuid-789" });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-org-id"]).toBe("org-uuid-789");
+      expect(opts.headers).not.toHaveProperty("x-clerk-org-id");
+    });
+  });
+
+  describe("campaign-client", () => {
+    it("sends x-org-id header (not x-clerk-org-id) for fetchCampaign", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ campaign: { id: "c1", name: "Test", targetAudience: null, targetOutcome: null, valueForTarget: null } }));
+
+      const { fetchCampaign } = await import("../../src/lib/campaign-client.js");
+      await fetchCampaign("campaign-123", "org-uuid-abc");
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-org-id"]).toBe("org-uuid-abc");
+      expect(opts.headers).not.toHaveProperty("x-clerk-org-id");
+    });
+  });
+
+  describe("brand-client", () => {
+    it("sends x-org-id header and orgId query param (not clerk variants)", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ brand: { id: "b1", name: "Test", domain: null, elevatorPitch: null, bio: null, mission: null, location: null, categories: null } }));
+
+      const { fetchBrand } = await import("../../src/lib/brand-client.js");
+      await fetchBrand("brand-123", "org-uuid-def");
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-org-id"]).toBe("org-uuid-def");
+      expect(opts.headers).not.toHaveProperty("x-clerk-org-id");
+      // Query param should be orgId, not clerkOrgId
+      expect(url).toContain("orgId=org-uuid-def");
+      expect(url).not.toContain("clerkOrgId");
+    });
+  });
+
+  describe("runs-client", () => {
+    it("sends orgId and userId in body (not clerkOrgId/clerkUserId)", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ id: "run-uuid-1" }, 201));
+
+      const { createRun } = await import("../../src/lib/runs-client.js");
+      await createRun({
+        orgId: "org-uuid-run",
+        appId: "test-app",
+        serviceName: "lead-service",
+        taskName: "test-task",
+        userId: "user-uuid-run",
+      });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [, opts] = fetchSpy.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.orgId).toBe("org-uuid-run");
+      expect(body.userId).toBe("user-uuid-run");
+      expect(body).not.toHaveProperty("clerkOrgId");
+      expect(body).not.toHaveProperty("clerkUserId");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Renames outgoing `x-clerk-org-id` headers to `x-org-id` in apollo-client, campaign-client, and brand-client (missed during the rename in PR #81)
- Renames `clerkOrgId`/`clerkUserId` body fields to `orgId`/`userId` in runs-client
- Renames `clerkOrgId` query param to `orgId` in brand-client
- Removes stale TODO comments that referenced pending migrations (now complete)

## Test plan
- [x] New unit tests verify correct header/body field names for all four service clients
- [x] All 68 unit tests pass
- [x] Build compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)