### PR TITLE
Rename mcpfactory to distribute, remove hardcoded appId

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -691,7 +691,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Identifies the calling application, e.g. mcpfactory"
+            "description": "Identifies the calling application"
           },
           {
             "in": "header",
@@ -759,7 +759,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Identifies the calling application, e.g. mcpfactory"
+            "description": "Identifies the calling application"
           },
           {
             "in": "header",
@@ -814,7 +814,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Identifies the calling application, e.g. mcpfactory"
+            "description": "Identifies the calling application"
           },
           {
             "in": "header",
@@ -890,7 +890,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Identifies the calling application, e.g. mcpfactory"
+            "description": "Identifies the calling application"
           },
           {
             "in": "header",
@@ -972,7 +972,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Identifies the calling application, e.g. mcpfactory"
+            "description": "Identifies the calling application"
           },
           {
             "in": "header",

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -1,4 +1,4 @@
-const RUNS_SERVICE_URL = process.env.RUNS_SERVICE_URL || "https://runs.mcpfactory.org";
+const RUNS_SERVICE_URL = process.env.RUNS_SERVICE_URL || "https://runs.distribute.org";
 const RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY || "";
 
 async function callRunsService(path: string, options: {

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -49,7 +49,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
     // Create child run for traceability
     const childRun = await createRun({
       orgId: req.externalOrgId!,
-      appId: req.appId || "mcpfactory",
+      appId: req.appId,
       serviceName: "lead-service",
       taskName: "lead-serve",
       parentRunId,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -27,7 +27,7 @@ const AuthHeaders = [
     name: "x-app-id",
     required: true,
     schema: { type: "string" as const },
-    description: "Identifies the calling application, e.g. mcpfactory",
+    description: "Identifies the calling application",
   },
   {
     in: "header" as const,


### PR DESCRIPTION
## Summary
- Removed `"mcpfactory"` fallback default from `appId` in buffer route — now uses `req.appId` directly (required via auth middleware)
- Renamed runs-service URL fallback from `runs.mcpfactory.org` to `runs.distribute.org`
- Removed brand-specific `"e.g. mcpfactory"` from x-app-id header descriptions in schemas
- Regenerated `openapi.json`

## Test plan
- [x] All 68 unit tests pass (`npm run test:unit`)
- [x] `grep -ri mcpfactory` returns zero matches across the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)