### PR TITLE
Remove appId, keySource, and internal org/user mapping tables

### DIFF
--- a/drizzle/0008_remove_appid_org_tables.sql
+++ b/drizzle/0008_remove_appid_org_tables.sql
@@ -1,0 +1,40 @@
+-- Add org_id to tables that only had organization_id FK
+ALTER TABLE "idempotency_cache" ADD COLUMN "org_id" text;--> statement-breakpoint
+ALTER TABLE "cursors" ADD COLUMN "org_id" text;--> statement-breakpoint
+
+-- Backfill org_id from organizations.external_id
+UPDATE "idempotency_cache" ic SET "org_id" = o."external_id"
+  FROM "organizations" o WHERE ic."organization_id" = o."id";--> statement-breakpoint
+UPDATE "cursors" c SET "org_id" = o."external_id"
+  FROM "organizations" o WHERE c."organization_id" = o."id";--> statement-breakpoint
+
+-- Delete orphaned rows (organization_id that doesn't exist in organizations)
+DELETE FROM "idempotency_cache" WHERE "org_id" IS NULL;--> statement-breakpoint
+DELETE FROM "cursors" WHERE "org_id" IS NULL;--> statement-breakpoint
+
+-- Make org_id NOT NULL on all dependent tables
+ALTER TABLE "idempotency_cache" ALTER COLUMN "org_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "cursors" ALTER COLUMN "org_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "served_leads" ALTER COLUMN "org_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "lead_buffer" ALTER COLUMN "org_id" SET NOT NULL;--> statement-breakpoint
+
+-- Drop old indexes that reference organization_id
+DROP INDEX IF EXISTS "idx_served_org_brand_email";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_served_org";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_buffer_org_ns_status";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_cursors_org_ns";--> statement-breakpoint
+
+-- Drop organization_id FK columns from all dependent tables
+ALTER TABLE "served_leads" DROP COLUMN "organization_id";--> statement-breakpoint
+ALTER TABLE "lead_buffer" DROP COLUMN "organization_id";--> statement-breakpoint
+ALTER TABLE "idempotency_cache" DROP COLUMN "organization_id";--> statement-breakpoint
+ALTER TABLE "cursors" DROP COLUMN "organization_id";--> statement-breakpoint
+
+-- Recreate indexes using org_id
+CREATE UNIQUE INDEX "idx_served_org_brand_email" ON "served_leads" USING btree ("org_id","brand_id","email");--> statement-breakpoint
+CREATE INDEX "idx_buffer_org_ns_status" ON "lead_buffer" USING btree ("org_id","namespace","status");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_cursors_org_ns" ON "cursors" USING btree ("org_id","namespace");--> statement-breakpoint
+
+-- Drop org/user mapping tables (users has FK to organizations, drop first)
+DROP TABLE "users";--> statement-breakpoint
+DROP TABLE "organizations";

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1772064000000,
       "tag": "0007_rename_clerk_to_org_user",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1772640000000,
+      "tag": "0008_remove_appid_org_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -449,15 +449,6 @@
             "type": "string",
             "minLength": 1
           },
-          "keySource": {
-            "type": "string",
-            "enum": [
-              "platform",
-              "app",
-              "byok"
-            ],
-            "description": "How downstream services resolve API keys: 'platform' = platform-owned keys (no appId needed), 'app' = client app keys (per appId), 'byok' = end user's own keys (per orgId/userId)."
-          },
           "searchParams": {
             "type": "object",
             "additionalProperties": {
@@ -478,8 +469,7 @@
         "required": [
           "campaignId",
           "brandId",
-          "parentRunId",
-          "keySource"
+          "parentRunId"
         ]
       },
       "CursorGetResponse": {
@@ -535,10 +525,6 @@
             "nullable": true,
             "format": "uuid"
           },
-          "organizationId": {
-            "type": "string",
-            "format": "uuid"
-          },
           "namespace": {
             "type": "string"
           },
@@ -567,8 +553,7 @@
             "type": "string"
           },
           "orgId": {
-            "type": "string",
-            "nullable": true
+            "type": "string"
           },
           "userId": {
             "type": "string",
@@ -584,7 +569,6 @@
         "required": [
           "id",
           "leadId",
-          "organizationId",
           "namespace",
           "email",
           "externalId",
@@ -686,21 +670,21 @@
           },
           {
             "in": "header",
-            "name": "x-app-id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Identifies the calling application"
-          },
-          {
-            "in": "header",
             "name": "x-org-id",
             "required": true,
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID"
+            "description": "Internal organization UUID from client-service"
+          },
+          {
+            "in": "header",
+            "name": "x-user-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Internal user UUID from client-service"
           }
         ],
         "requestBody": {
@@ -754,21 +738,21 @@
           },
           {
             "in": "header",
-            "name": "x-app-id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Identifies the calling application"
-          },
-          {
-            "in": "header",
             "name": "x-org-id",
             "required": true,
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID"
+            "description": "Internal organization UUID from client-service"
+          },
+          {
+            "in": "header",
+            "name": "x-user-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Internal user UUID from client-service"
           },
           {
             "schema": {
@@ -809,21 +793,21 @@
           },
           {
             "in": "header",
-            "name": "x-app-id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Identifies the calling application"
-          },
-          {
-            "in": "header",
             "name": "x-org-id",
             "required": true,
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID"
+            "description": "Internal organization UUID from client-service"
+          },
+          {
+            "in": "header",
+            "name": "x-user-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Internal user UUID from client-service"
           },
           {
             "schema": {
@@ -885,21 +869,21 @@
           },
           {
             "in": "header",
-            "name": "x-app-id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Identifies the calling application"
-          },
-          {
-            "in": "header",
             "name": "x-org-id",
             "required": true,
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID"
+            "description": "Internal organization UUID from client-service"
+          },
+          {
+            "in": "header",
+            "name": "x-user-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Internal user UUID from client-service"
           },
           {
             "in": "query",
@@ -967,21 +951,21 @@
           },
           {
             "in": "header",
-            "name": "x-app-id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Identifies the calling application"
-          },
-          {
-            "in": "header",
             "name": "x-org-id",
             "required": true,
             "schema": {
               "type": "string"
             },
-            "description": "External organization ID"
+            "description": "Internal organization UUID from client-service"
+          },
+          {
+            "in": "header",
+            "name": "x-user-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Internal user UUID from client-service"
           },
           {
             "in": "query",
@@ -1010,14 +994,6 @@
           {
             "in": "query",
             "name": "userId",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "appId",
             "required": false,
             "schema": {
               "type": "string"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,35 +1,5 @@
 import { pgTable, uuid, text, timestamp, uniqueIndex, index, jsonb } from "drizzle-orm/pg-core";
 
-// Organizations — maps external org IDs to internal UUIDs
-export const organizations = pgTable(
-  "organizations",
-  {
-    id: uuid("id").primaryKey().defaultRandom(),
-    appId: text("app_id").notNull(),
-    externalId: text("external_id").notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  },
-  (table) => [
-    uniqueIndex("idx_orgs_app_external").on(table.appId, table.externalId),
-  ]
-);
-
-// Users — maps external user IDs to internal UUIDs
-export const users = pgTable(
-  "users",
-  {
-    id: uuid("id").primaryKey().defaultRandom(),
-    externalId: text("external_id").notNull(),
-    organizationId: uuid("organization_id")
-      .notNull()
-      .references(() => organizations.id, { onDelete: "cascade" }),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  },
-  (table) => [
-    uniqueIndex("idx_users_org_external").on(table.organizationId, table.externalId),
-  ]
-);
-
 // Leads — global identity registry (no org/brand/campaign scoping)
 export const leads = pgTable(
   "leads",
@@ -66,9 +36,6 @@ export const servedLeads = pgTable(
   "served_leads",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    organizationId: uuid("organization_id")
-      .notNull()
-      .references(() => organizations.id, { onDelete: "cascade" }),
     leadId: uuid("lead_id").references(() => leads.id),
     namespace: text("namespace").notNull(),
     email: text("email").notNull(),
@@ -78,13 +45,12 @@ export const servedLeads = pgTable(
     runId: text("run_id"),
     brandId: text("brand_id").notNull(),
     campaignId: text("campaign_id").notNull(),
-    orgId: text("org_id"),
+    orgId: text("org_id").notNull(),
     userId: text("user_id"),
     servedAt: timestamp("served_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("idx_served_org_brand_email").on(table.organizationId, table.brandId, table.email),
-    index("idx_served_org").on(table.organizationId),
+    uniqueIndex("idx_served_org_brand_email").on(table.orgId, table.brandId, table.email),
     index("idx_served_brand").on(table.brandId),
     index("idx_served_campaign").on(table.campaignId),
     index("idx_served_org_id").on(table.orgId),
@@ -97,9 +63,6 @@ export const leadBuffer = pgTable(
   "lead_buffer",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    organizationId: uuid("organization_id")
-      .notNull()
-      .references(() => organizations.id, { onDelete: "cascade" }),
     namespace: text("namespace").notNull(),
     campaignId: text("campaign_id").notNull(),
     email: text("email").notNull(),
@@ -108,12 +71,12 @@ export const leadBuffer = pgTable(
     status: text("status").notNull().default("buffered"),
     pushRunId: text("push_run_id"),
     brandId: text("brand_id"),
-    orgId: text("org_id"),
+    orgId: text("org_id").notNull(),
     userId: text("user_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_buffer_org_ns_status").on(table.organizationId, table.namespace, table.status),
+    index("idx_buffer_org_ns_status").on(table.orgId, table.namespace, table.status),
   ]
 );
 
@@ -147,9 +110,7 @@ export const idempotencyCache = pgTable(
   {
     id: uuid("id").primaryKey().defaultRandom(),
     idempotencyKey: text("idempotency_key").notNull(),
-    organizationId: uuid("organization_id")
-      .notNull()
-      .references(() => organizations.id, { onDelete: "cascade" }),
+    orgId: text("org_id").notNull(),
     response: jsonb("response").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -163,23 +124,17 @@ export const cursors = pgTable(
   "cursors",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    organizationId: uuid("organization_id")
-      .notNull()
-      .references(() => organizations.id, { onDelete: "cascade" }),
+    orgId: text("org_id").notNull(),
     namespace: text("namespace").notNull(),
     state: jsonb("state"),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("idx_cursors_org_ns").on(table.organizationId, table.namespace),
+    uniqueIndex("idx_cursors_org_ns").on(table.orgId, table.namespace),
   ]
 );
 
 // Type exports
-export type Organization = typeof organizations.$inferSelect;
-export type NewOrganization = typeof organizations.$inferInsert;
-export type User = typeof users.$inferSelect;
-export type NewUser = typeof users.$inferInsert;
 export type ServedLead = typeof servedLeads.$inferSelect;
 export type NewServedLead = typeof servedLeads.$inferInsert;
 export type LeadBufferRow = typeof leadBuffer.$inferSelect;

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -139,7 +139,7 @@ interface ApolloSearchRawResponse {
 export async function apolloSearch(
   params: ApolloSearchParams,
   page: number = 1,
-  options?: { runId?: string | null; orgId?: string | null; appId?: string; brandId?: string; campaignId?: string; workflowName?: string }
+  options?: { runId?: string | null; orgId?: string | null; brandId?: string; campaignId?: string; workflowName?: string }
 ): Promise<ApolloSearchResult | null> {
   try {
     const headers: Record<string, string> = {};
@@ -151,7 +151,6 @@ export async function apolloSearch(
         ...params,
         page,
         ...(options?.runId ? { runId: options.runId } : {}),
-        ...(options?.appId ? { appId: options.appId } : {}),
         ...(options?.brandId ? { brandId: options.brandId } : {}),
         ...(options?.campaignId ? { campaignId: options.campaignId } : {}),
         ...(options?.workflowName ? { workflowName: options.workflowName } : {}),
@@ -185,7 +184,6 @@ export interface ApolloSearchNextResult {
 export async function apolloSearchNext(options: {
   campaignId: string;
   brandId: string;
-  appId: string;
   searchParams?: ApolloSearchParams;
   runId?: string | null;
   orgId?: string | null;
@@ -198,7 +196,6 @@ export async function apolloSearchNext(options: {
     const body: Record<string, unknown> = {
       campaignId: options.campaignId,
       brandId: options.brandId,
-      appId: options.appId,
     };
     if (options.searchParams) body.searchParams = options.searchParams;
     if (options.runId) body.runId = options.runId;
@@ -225,9 +222,7 @@ export interface ApolloSearchParamsResult {
 
 export async function apolloSearchParams(options: {
   context: string;
-  keySource: "platform" | "app" | "byok";
   runId: string;
-  appId: string;
   brandId: string;
   campaignId: string;
   orgId?: string | null;
@@ -240,9 +235,7 @@ export async function apolloSearchParams(options: {
     method: "POST",
     body: {
       context: options.context,
-      keySource: options.keySource,
       runId: options.runId,
-      appId: options.appId,
       brandId: options.brandId,
       campaignId: options.campaignId,
       ...(options.workflowName ? { workflowName: options.workflowName } : {}),
@@ -261,7 +254,7 @@ export interface ApolloStats {
 }
 
 export async function fetchApolloStats(
-  filters: { runIds?: string[]; appId?: string; brandId?: string; campaignId?: string },
+  filters: { runIds?: string[]; brandId?: string; campaignId?: string },
   orgId?: string | null
 ): Promise<ApolloStats> {
   try {
@@ -289,7 +282,7 @@ export interface ApolloEnrichResult {
 
 export async function apolloEnrich(
   personId: string,
-  options?: { runId?: string | null; orgId?: string | null; appId?: string; brandId?: string; campaignId?: string; workflowName?: string }
+  options?: { runId?: string | null; orgId?: string | null; brandId?: string; campaignId?: string; workflowName?: string }
 ): Promise<ApolloEnrichResult | null> {
   try {
     const headers: Record<string, string> = {};
@@ -300,7 +293,6 @@ export async function apolloEnrich(
       body: {
         apolloPersonId: personId,
         ...(options?.runId ? { runId: options.runId } : {}),
-        ...(options?.appId ? { appId: options.appId } : {}),
         ...(options?.brandId ? { brandId: options.brandId } : {}),
         ...(options?.campaignId ? { campaignId: options.campaignId } : {}),
         ...(options?.workflowName ? { workflowName: options.workflowName } : {}),

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -7,10 +7,10 @@ import { apolloSearchNext, apolloEnrich, apolloSearchParams, type ApolloSearchPa
 import { fetchCampaign } from "./campaign-client.js";
 import { fetchBrand } from "./brand-client.js";
 
-async function isInBuffer(organizationId: string, campaignId: string, externalId: string): Promise<boolean> {
+async function isInBuffer(orgId: string, campaignId: string, externalId: string): Promise<boolean> {
   const row = await db.query.leadBuffer.findFirst({
     where: and(
-      eq(leadBuffer.organizationId, organizationId),
+      eq(leadBuffer.orgId, orgId),
       eq(leadBuffer.namespace, campaignId),
       eq(leadBuffer.externalId, externalId)
     ),
@@ -21,15 +21,12 @@ async function isInBuffer(organizationId: string, campaignId: string, externalId
 const MAX_PAGES = 50;
 
 async function fillBufferFromSearch(params: {
-  organizationId: string;
+  orgId: string;
   campaignId: string;
   brandId: string;
   searchParams: ApolloSearchParams;
-  keySource: "platform" | "app" | "byok";
   pushRunId?: string | null;
-  orgId?: string | null;
   userId?: string | null;
-  appId?: string;
   workflowName?: string;
 }): Promise<{ filled: number }> {
   // Fetch campaign + brand details in parallel for rich LLM context
@@ -62,9 +59,7 @@ async function fillBufferFromSearch(params: {
 
   const { searchParams: validatedParams } = await apolloSearchParams({
     context,
-    keySource: params.keySource,
     runId: params.pushRunId ?? "",
-    appId: params.appId ?? "",
     brandId: params.brandId,
     campaignId: params.campaignId,
     orgId: params.orgId,
@@ -78,7 +73,6 @@ async function fillBufferFromSearch(params: {
     const result = await apolloSearchNext({
       campaignId: params.campaignId,
       brandId: params.brandId,
-      appId: params.appId ?? "",
       searchParams: validatedParams,
       runId: params.pushRunId,
       orgId: params.orgId,
@@ -105,7 +99,7 @@ async function fillBufferFromSearch(params: {
 
     for (const person of result.people) {
       // Skip if already in buffer
-      if (person.id && await isInBuffer(params.organizationId, params.campaignId, person.id)) {
+      if (person.id && await isInBuffer(params.orgId, params.campaignId, person.id)) {
         continue;
       }
 
@@ -157,7 +151,6 @@ async function fillBufferFromSearch(params: {
       if (email && deliveredMap.get(email)) continue;
 
       await db.insert(leadBuffer).values({
-        organizationId: params.organizationId,
         namespace: params.campaignId,
         campaignId: params.campaignId,
         email: email ?? "",
@@ -166,7 +159,7 @@ async function fillBufferFromSearch(params: {
         status: "buffered",
         pushRunId: params.pushRunId ?? null,
         brandId: params.brandId,
-        orgId: params.orgId ?? null,
+        orgId: params.orgId,
         userId: params.userId ?? null,
       });
       pageFilled++;
@@ -193,16 +186,13 @@ async function fillBufferFromSearch(params: {
 }
 
 export async function pullNext(params: {
-  organizationId: string;
+  orgId: string;
   campaignId: string;
   brandId: string;
   parentRunId?: string | null;
   runId?: string | null;
-  keySource?: "platform" | "app" | "byok";
   searchParams?: ApolloSearchParams;
-  orgId?: string | null;
   userId?: string | null;
-  appId?: string;
   workflowName?: string;
 }): Promise<{
   found: boolean;
@@ -227,7 +217,7 @@ export async function pullNext(params: {
     }
     const row = await db.query.leadBuffer.findFirst({
       where: and(
-        eq(leadBuffer.organizationId, params.organizationId),
+        eq(leadBuffer.orgId, params.orgId),
         eq(leadBuffer.namespace, params.campaignId),
         eq(leadBuffer.status, "buffered")
       ),
@@ -236,17 +226,14 @@ export async function pullNext(params: {
 
     if (!row) {
       // Buffer empty - try to fill from search if searchParams provided
-      if (params.searchParams && params.keySource) {
+      if (params.searchParams) {
         const { filled } = await fillBufferFromSearch({
-          organizationId: params.organizationId,
+          orgId: params.orgId,
           campaignId: params.campaignId,
           brandId: params.brandId,
           searchParams: params.searchParams,
-          keySource: params.keySource,
           pushRunId: params.runId,
-          orgId: params.orgId,
           userId: params.userId,
-          appId: params.appId,
           workflowName: params.workflowName,
         });
 
@@ -286,7 +273,6 @@ export async function pullNext(params: {
         const enrichResult = await apolloEnrich(row.externalId, {
           runId: params.runId,
           orgId: params.orgId,
-          appId: params.appId,
           brandId: params.brandId,
           campaignId: params.campaignId,
           workflowName: params.workflowName,
@@ -372,7 +358,7 @@ export async function pullNext(params: {
     }
 
     await markServed({
-      organizationId: params.organizationId,
+      orgId: params.orgId,
       namespace: params.campaignId,
       brandId: params.brandId,
       campaignId: params.campaignId,
@@ -382,7 +368,6 @@ export async function pullNext(params: {
       metadata: enrichedData,
       parentRunId: params.parentRunId ?? null,
       runId: params.runId ?? null,
-      orgId: row.orgId,
       userId: row.userId,
     });
 

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -42,7 +42,7 @@ export async function checkDelivered(
  * Now includes leadId for the global identity link.
  */
 export async function markServed(params: {
-  organizationId: string;
+  orgId: string;
   namespace: string;
   brandId: string;
   campaignId: string;
@@ -52,13 +52,12 @@ export async function markServed(params: {
   metadata?: unknown;
   parentRunId?: string | null;
   runId?: string | null;
-  orgId?: string | null;
   userId?: string | null;
 }): Promise<{ inserted: boolean }> {
   const result = await db
     .insert(servedLeads)
     .values({
-      organizationId: params.organizationId,
+      orgId: params.orgId,
       namespace: params.namespace,
       email: params.email,
       leadId: params.leadId ?? null,
@@ -68,7 +67,6 @@ export async function markServed(params: {
       runId: params.runId ?? null,
       brandId: params.brandId,
       campaignId: params.campaignId,
-      orgId: params.orgId ?? null,
       userId: params.userId ?? null,
     })
     .onConflictDoNothing()

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -26,7 +26,6 @@ async function callRunsService(path: string, options: {
 
 export async function createRun(params: {
   orgId: string;
-  appId: string;
   serviceName: string;
   taskName: string;
   parentRunId?: string;
@@ -39,7 +38,6 @@ export async function createRun(params: {
     method: "POST",
     body: {
       orgId: params.orgId,
-      appId: params.appId,
       serviceName: params.serviceName,
       taskName: params.taskName,
       parentRunId: params.parentRunId,
@@ -63,7 +61,7 @@ export async function updateRun(
 
 export async function addCosts(
   runId: string,
-  items: Array<{ costName: string; quantity: number }>
+  items: Array<{ costName: string; quantity: number; costSource: "platform" | "org" }>
 ): Promise<void> {
   if (items.length === 0) return;
   await callRunsService(`/runs/${runId}/costs`, {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,12 +1,8 @@
 import { Request, Response, NextFunction } from "express";
-import { eq, and } from "drizzle-orm";
-import { db } from "../db/index.js";
-import { organizations } from "../db/schema.js";
 
 export interface AuthenticatedRequest extends Request {
-  organizationId?: string;
-  appId?: string;
-  externalOrgId?: string;
+  orgId?: string;
+  userId?: string;
 }
 
 export async function authenticate(
@@ -20,48 +16,15 @@ export async function authenticate(
       return res.status(401).json({ error: "Invalid API key" });
     }
 
-    const appId = req.headers["x-app-id"] as string;
-    const externalOrgId = req.headers["x-org-id"] as string;
+    const orgId = req.headers["x-org-id"] as string;
+    const userId = req.headers["x-user-id"] as string;
 
-    if (!appId || !externalOrgId) {
-      return res.status(400).json({ error: "x-app-id and x-org-id headers required" });
+    if (!orgId || !userId) {
+      return res.status(400).json({ error: "x-org-id and x-user-id headers required" });
     }
 
-    // Find or create org
-    let org = await db.query.organizations.findFirst({
-      where: and(
-        eq(organizations.appId, appId),
-        eq(organizations.externalId, externalOrgId)
-      ),
-    });
-
-    if (!org) {
-      const [newOrg] = await db
-        .insert(organizations)
-        .values({ appId, externalId: externalOrgId })
-        .onConflictDoNothing()
-        .returning();
-
-      if (newOrg) {
-        org = newOrg;
-      } else {
-        // Race condition: another request created it
-        org = await db.query.organizations.findFirst({
-          where: and(
-            eq(organizations.appId, appId),
-            eq(organizations.externalId, externalOrgId)
-          ),
-        });
-      }
-    }
-
-    if (!org) {
-      return res.status(500).json({ error: "Failed to resolve organization" });
-    }
-
-    req.organizationId = org.id;
-    req.appId = appId;
-    req.externalOrgId = externalOrgId;
+    req.orgId = orgId;
+    req.userId = userId;
     next();
   } catch (error) {
     console.error("[auth] Error:", error);

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -32,12 +32,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
   }
 
   try {
-    const { campaignId, brandId, parentRunId, keySource, searchParams, userId, workflowName, idempotencyKey } = parsed.data;
-    const orgId = req.externalOrgId ?? null;
-
-    if (!req.appId) {
-      return res.status(400).json({ error: "x-app-id header is required" });
-    }
+    const { campaignId, brandId, parentRunId, searchParams, userId, workflowName, idempotencyKey } = parsed.data;
 
     // Idempotency: return cached response if this key was already processed
     if (idempotencyKey) {
@@ -52,12 +47,11 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
 
     // Create child run for traceability
     const childRun = await createRun({
-      orgId: req.externalOrgId!,
-      appId: req.appId,
+      orgId: req.orgId!,
       serviceName: "lead-service",
       taskName: "lead-serve",
       parentRunId,
-      userId,
+      userId: userId ?? req.userId,
       brandId,
       campaignId,
       workflowName,
@@ -65,16 +59,13 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
     const serveRunId = childRun.id;
 
     const result = await pullNext({
-      organizationId: req.organizationId!,
+      orgId: req.orgId!,
       campaignId,
       brandId,
       parentRunId,
       runId: serveRunId,
-      keySource,
       searchParams: searchParams ?? undefined,
-      orgId,
-      userId: userId ?? null,
-      appId: req.appId,
+      userId: userId ?? req.userId ?? null,
       workflowName,
     });
 
@@ -84,7 +75,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       try {
         await db.insert(idempotencyCache).values({
           idempotencyKey,
-          organizationId: req.organizationId!,
+          orgId: req.orgId!,
           response: result,
         });
       } catch (err) {

--- a/src/routes/cursor.ts
+++ b/src/routes/cursor.ts
@@ -13,7 +13,7 @@ router.get("/cursor/:namespace", authenticate, async (req: AuthenticatedRequest,
 
     const cursor = await db.query.cursors.findFirst({
       where: and(
-        eq(cursors.organizationId, req.organizationId!),
+        eq(cursors.orgId, req.orgId!),
         eq(cursors.namespace, namespace)
       ),
     });
@@ -41,7 +41,7 @@ router.put("/cursor/:namespace", authenticate, async (req: AuthenticatedRequest,
 
     const existing = await db.query.cursors.findFirst({
       where: and(
-        eq(cursors.organizationId, req.organizationId!),
+        eq(cursors.orgId, req.orgId!),
         eq(cursors.namespace, namespace)
       ),
     });
@@ -53,7 +53,7 @@ router.put("/cursor/:namespace", authenticate, async (req: AuthenticatedRequest,
         .where(eq(cursors.id, existing.id));
     } else {
       await db.insert(cursors).values({
-        organizationId: req.organizationId!,
+        orgId: req.orgId!,
         namespace,
         state,
       });

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -20,7 +20,7 @@ router.get("/leads", authenticate, async (req: AuthenticatedRequest, res) => {
     const { brandId, campaignId, orgId, userId } = req.query;
 
     // Build filter conditions
-    const conditions: SQL[] = [eq(servedLeads.organizationId, req.organizationId!)];
+    const conditions: SQL[] = [eq(servedLeads.orgId, req.orgId!)];
 
     if (brandId && typeof brandId === "string") {
       conditions.push(eq(servedLeads.brandId, brandId));

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -2,24 +2,23 @@ import { Router } from "express";
 import { eq, and, count, inArray, or, type SQL } from "drizzle-orm";
 import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
 import { db } from "../db/index.js";
-import { servedLeads, leadBuffer, organizations } from "../db/schema.js";
+import { servedLeads, leadBuffer } from "../db/schema.js";
 import { fetchApolloStats } from "../lib/apollo-client.js";
 
 const router = Router();
 
 router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
-    const { brandId, campaignId, orgId, userId, appId, runIds } = req.query;
+    const { brandId, campaignId, orgId, userId, runIds } = req.query;
     const str = (v: unknown): string | undefined => typeof v === "string" ? v : undefined;
     const brandIdStr = str(brandId);
     const campaignIdStr = str(campaignId);
     const orgIdStr = str(orgId);
     const userIdStr = str(userId);
-    const appIdStr = str(appId);
     const runIdList = typeof runIds === "string" ? runIds.split(",").filter(Boolean) : [];
 
-    const servedConditions: SQL[] = [eq(servedLeads.organizationId, req.organizationId!)];
-    const bufferConditions: SQL[] = [eq(leadBuffer.organizationId, req.organizationId!)];
+    const servedConditions: SQL[] = [eq(servedLeads.orgId, req.orgId!)];
+    const bufferConditions: SQL[] = [eq(leadBuffer.orgId, req.orgId!)];
 
     if (brandIdStr) {
       servedConditions.push(eq(servedLeads.brandId, brandIdStr));
@@ -37,19 +36,6 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
       servedConditions.push(eq(servedLeads.userId, userIdStr));
       bufferConditions.push(eq(leadBuffer.userId, userIdStr));
     }
-    if (appIdStr) {
-      const orgs = await db.query.organizations.findMany({
-        where: eq(organizations.appId, appIdStr),
-      });
-      if (orgs.length > 0) {
-        const orgIds = orgs.map((o) => o.id);
-        servedConditions.push(inArray(servedLeads.organizationId, orgIds));
-        bufferConditions.push(inArray(leadBuffer.organizationId, orgIds));
-      } else {
-        const emptyApollo = { enrichedLeadsCount: 0, searchCount: 0, fetchedPeopleCount: 0, totalMatchingPeople: 0 };
-        return res.json({ served: 0, buffered: 0, skipped: 0, apollo: emptyApollo });
-      }
-    }
     if (runIdList.length > 0) {
       servedConditions.push(
         or(
@@ -63,13 +49,12 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
     const apolloFilters: Record<string, unknown> = {};
     if (brandIdStr) apolloFilters.brandId = brandIdStr;
     if (campaignIdStr) apolloFilters.campaignId = campaignIdStr;
-    if (appIdStr) apolloFilters.appId = appIdStr;
     if (runIdList.length > 0) apolloFilters.runIds = runIdList;
 
     const [servedResult, bufferRows, apollo] = await Promise.all([
       db.select({ count: count() }).from(servedLeads).where(and(...servedConditions)).then(([r]) => r),
       db.select({ status: leadBuffer.status, count: count() }).from(leadBuffer).where(and(...bufferConditions)).groupBy(leadBuffer.status),
-      fetchApolloStats(apolloFilters as Parameters<typeof fetchApolloStats>[0], orgIdStr ?? req.externalOrgId),
+      fetchApolloStats(apolloFilters as Parameters<typeof fetchApolloStats>[0], orgIdStr ?? req.orgId),
     ]);
 
     const bufferByStatus = Object.fromEntries(bufferRows.map((r) => [r.status, r.count]));

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -24,17 +24,17 @@ const AuthHeaders = [
   },
   {
     in: "header" as const,
-    name: "x-app-id",
-    required: true,
-    schema: { type: "string" as const },
-    description: "Identifies the calling application",
-  },
-  {
-    in: "header" as const,
     name: "x-org-id",
     required: true,
     schema: { type: "string" as const },
-    description: "External organization ID",
+    description: "Internal organization UUID from client-service",
+  },
+  {
+    in: "header" as const,
+    name: "x-user-id",
+    required: true,
+    schema: { type: "string" as const },
+    description: "Internal user UUID from client-service",
   },
 ];
 
@@ -153,9 +153,6 @@ export const BufferNextRequestSchema = z
     campaignId: z.string().min(1),
     brandId: z.string().min(1),
     parentRunId: z.string().min(1),
-    keySource: z.enum(["platform", "app", "byok"]).openapi({
-      description: "How downstream services resolve API keys: 'platform' = platform-owned keys (no appId needed), 'app' = client app keys (per appId), 'byok' = end user's own keys (per orgId/userId).",
-    }),
     searchParams: z.record(z.string(), z.unknown()).optional(),
     userId: z.string().optional(),
     workflowName: z.string().optional(),
@@ -206,7 +203,6 @@ const LeadDetailSchema = z
   .object({
     id: z.string().uuid(),
     leadId: z.string().uuid().nullable(),
-    organizationId: z.string().uuid(),
     namespace: z.string(),
     email: z.string(),
     externalId: z.string().nullable(),
@@ -215,7 +211,7 @@ const LeadDetailSchema = z
     runId: z.string().nullable(),
     brandId: z.string(),
     campaignId: z.string(),
-    orgId: z.string().nullable(),
+    orgId: z.string(),
     userId: z.string().nullable(),
     servedAt: z.string(),
     enrichment: ApolloPersonDataSchema.nullable(),
@@ -394,12 +390,6 @@ registry.registerPath({
     {
       in: "query" as const,
       name: "userId",
-      required: false,
-      schema: { type: "string" as const },
-    },
-    {
-      in: "query" as const,
-      name: "appId",
       required: false,
       schema: { type: "string" as const },
     },

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vites
 import request from "supertest";
 import app from "../../src/index.js";
 import {
-  setupTestOrg,
   cleanupTestData,
   closeDb,
   getAuthHeaders,
@@ -13,7 +12,6 @@ import { createRun } from "../../src/lib/runs-client.js";
 import { checkDeliveryStatus, isDelivered } from "../../src/lib/email-gateway-client.js";
 
 vi.mock("../../src/lib/runs-client.js", () => ({
-  ensureOrganization: vi.fn().mockResolvedValue("mock-org-id"),
   createRun: vi.fn().mockResolvedValue({ id: "mock-run-id" }),
   updateRun: vi.fn().mockResolvedValue(undefined),
   addCosts: vi.fn().mockResolvedValue(undefined),
@@ -27,7 +25,6 @@ vi.mock("../../src/lib/email-gateway-client.js", () => ({
 describe("API Integration Tests", () => {
   beforeAll(async () => {
     process.env.LEAD_SERVICE_API_KEY = TEST_API_KEY;
-    await setupTestOrg();
   });
 
   afterAll(async () => {
@@ -53,7 +50,7 @@ describe("API Integration Tests", () => {
     it("rejects requests without API key", async () => {
       const res = await request(app)
         .post("/buffer/next")
-        .send({ campaignId: "c1", brandId: "b1", parentRunId: "r1", keySource: "app" });
+        .send({ campaignId: "c1", brandId: "b1", parentRunId: "r1" });
 
       expect(res.status).toBe(401);
     });
@@ -62,11 +59,21 @@ describe("API Integration Tests", () => {
       const res = await request(app)
         .post("/buffer/next")
         .set("x-api-key", "wrong-key")
-        .set("x-app-id", "test")
         .set("x-org-id", "test")
-        .send({ campaignId: "c1", brandId: "b1", parentRunId: "r1", keySource: "app" });
+        .set("x-user-id", "test")
+        .send({ campaignId: "c1", brandId: "b1", parentRunId: "r1" });
 
       expect(res.status).toBe(401);
+    });
+
+    it("rejects requests without x-user-id header", async () => {
+      const res = await request(app)
+        .post("/buffer/next")
+        .set("x-api-key", TEST_API_KEY)
+        .set("x-org-id", "test")
+        .send({ campaignId: "c1", brandId: "b1", parentRunId: "r1" });
+
+      expect(res.status).toBe(400);
     });
   });
 
@@ -81,7 +88,7 @@ describe("API Integration Tests", () => {
       const res = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-b", brandId: "brand-b", parentRunId: "test-run-next-b", keySource: "app" });
+        .send({ campaignId: "campaign-b", brandId: "brand-b", parentRunId: "test-run-next-b" });
 
       expect(res.status).toBe(200);
       expect(res.body.found).toBe(true);
@@ -93,7 +100,7 @@ describe("API Integration Tests", () => {
       const res = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-empty", brandId: "brand-empty", parentRunId: "test-run-next-empty", keySource: "app" });
+        .send({ campaignId: "campaign-empty", brandId: "brand-empty", parentRunId: "test-run-next-empty" });
 
       expect(res.status).toBe(200);
       expect(res.body.found).toBe(false);
@@ -103,7 +110,7 @@ describe("API Integration Tests", () => {
       const res = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-x", brandId: "", parentRunId: "test-run", keySource: "app" });
+        .send({ campaignId: "campaign-x", brandId: "", parentRunId: "test-run" });
 
       expect(res.status).toBe(400);
       expect(res.body.details.fieldErrors.brandId).toBeDefined();
@@ -125,7 +132,6 @@ describe("API Integration Tests", () => {
           campaignId: "campaign-wf-next",
           brandId: "brand-wf-next",
           parentRunId: "test-run-wf-next",
-          keySource: "app",
           workflowName: "cold-email-outreach",
         });
 
@@ -175,7 +181,7 @@ describe("API Integration Tests", () => {
       const res = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-c", brandId: "brand-c", parentRunId: "test-run-next-c", keySource: "app" });
+        .send({ campaignId: "campaign-c", brandId: "brand-c", parentRunId: "test-run-next-c" });
 
       expect(res.body.found).toBe(true);
       expect(res.body.lead.email).toBe("fresh@example.com");
@@ -202,7 +208,6 @@ describe("API Integration Tests", () => {
           campaignId: "campaign-idem-1",
           brandId: "brand-idem-1",
           parentRunId: "test-run-idem-1",
-          keySource: "app",
           idempotencyKey: "run-idem-1",
         });
 
@@ -219,7 +224,6 @@ describe("API Integration Tests", () => {
           campaignId: "campaign-idem-1",
           brandId: "brand-idem-1",
           parentRunId: "test-run-idem-1",
-          keySource: "app",
           idempotencyKey: "run-idem-1",
         });
 
@@ -246,7 +250,6 @@ describe("API Integration Tests", () => {
           campaignId: "campaign-idem-2",
           brandId: "brand-idem-2",
           parentRunId: "test-run-idem-2a",
-          keySource: "app",
           idempotencyKey: "run-idem-2",
         });
 
@@ -261,7 +264,6 @@ describe("API Integration Tests", () => {
           campaignId: "campaign-idem-2",
           brandId: "brand-idem-2",
           parentRunId: "test-run-idem-2a",
-          keySource: "app",
           idempotencyKey: "run-idem-2",
         });
 
@@ -273,7 +275,6 @@ describe("API Integration Tests", () => {
           campaignId: "campaign-idem-2",
           brandId: "brand-idem-2",
           parentRunId: "test-run-idem-2b",
-          keySource: "app",
           idempotencyKey: "run-idem-2b",
         });
 
@@ -290,7 +291,6 @@ describe("API Integration Tests", () => {
           campaignId: "campaign-idem-empty",
           brandId: "brand-idem-empty",
           parentRunId: "test-run-idem-empty",
-          keySource: "app",
           idempotencyKey: "run-idem-empty",
         });
 
@@ -311,7 +311,6 @@ describe("API Integration Tests", () => {
           campaignId: "campaign-idem-empty",
           brandId: "brand-idem-empty",
           parentRunId: "test-run-idem-empty",
-          keySource: "app",
           idempotencyKey: "run-idem-empty",
         });
 
@@ -332,7 +331,6 @@ describe("API Integration Tests", () => {
           campaignId: "campaign-idem-compat",
           brandId: "brand-idem-compat",
           parentRunId: "test-run-idem-compat",
-          keySource: "app",
         });
 
       expect(res.status).toBe(200);
@@ -375,7 +373,7 @@ describe("API Integration Tests", () => {
       await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-leads", brandId: "brand-leads", parentRunId: "test-run-next-leads", keySource: "app" });
+        .send({ campaignId: "campaign-leads", brandId: "brand-leads", parentRunId: "test-run-next-leads" });
 
       // Query GET /leads
       const res = await request(app)
@@ -415,7 +413,7 @@ describe("API Integration Tests", () => {
       await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-leads-empty", brandId: "brand-leads-empty", parentRunId: "test-run-next-leads-empty", keySource: "app" });
+        .send({ campaignId: "campaign-leads-empty", brandId: "brand-leads-empty", parentRunId: "test-run-next-leads-empty" });
 
       const res = await request(app)
         .get("/leads?brandId=brand-leads-empty&campaignId=campaign-leads-empty")

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,53 +1,19 @@
 import { db, sql } from "../../src/db/index.js";
-import { organizations, servedLeads, leadBuffer, cursors, idempotencyCache, leadEmails, leads } from "../../src/db/schema.js";
-import { eq, and } from "drizzle-orm";
+import { servedLeads, leadBuffer, cursors, idempotencyCache } from "../../src/db/schema.js";
+import { eq } from "drizzle-orm";
 
 export const TEST_API_KEY = "test-api-key-12345";
-export const TEST_APP_ID = "test-app";
-export const TEST_ORG_ID = "test-org-integration";
-
-let testOrgUuid: string | null = null;
-
-export async function setupTestOrg(): Promise<string> {
-  // Clean up stale test data from previous runs (by appId/externalId, not in-memory uuid)
-  const existing = await db
-    .select({ id: organizations.id })
-    .from(organizations)
-    .where(
-      and(
-        eq(organizations.appId, TEST_APP_ID),
-        eq(organizations.externalId, TEST_ORG_ID)
-      )
-    );
-
-  if (existing.length > 0) {
-    testOrgUuid = existing[0].id;
-    await cleanupTestData();
-  }
-
-  // Create test organization
-  const [org] = await db
-    .insert(organizations)
-    .values({ appId: TEST_APP_ID, externalId: TEST_ORG_ID })
-    .returning();
-
-  testOrgUuid = org.id;
-  return org.id;
-}
+export const TEST_ORG_ID = "test-org-uuid-integration";
+export const TEST_USER_ID = "test-user-uuid-integration";
 
 export async function cleanupTestData(): Promise<void> {
-  if (testOrgUuid) {
-    await db.delete(idempotencyCache).where(eq(idempotencyCache.organizationId, testOrgUuid));
-    await db.delete(cursors).where(eq(cursors.organizationId, testOrgUuid));
-    await db.delete(leadBuffer).where(eq(leadBuffer.organizationId, testOrgUuid));
-    await db.delete(servedLeads).where(eq(servedLeads.organizationId, testOrgUuid));
-    // Clean up global tables in FK-safe order: served_leads → lead_emails → leads
-    await sql`DELETE FROM served_leads WHERE lead_id IN (SELECT id FROM leads)`;
-    await sql`DELETE FROM lead_emails WHERE lead_id IN (SELECT id FROM leads)`;
-    await sql`DELETE FROM leads`;
-    await db.delete(organizations).where(eq(organizations.id, testOrgUuid));
-    testOrgUuid = null;
-  }
+  await db.delete(idempotencyCache).where(eq(idempotencyCache.orgId, TEST_ORG_ID));
+  await db.delete(cursors).where(eq(cursors.orgId, TEST_ORG_ID));
+  await db.delete(leadBuffer).where(eq(leadBuffer.orgId, TEST_ORG_ID));
+  await db.delete(servedLeads).where(eq(servedLeads.orgId, TEST_ORG_ID));
+  // Clean up global tables in FK-safe order: lead_emails → leads
+  await sql`DELETE FROM lead_emails WHERE lead_id IN (SELECT id FROM leads)`;
+  await sql`DELETE FROM leads`;
 }
 
 export async function closeDb(): Promise<void> {
@@ -57,8 +23,8 @@ export async function closeDb(): Promise<void> {
 export function getAuthHeaders() {
   return {
     "x-api-key": TEST_API_KEY,
-    "x-app-id": TEST_APP_ID,
     "x-org-id": TEST_ORG_ID,
+    "x-user-id": TEST_USER_ID,
   };
 }
 
@@ -68,10 +34,8 @@ export async function seedBuffer(params: {
   brandId: string;
   leads: Array<{ email: string; externalId?: string; data?: unknown }>;
 }): Promise<void> {
-  if (!testOrgUuid) throw new Error("setupTestOrg() must be called first");
   for (const lead of params.leads) {
     await db.insert(leadBuffer).values({
-      organizationId: testOrgUuid,
       namespace: params.campaignId,
       campaignId: params.campaignId,
       email: lead.email,

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -65,7 +65,7 @@ describe("buffer", () => {
       vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValue(undefined);
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
       });
@@ -76,7 +76,6 @@ describe("buffer", () => {
     it("returns a lead with leadId and marks it served", async () => {
       vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValue({
         id: "buf-1",
-        organizationId: "org-1",
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "alice@acme.com",
@@ -85,7 +84,7 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        orgId: null,
+        orgId: "org-1",
         userId: null,
         createdAt: new Date(),
       });
@@ -108,7 +107,7 @@ describe("buffer", () => {
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
         parentRunId: "run-1",
@@ -132,7 +131,6 @@ describe("buffer", () => {
 
       vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValue({
         id: "buf-1",
-        organizationId: "org-1",
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "svitlana@hashtagweb3.com",
@@ -141,7 +139,7 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        orgId: null,
+        orgId: "org-1",
         userId: null,
         createdAt: new Date(),
       });
@@ -159,7 +157,7 @@ describe("buffer", () => {
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
       });
@@ -173,7 +171,6 @@ describe("buffer", () => {
       vi.mocked(db.query.leadBuffer.findFirst)
         .mockResolvedValueOnce({
           id: "buf-1",
-          organizationId: "org-1",
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "alice@acme.com",
@@ -182,13 +179,12 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          orgId: null,
+          orgId: "org-1",
           userId: null,
           createdAt: new Date(),
         })
         .mockResolvedValueOnce({
           id: "buf-2",
-          organizationId: "org-1",
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "bob@acme.com",
@@ -197,7 +193,7 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          orgId: null,
+          orgId: "org-1",
           userId: null,
           createdAt: new Date(),
         });
@@ -238,7 +234,7 @@ describe("buffer", () => {
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
       });
@@ -251,7 +247,6 @@ describe("buffer", () => {
     it("fills buffer from apolloSearchNext when buffer empty and searchParams provided", async () => {
       const newLeadRow = {
         id: "buf-new",
-        organizationId: "org-1",
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "new-lead@example.com",
@@ -260,7 +255,7 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        orgId: null,
+        orgId: "org-1",
         userId: null,
         createdAt: new Date(),
       };
@@ -293,12 +288,12 @@ describe("buffer", () => {
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-        keySource: "byok",
+
         searchParams: { description: "tech CEOs" },
-        appId: "my-app",
+
       });
 
       expect(result.found).toBe(true);
@@ -313,7 +308,6 @@ describe("buffer", () => {
       // merge the enriched data so pullNext returns complete lead.data.
       const enrichedLeadRow = {
         id: "buf-enriched",
-        organizationId: "org-1",
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "briannah@example.com",
@@ -329,7 +323,7 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        orgId: null,
+        orgId: "org-1",
         userId: null,
         createdAt: new Date(),
       };
@@ -379,12 +373,12 @@ describe("buffer", () => {
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-        keySource: "byok",
+
         searchParams: { description: "community directors" },
-        appId: "my-app",
+
       });
 
       expect(result.found).toBe(true);
@@ -411,12 +405,12 @@ describe("buffer", () => {
       });
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-        keySource: "byok",
+
         searchParams: { description: "impossible search" },
-        appId: "my-app",
+
       });
 
       expect(result.found).toBe(false);
@@ -426,7 +420,6 @@ describe("buffer", () => {
     it("uses cached enrichment instead of calling apolloEnrich", async () => {
       vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValue({
         id: "buf-1",
-        organizationId: "org-1",
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "",
@@ -435,7 +428,7 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        orgId: null,
+        orgId: "org-1",
         userId: null,
         createdAt: new Date(),
       });
@@ -469,7 +462,7 @@ describe("buffer", () => {
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
         runId: "run-1",
@@ -485,7 +478,6 @@ describe("buffer", () => {
       vi.mocked(db.query.leadBuffer.findFirst)
         .mockResolvedValueOnce({
           id: "buf-1",
-          organizationId: "org-1",
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "",
@@ -494,13 +486,12 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          orgId: null,
+          orgId: "org-1",
           userId: null,
           createdAt: new Date(),
         })
         .mockResolvedValueOnce({
           id: "buf-2",
-          organizationId: "org-1",
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "bob@acme.com",
@@ -509,7 +500,7 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          orgId: null,
+          orgId: "org-1",
           userId: null,
           createdAt: new Date(),
         });
@@ -535,7 +526,7 @@ describe("buffer", () => {
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
       });
@@ -548,7 +539,6 @@ describe("buffer", () => {
     it("passes workflowName to apolloSearchParams, apolloSearchNext, and apolloEnrich", async () => {
       const newLeadRow = {
         id: "buf-wf",
-        organizationId: "org-1",
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "",
@@ -557,7 +547,7 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        orgId: null,
+        orgId: "org-1",
         userId: null,
         createdAt: new Date(),
       };
@@ -596,12 +586,12 @@ describe("buffer", () => {
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-        keySource: "byok",
+
         searchParams: { description: "tech CEOs" },
-        appId: "my-app",
+
         workflowName: "cold-email-outreach",
       });
 
@@ -623,7 +613,6 @@ describe("buffer", () => {
     it("always includes email in data even when data.email is null (DAG reads data.email)", async () => {
       vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValue({
         id: "buf-1",
-        organizationId: "org-1",
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "torian@theorion.com",
@@ -632,7 +621,7 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        orgId: null,
+        orgId: "org-1",
         userId: null,
         createdAt: new Date(),
       });
@@ -650,7 +639,7 @@ describe("buffer", () => {
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
       });
@@ -668,7 +657,6 @@ describe("buffer", () => {
       vi.mocked(db.query.leadBuffer.findFirst)
         .mockResolvedValueOnce({
           id: "buf-no-email",
-          organizationId: "org-1",
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "",
@@ -677,7 +665,7 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          orgId: null,
+          orgId: "org-1",
           userId: null,
           createdAt: new Date(),
         })
@@ -689,7 +677,7 @@ describe("buffer", () => {
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
       });
@@ -703,7 +691,6 @@ describe("buffer", () => {
       vi.mocked(db.query.leadBuffer.findFirst)
         .mockResolvedValueOnce({
           id: "buf-no-email",
-          organizationId: "org-1",
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "",
@@ -712,13 +699,12 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          orgId: null,
+          orgId: "org-1",
           userId: null,
           createdAt: new Date(),
         })
         .mockResolvedValueOnce({
           id: "buf-good",
-          organizationId: "org-1",
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "good@acme.com",
@@ -727,7 +713,7 @@ describe("buffer", () => {
           status: "buffered",
           pushRunId: null,
           brandId: "brand-1",
-          orgId: null,
+          orgId: "org-1",
           userId: null,
           createdAt: new Date(),
         });
@@ -751,7 +737,7 @@ describe("buffer", () => {
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
       });
@@ -763,7 +749,6 @@ describe("buffer", () => {
     it("continues when email-gateway is unreachable (fallback)", async () => {
       vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValue({
         id: "buf-1",
-        organizationId: "org-1",
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "alice@acme.com",
@@ -772,7 +757,7 @@ describe("buffer", () => {
         status: "buffered",
         pushRunId: null,
         brandId: "brand-1",
-        orgId: null,
+        orgId: "org-1",
         userId: null,
         createdAt: new Date(),
       });
@@ -791,7 +776,7 @@ describe("buffer", () => {
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
 
       const result = await pullNext({
-        organizationId: "org-1",
+        orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
       });

--- a/tests/unit/dedup.test.ts
+++ b/tests/unit/dedup.test.ts
@@ -100,7 +100,7 @@ describe("dedup", () => {
       vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
 
       const result = await markServed({
-        organizationId: "org-1",
+        orgId: "org-1",
         namespace: "campaign-1",
         brandId: "brand-1",
         campaignId: "campaign-1",
@@ -121,7 +121,7 @@ describe("dedup", () => {
       vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
 
       const result = await markServed({
-        organizationId: "org-1",
+        orgId: "org-1",
         namespace: "campaign-1",
         brandId: "brand-1",
         campaignId: "campaign-1",
@@ -138,7 +138,7 @@ describe("dedup", () => {
       vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
 
       await markServed({
-        organizationId: "org-1",
+        orgId: "org-1",
         namespace: "campaign-1",
         brandId: "brand-1",
         campaignId: "campaign-1",

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -39,7 +39,6 @@ describe("schema validation", () => {
         campaignId: "c1",
         brandId: "b1",
         parentRunId: "r1",
-        keySource: "byok",
       });
       expect(result.success).toBe(true);
     });
@@ -49,7 +48,6 @@ describe("schema validation", () => {
         campaignId: "c1",
         brandId: "b1",
         parentRunId: "r1",
-        keySource: "byok",
         idempotencyKey: "run-123",
       });
       expect(result.success).toBe(true);
@@ -70,7 +68,6 @@ describe("schema validation", () => {
         campaignId: "c1",
         brandId: "b1",
         parentRunId: "r1",
-        keySource: "byok",
         workflowName: "cold-email-outreach",
       });
       expect(result.success).toBe(true);
@@ -84,24 +81,10 @@ describe("schema validation", () => {
         campaignId: "c1",
         brandId: "b1",
         parentRunId: "r1",
-        keySource: "app",
       });
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.workflowName).toBeUndefined();
-      }
-    });
-
-    it("accepts keySource 'platform'", () => {
-      const result = BufferNextRequestSchema.safeParse({
-        campaignId: "c1",
-        brandId: "b1",
-        parentRunId: "r1",
-        keySource: "platform",
-      });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.keySource).toBe("platform");
       }
     });
   });

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -100,7 +100,6 @@ describe("service client headers", () => {
       const { createRun } = await import("../../src/lib/runs-client.js");
       await createRun({
         orgId: "org-uuid-run",
-        appId: "test-app",
         serviceName: "lead-service",
         taskName: "test-task",
         userId: "user-uuid-run",
@@ -113,6 +112,7 @@ describe("service client headers", () => {
       expect(body.userId).toBe("user-uuid-run");
       expect(body).not.toHaveProperty("clerkOrgId");
       expect(body).not.toHaveProperty("clerkUserId");
+      expect(body).not.toHaveProperty("appId");
     });
   });
 });


### PR DESCRIPTION
## Summary
- **Remove appId** from all request bodies, query params, headers, and service client calls (key-service no longer accepts it)
- **Remove keySource** from `BufferNextRequestSchema` and all downstream Apollo/buffer calls (columbia no longer sends it; key resolution via `GET /keys/:provider/decrypt`)
- **Drop organizations and users tables** — client-service is now the single source of truth for identity; replace `organization_id` FK columns with `org_id` text columns
- **Auth middleware simplified** — reads `x-org-id` + `x-user-id` headers directly, no DB lookup
- **Add `costSource`** field to runs-client `addCosts` interface (runs-service now requires it)
- SQL migration `0008` handles data backfill from `organizations.external_id` → `org_id` and drops the mapping tables

## Test plan
- [x] TypeScript builds cleanly (`npm run build`)
- [x] All 67 unit tests pass (`npm run test:unit`)
- [x] OpenAPI spec regenerated from updated Zod schemas
- [ ] Integration tests pass after applying migration to test DB
- [ ] Deploy migration `0008` before deploying the new code (backfill + drop tables)
- [ ] Verify `POST /buffer/next` works without `keySource` or `appId` in request body
- [ ] Verify auth rejects requests missing `x-org-id` or `x-user-id` headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)