### PR TITLE
Add runtime appId guard to fix TypeScript build

### DIFF
--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -35,6 +35,10 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
     const { campaignId, brandId, parentRunId, keySource, searchParams, userId, workflowName, idempotencyKey } = parsed.data;
     const orgId = req.externalOrgId ?? null;
 
+    if (!req.appId) {
+      return res.status(400).json({ error: "x-app-id header is required" });
+    }
+
     // Idempotency: return cached response if this key was already processed
     if (idempotencyKey) {
       const cached = await db.query.idempotencyCache.findFirst({


### PR DESCRIPTION
## Summary
- Added explicit `if (!req.appId)` guard in the buffer route before passing to `createRun()`
- The auth middleware already validates `x-app-id` is present (returns 400 if missing), but the TypeScript type is `string | undefined`
- This narrows the type so `req.appId` satisfies `createRun(appId: string)` without a fallback default

## Test plan
- [x] `npm run build` passes (was failing with TS2322)
- [x] All 68 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)