### PR TITLE
Move apollo-service run context from body to headers

### DIFF
--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -144,16 +144,16 @@ export async function apolloSearch(
   try {
     const headers: Record<string, string> = {};
     if (options?.orgId) headers["x-org-id"] = options.orgId;
+    if (options?.runId) headers["x-run-id"] = options.runId;
+    if (options?.brandId) headers["x-brand-id"] = options.brandId;
+    if (options?.campaignId) headers["x-campaign-id"] = options.campaignId;
+    if (options?.workflowName) headers["x-workflow-name"] = options.workflowName;
 
     const raw = await callApolloService<ApolloSearchRawResponse>("/search", {
       method: "POST",
       body: {
         ...params,
         page,
-        ...(options?.runId ? { runId: options.runId } : {}),
-        ...(options?.brandId ? { brandId: options.brandId } : {}),
-        ...(options?.campaignId ? { campaignId: options.campaignId } : {}),
-        ...(options?.workflowName ? { workflowName: options.workflowName } : {}),
       },
       headers,
     });
@@ -192,14 +192,13 @@ export async function apolloSearchNext(options: {
   try {
     const headers: Record<string, string> = {};
     if (options.orgId) headers["x-org-id"] = options.orgId;
+    if (options.runId) headers["x-run-id"] = options.runId;
+    headers["x-brand-id"] = options.brandId;
+    headers["x-campaign-id"] = options.campaignId;
+    if (options.workflowName) headers["x-workflow-name"] = options.workflowName;
 
-    const body: Record<string, unknown> = {
-      campaignId: options.campaignId,
-      brandId: options.brandId,
-    };
+    const body: Record<string, unknown> = {};
     if (options.searchParams) body.searchParams = options.searchParams;
-    if (options.runId) body.runId = options.runId;
-    if (options.workflowName) body.workflowName = options.workflowName;
 
     return await callApolloService<ApolloSearchNextResult>("/search/next", {
       method: "POST",
@@ -230,15 +229,15 @@ export async function apolloSearchParams(options: {
 }): Promise<ApolloSearchParamsResult> {
   const headers: Record<string, string> = {};
   if (options.orgId) headers["x-org-id"] = options.orgId;
+  headers["x-run-id"] = options.runId;
+  headers["x-brand-id"] = options.brandId;
+  headers["x-campaign-id"] = options.campaignId;
+  if (options.workflowName) headers["x-workflow-name"] = options.workflowName;
 
   return callApolloService<ApolloSearchParamsResult>("/search/params", {
     method: "POST",
     body: {
       context: options.context,
-      runId: options.runId,
-      brandId: options.brandId,
-      campaignId: options.campaignId,
-      ...(options.workflowName ? { workflowName: options.workflowName } : {}),
     },
     headers,
   });
@@ -287,15 +286,15 @@ export async function apolloEnrich(
   try {
     const headers: Record<string, string> = {};
     if (options?.orgId) headers["x-org-id"] = options.orgId;
+    if (options?.runId) headers["x-run-id"] = options.runId;
+    if (options?.brandId) headers["x-brand-id"] = options.brandId;
+    if (options?.campaignId) headers["x-campaign-id"] = options.campaignId;
+    if (options?.workflowName) headers["x-workflow-name"] = options.workflowName;
 
     const result = await callApolloService<ApolloEnrichResult>("/enrich", {
       method: "POST",
       body: {
         apolloPersonId: personId,
-        ...(options?.runId ? { runId: options.runId } : {}),
-        ...(options?.brandId ? { brandId: options.brandId } : {}),
-        ...(options?.campaignId ? { campaignId: options.campaignId } : {}),
-        ...(options?.workflowName ? { workflowName: options.workflowName } : {}),
       },
       headers,
     });

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -49,6 +49,26 @@ describe("service client headers", () => {
       expect(opts.headers).not.toHaveProperty("x-clerk-org-id");
     });
 
+    it("sends run context as headers (not body) for apolloSearch", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ people: [], pagination: { page: 1, totalPages: 1, totalEntries: 0 } }));
+
+      const { apolloSearch } = await import("../../src/lib/apollo-client.js");
+      await apolloSearch({ personTitles: ["CEO"] }, 1, {
+        orgId: "org-1", runId: "run-1", brandId: "brand-1", campaignId: "camp-1", workflowName: "wf-1",
+      });
+
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-run-id"]).toBe("run-1");
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
+      expect(opts.headers["x-campaign-id"]).toBe("camp-1");
+      expect(opts.headers["x-workflow-name"]).toBe("wf-1");
+      const body = JSON.parse(opts.body);
+      expect(body).not.toHaveProperty("runId");
+      expect(body).not.toHaveProperty("brandId");
+      expect(body).not.toHaveProperty("campaignId");
+      expect(body).not.toHaveProperty("workflowName");
+    });
+
     it("sends x-org-id header for apolloEnrich", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ person: { id: "p1" } }));
 
@@ -59,6 +79,26 @@ describe("service client headers", () => {
       const [, opts] = fetchSpy.mock.calls[0];
       expect(opts.headers["x-org-id"]).toBe("org-uuid-789");
       expect(opts.headers).not.toHaveProperty("x-clerk-org-id");
+    });
+
+    it("sends run context as headers (not body) for apolloEnrich", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ person: { id: "p1" } }));
+
+      const { apolloEnrich } = await import("../../src/lib/apollo-client.js");
+      await apolloEnrich("person-123", {
+        orgId: "org-1", runId: "run-1", brandId: "brand-1", campaignId: "camp-1", workflowName: "wf-1",
+      });
+
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-run-id"]).toBe("run-1");
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
+      expect(opts.headers["x-campaign-id"]).toBe("camp-1");
+      expect(opts.headers["x-workflow-name"]).toBe("wf-1");
+      const body = JSON.parse(opts.body);
+      expect(body).not.toHaveProperty("runId");
+      expect(body).not.toHaveProperty("brandId");
+      expect(body).not.toHaveProperty("campaignId");
+      expect(body).not.toHaveProperty("workflowName");
     });
   });
 


### PR DESCRIPTION
## Summary
- Migrates `runId`, `brandId`, `campaignId`, and `workflowName` from request body to HTTP headers (`x-run-id`, `x-brand-id`, `x-campaign-id`, `x-workflow-name`) in all apollo-client calls
- Affected functions: `apolloSearch`, `apolloSearchNext`, `apolloSearchParams`, `apolloEnrich`
- `fetchApolloStats` unchanged (its body fields are query filters, not run context)
- Adds regression tests verifying headers are sent and body is clean

## Test plan
- [x] All 68 unit tests pass
- [x] New tests verify run-context fields appear in headers, not body, for `apolloSearch` and `apolloEnrich`
- [x] TypeScript build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)