### PR TITLE
Add x-run-id as required header on all endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -445,10 +445,6 @@
             "type": "string",
             "minLength": 1
           },
-          "parentRunId": {
-            "type": "string",
-            "minLength": 1
-          },
           "searchParams": {
             "type": "object",
             "additionalProperties": {
@@ -468,8 +464,7 @@
         },
         "required": [
           "campaignId",
-          "brandId",
-          "parentRunId"
+          "brandId"
         ]
       },
       "CursorGetResponse": {
@@ -685,6 +680,15 @@
               "type": "string"
             },
             "description": "Internal user UUID from client-service"
+          },
+          {
+            "in": "header",
+            "name": "x-run-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The caller's run ID (used as parentRunId when creating this service's own run)"
           }
         ],
         "requestBody": {
@@ -755,6 +759,15 @@
             "description": "Internal user UUID from client-service"
           },
           {
+            "in": "header",
+            "name": "x-run-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The caller's run ID (used as parentRunId when creating this service's own run)"
+          },
+          {
             "schema": {
               "type": "string"
             },
@@ -808,6 +821,15 @@
               "type": "string"
             },
             "description": "Internal user UUID from client-service"
+          },
+          {
+            "in": "header",
+            "name": "x-run-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The caller's run ID (used as parentRunId when creating this service's own run)"
           },
           {
             "schema": {
@@ -884,6 +906,15 @@
               "type": "string"
             },
             "description": "Internal user UUID from client-service"
+          },
+          {
+            "in": "header",
+            "name": "x-run-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The caller's run ID (used as parentRunId when creating this service's own run)"
           },
           {
             "in": "query",
@@ -966,6 +997,15 @@
               "type": "string"
             },
             "description": "Internal user UUID from client-service"
+          },
+          {
+            "in": "header",
+            "name": "x-run-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The caller's run ID (used as parentRunId when creating this service's own run)"
           },
           {
             "in": "query",

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -189,7 +189,6 @@ export async function pullNext(params: {
   orgId: string;
   campaignId: string;
   brandId: string;
-  parentRunId?: string | null;
   runId?: string | null;
   searchParams?: ApolloSearchParams;
   userId?: string | null;
@@ -366,7 +365,6 @@ export async function pullNext(params: {
       leadId,
       externalId: row.externalId,
       metadata: enrichedData,
-      parentRunId: params.parentRunId ?? null,
       runId: params.runId ?? null,
       userId: row.userId,
     });

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -50,7 +50,6 @@ export async function markServed(params: {
   leadId?: string | null;
   externalId?: string | null;
   metadata?: unknown;
-  parentRunId?: string | null;
   runId?: string | null;
   userId?: string | null;
 }): Promise<{ inserted: boolean }> {
@@ -63,7 +62,6 @@ export async function markServed(params: {
       leadId: params.leadId ?? null,
       externalId: params.externalId ?? null,
       metadata: params.metadata ?? null,
-      parentRunId: params.parentRunId ?? null,
       runId: params.runId ?? null,
       brandId: params.brandId,
       campaignId: params.campaignId,

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -3,6 +3,7 @@ import { Request, Response, NextFunction } from "express";
 export interface AuthenticatedRequest extends Request {
   orgId?: string;
   userId?: string;
+  runId?: string;
 }
 
 export async function authenticate(
@@ -18,13 +19,15 @@ export async function authenticate(
 
     const orgId = req.headers["x-org-id"] as string;
     const userId = req.headers["x-user-id"] as string;
+    const runId = req.headers["x-run-id"] as string;
 
-    if (!orgId || !userId) {
-      return res.status(400).json({ error: "x-org-id and x-user-id headers required" });
+    if (!orgId || !userId || !runId) {
+      return res.status(400).json({ error: "x-org-id, x-user-id, and x-run-id headers required" });
     }
 
     req.orgId = orgId;
     req.userId = userId;
+    req.runId = runId;
     next();
   } catch (error) {
     console.error("[auth] Error:", error);

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -32,7 +32,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
   }
 
   try {
-    const { campaignId, brandId, parentRunId, searchParams, userId, workflowName, idempotencyKey } = parsed.data;
+    const { campaignId, brandId, searchParams, userId, workflowName, idempotencyKey } = parsed.data;
 
     // Idempotency: return cached response if this key was already processed
     if (idempotencyKey) {
@@ -45,12 +45,12 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       }
     }
 
-    // Create child run for traceability
+    // Create child run for traceability (x-run-id from caller becomes our parentRunId)
     const childRun = await createRun({
       orgId: req.orgId!,
       serviceName: "lead-service",
       taskName: "lead-serve",
-      parentRunId,
+      parentRunId: req.runId!,
       userId: userId ?? req.userId,
       brandId,
       campaignId,
@@ -62,7 +62,6 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       orgId: req.orgId!,
       campaignId,
       brandId,
-      parentRunId,
       runId: serveRunId,
       searchParams: searchParams ?? undefined,
       userId: userId ?? req.userId ?? null,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -36,6 +36,13 @@ const AuthHeaders = [
     schema: { type: "string" as const },
     description: "Internal user UUID from client-service",
   },
+  {
+    in: "header" as const,
+    name: "x-run-id",
+    required: true,
+    schema: { type: "string" as const },
+    description: "The caller's run ID (used as parentRunId when creating this service's own run)",
+  },
 ];
 
 // --- Health ---
@@ -152,7 +159,6 @@ export const BufferNextRequestSchema = z
   .object({
     campaignId: z.string().min(1),
     brandId: z.string().min(1),
-    parentRunId: z.string().min(1),
     searchParams: z.record(z.string(), z.unknown()).optional(),
     userId: z.string().optional(),
     workflowName: z.string().optional(),

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -50,7 +50,7 @@ describe("API Integration Tests", () => {
     it("rejects requests without API key", async () => {
       const res = await request(app)
         .post("/buffer/next")
-        .send({ campaignId: "c1", brandId: "b1", parentRunId: "r1" });
+        .send({ campaignId: "c1", brandId: "b1" });
 
       expect(res.status).toBe(401);
     });
@@ -61,7 +61,8 @@ describe("API Integration Tests", () => {
         .set("x-api-key", "wrong-key")
         .set("x-org-id", "test")
         .set("x-user-id", "test")
-        .send({ campaignId: "c1", brandId: "b1", parentRunId: "r1" });
+        .set("x-run-id", "test")
+        .send({ campaignId: "c1", brandId: "b1" });
 
       expect(res.status).toBe(401);
     });
@@ -71,7 +72,19 @@ describe("API Integration Tests", () => {
         .post("/buffer/next")
         .set("x-api-key", TEST_API_KEY)
         .set("x-org-id", "test")
-        .send({ campaignId: "c1", brandId: "b1", parentRunId: "r1" });
+        .set("x-run-id", "test")
+        .send({ campaignId: "c1", brandId: "b1" });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects requests without x-run-id header", async () => {
+      const res = await request(app)
+        .post("/buffer/next")
+        .set("x-api-key", TEST_API_KEY)
+        .set("x-org-id", "test")
+        .set("x-user-id", "test")
+        .send({ campaignId: "c1", brandId: "b1" });
 
       expect(res.status).toBe(400);
     });
@@ -88,7 +101,7 @@ describe("API Integration Tests", () => {
       const res = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-b", brandId: "brand-b", parentRunId: "test-run-next-b" });
+        .send({ campaignId: "campaign-b", brandId: "brand-b" });
 
       expect(res.status).toBe(200);
       expect(res.body.found).toBe(true);
@@ -100,7 +113,7 @@ describe("API Integration Tests", () => {
       const res = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-empty", brandId: "brand-empty", parentRunId: "test-run-next-empty" });
+        .send({ campaignId: "campaign-empty", brandId: "brand-empty" });
 
       expect(res.status).toBe(200);
       expect(res.body.found).toBe(false);
@@ -110,7 +123,7 @@ describe("API Integration Tests", () => {
       const res = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-x", brandId: "", parentRunId: "test-run" });
+        .send({ campaignId: "campaign-x", brandId: "" });
 
       expect(res.status).toBe(400);
       expect(res.body.details.fieldErrors.brandId).toBeDefined();
@@ -131,7 +144,6 @@ describe("API Integration Tests", () => {
         .send({
           campaignId: "campaign-wf-next",
           brandId: "brand-wf-next",
-          parentRunId: "test-run-wf-next",
           workflowName: "cold-email-outreach",
         });
 
@@ -181,7 +193,7 @@ describe("API Integration Tests", () => {
       const res = await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-c", brandId: "brand-c", parentRunId: "test-run-next-c" });
+        .send({ campaignId: "campaign-c", brandId: "brand-c" });
 
       expect(res.body.found).toBe(true);
       expect(res.body.lead.email).toBe("fresh@example.com");
@@ -207,7 +219,6 @@ describe("API Integration Tests", () => {
         .send({
           campaignId: "campaign-idem-1",
           brandId: "brand-idem-1",
-          parentRunId: "test-run-idem-1",
           idempotencyKey: "run-idem-1",
         });
 
@@ -223,7 +234,6 @@ describe("API Integration Tests", () => {
         .send({
           campaignId: "campaign-idem-1",
           brandId: "brand-idem-1",
-          parentRunId: "test-run-idem-1",
           idempotencyKey: "run-idem-1",
         });
 
@@ -249,7 +259,6 @@ describe("API Integration Tests", () => {
         .send({
           campaignId: "campaign-idem-2",
           brandId: "brand-idem-2",
-          parentRunId: "test-run-idem-2a",
           idempotencyKey: "run-idem-2",
         });
 
@@ -263,7 +272,6 @@ describe("API Integration Tests", () => {
         .send({
           campaignId: "campaign-idem-2",
           brandId: "brand-idem-2",
-          parentRunId: "test-run-idem-2a",
           idempotencyKey: "run-idem-2",
         });
 
@@ -274,7 +282,6 @@ describe("API Integration Tests", () => {
         .send({
           campaignId: "campaign-idem-2",
           brandId: "brand-idem-2",
-          parentRunId: "test-run-idem-2b",
           idempotencyKey: "run-idem-2b",
         });
 
@@ -290,7 +297,6 @@ describe("API Integration Tests", () => {
         .send({
           campaignId: "campaign-idem-empty",
           brandId: "brand-idem-empty",
-          parentRunId: "test-run-idem-empty",
           idempotencyKey: "run-idem-empty",
         });
 
@@ -310,7 +316,6 @@ describe("API Integration Tests", () => {
         .send({
           campaignId: "campaign-idem-empty",
           brandId: "brand-idem-empty",
-          parentRunId: "test-run-idem-empty",
           idempotencyKey: "run-idem-empty",
         });
 
@@ -330,7 +335,6 @@ describe("API Integration Tests", () => {
         .send({
           campaignId: "campaign-idem-compat",
           brandId: "brand-idem-compat",
-          parentRunId: "test-run-idem-compat",
         });
 
       expect(res.status).toBe(200);
@@ -373,7 +377,7 @@ describe("API Integration Tests", () => {
       await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-leads", brandId: "brand-leads", parentRunId: "test-run-next-leads" });
+        .send({ campaignId: "campaign-leads", brandId: "brand-leads" });
 
       // Query GET /leads
       const res = await request(app)
@@ -413,7 +417,7 @@ describe("API Integration Tests", () => {
       await request(app)
         .post("/buffer/next")
         .set(getAuthHeaders())
-        .send({ campaignId: "campaign-leads-empty", brandId: "brand-leads-empty", parentRunId: "test-run-next-leads-empty" });
+        .send({ campaignId: "campaign-leads-empty", brandId: "brand-leads-empty" });
 
       const res = await request(app)
         .get("/leads?brandId=brand-leads-empty&campaignId=campaign-leads-empty")

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 export const TEST_API_KEY = "test-api-key-12345";
 export const TEST_ORG_ID = "test-org-uuid-integration";
 export const TEST_USER_ID = "test-user-uuid-integration";
+export const TEST_RUN_ID = "test-run-uuid-integration";
 
 export async function cleanupTestData(): Promise<void> {
   await db.delete(idempotencyCache).where(eq(idempotencyCache.orgId, TEST_ORG_ID));
@@ -25,6 +26,7 @@ export function getAuthHeaders() {
     "x-api-key": TEST_API_KEY,
     "x-org-id": TEST_ORG_ID,
     "x-user-id": TEST_USER_ID,
+    "x-run-id": TEST_RUN_ID,
   };
 }
 

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -110,7 +110,6 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-        parentRunId: "run-1",
         runId: "child-run-1",
       });
 

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -7,7 +7,6 @@ describe("schema validation", () => {
       const result = BufferNextRequestSchema.safeParse({
         campaignId: "c1",
         brandId: "",
-        parentRunId: "r1",
       });
       expect(result.success).toBe(false);
       if (!result.success) {
@@ -20,16 +19,6 @@ describe("schema validation", () => {
       const result = BufferNextRequestSchema.safeParse({
         campaignId: "",
         brandId: "b1",
-        parentRunId: "r1",
-      });
-      expect(result.success).toBe(false);
-    });
-
-    it("rejects empty parentRunId", () => {
-      const result = BufferNextRequestSchema.safeParse({
-        campaignId: "c1",
-        brandId: "b1",
-        parentRunId: "",
       });
       expect(result.success).toBe(false);
     });
@@ -38,7 +27,6 @@ describe("schema validation", () => {
       const result = BufferNextRequestSchema.safeParse({
         campaignId: "c1",
         brandId: "b1",
-        parentRunId: "r1",
       });
       expect(result.success).toBe(true);
     });
@@ -47,7 +35,6 @@ describe("schema validation", () => {
       const result = BufferNextRequestSchema.safeParse({
         campaignId: "c1",
         brandId: "b1",
-        parentRunId: "r1",
         idempotencyKey: "run-123",
       });
       expect(result.success).toBe(true);
@@ -57,7 +44,6 @@ describe("schema validation", () => {
       const result = BufferNextRequestSchema.safeParse({
         campaignId: "c1",
         brandId: "b1",
-        parentRunId: "r1",
         idempotencyKey: "",
       });
       expect(result.success).toBe(false);
@@ -67,7 +53,6 @@ describe("schema validation", () => {
       const result = BufferNextRequestSchema.safeParse({
         campaignId: "c1",
         brandId: "b1",
-        parentRunId: "r1",
         workflowName: "cold-email-outreach",
       });
       expect(result.success).toBe(true);
@@ -80,7 +65,6 @@ describe("schema validation", () => {
       const result = BufferNextRequestSchema.safeParse({
         campaignId: "c1",
         brandId: "b1",
-        parentRunId: "r1",
       });
       expect(result.success).toBe(true);
       if (result.success) {


### PR DESCRIPTION
## Summary
- Added `x-run-id` as a required header on all authenticated endpoints (alongside `x-org-id` and `x-user-id`)
- The caller's run ID from the header is used as `parentRunId` when creating this service's own run in runs-service
- Removed `parentRunId` from `BufferNextRequestSchema` body — it now comes exclusively via the `x-run-id` header
- Stopped writing `parentRunId` to `servedLeads` table — the parent-child link lives only in runs-service

## Test plan
- [x] All 66 unit tests pass
- [x] Auth middleware validates `x-run-id` presence (returns 400 if missing)
- [x] New test case added: "rejects requests without x-run-id header"
- [x] OpenAPI spec regenerated with `x-run-id` in all authenticated endpoint parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)