### PR TITLE
Forward required headers to all downstream services

### DIFF
--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -139,11 +139,12 @@ interface ApolloSearchRawResponse {
 export async function apolloSearch(
   params: ApolloSearchParams,
   page: number = 1,
-  options?: { runId?: string | null; orgId?: string | null; brandId?: string; campaignId?: string; workflowName?: string }
+  options?: { runId?: string | null; orgId?: string | null; userId?: string | null; brandId?: string; campaignId?: string; workflowName?: string }
 ): Promise<ApolloSearchResult | null> {
   try {
     const headers: Record<string, string> = {};
     if (options?.orgId) headers["x-org-id"] = options.orgId;
+    if (options?.userId) headers["x-user-id"] = options.userId;
     if (options?.runId) headers["x-run-id"] = options.runId;
     if (options?.brandId) headers["x-brand-id"] = options.brandId;
     if (options?.campaignId) headers["x-campaign-id"] = options.campaignId;
@@ -187,11 +188,13 @@ export async function apolloSearchNext(options: {
   searchParams?: ApolloSearchParams;
   runId?: string | null;
   orgId?: string | null;
+  userId?: string | null;
   workflowName?: string;
 }): Promise<ApolloSearchNextResult | null> {
   try {
     const headers: Record<string, string> = {};
     if (options.orgId) headers["x-org-id"] = options.orgId;
+    if (options.userId) headers["x-user-id"] = options.userId;
     if (options.runId) headers["x-run-id"] = options.runId;
     headers["x-brand-id"] = options.brandId;
     headers["x-campaign-id"] = options.campaignId;
@@ -225,10 +228,12 @@ export async function apolloSearchParams(options: {
   brandId: string;
   campaignId: string;
   orgId?: string | null;
+  userId?: string | null;
   workflowName?: string;
 }): Promise<ApolloSearchParamsResult> {
   const headers: Record<string, string> = {};
   if (options.orgId) headers["x-org-id"] = options.orgId;
+  if (options.userId) headers["x-user-id"] = options.userId;
   headers["x-run-id"] = options.runId;
   headers["x-brand-id"] = options.brandId;
   headers["x-campaign-id"] = options.campaignId;
@@ -254,11 +259,14 @@ export interface ApolloStats {
 
 export async function fetchApolloStats(
   filters: { runIds?: string[]; brandId?: string; campaignId?: string },
-  orgId?: string | null
+  orgId?: string | null,
+  context?: { userId?: string; runId?: string }
 ): Promise<ApolloStats> {
   try {
     const headers: Record<string, string> = {};
     if (orgId) headers["x-org-id"] = orgId;
+    if (context?.userId) headers["x-user-id"] = context.userId;
+    if (context?.runId) headers["x-run-id"] = context.runId;
 
     const result = await callApolloService<{ stats: ApolloStats }>("/stats", {
       method: "POST",
@@ -281,11 +289,12 @@ export interface ApolloEnrichResult {
 
 export async function apolloEnrich(
   personId: string,
-  options?: { runId?: string | null; orgId?: string | null; brandId?: string; campaignId?: string; workflowName?: string }
+  options?: { runId?: string | null; orgId?: string | null; userId?: string | null; brandId?: string; campaignId?: string; workflowName?: string }
 ): Promise<ApolloEnrichResult | null> {
   try {
     const headers: Record<string, string> = {};
     if (options?.orgId) headers["x-org-id"] = options.orgId;
+    if (options?.userId) headers["x-user-id"] = options.userId;
     if (options?.runId) headers["x-run-id"] = options.runId;
     if (options?.brandId) headers["x-brand-id"] = options.brandId;
     if (options?.campaignId) headers["x-campaign-id"] = options.campaignId;

--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -14,7 +14,8 @@ export interface BrandDetails {
 
 export async function fetchBrand(
   brandId: string,
-  orgId?: string | null
+  orgId?: string | null,
+  context?: { userId?: string; runId?: string }
 ): Promise<BrandDetails | null> {
   try {
     const headers: Record<string, string> = {
@@ -22,6 +23,8 @@ export async function fetchBrand(
       "X-API-Key": BRAND_SERVICE_API_KEY,
     };
     if (orgId) headers["x-org-id"] = orgId;
+    if (context?.userId) headers["x-user-id"] = context.userId;
+    if (context?.runId) headers["x-run-id"] = context.runId;
 
     const url = new URL(`${BRAND_SERVICE_URL}/brands/${brandId}`);
     if (orgId) url.searchParams.set("orgId", orgId);

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -29,10 +29,12 @@ async function fillBufferFromSearch(params: {
   userId?: string | null;
   workflowName?: string;
 }): Promise<{ filled: number }> {
+  const serviceContext = { userId: params.userId ?? undefined, runId: params.pushRunId ?? undefined };
+
   // Fetch campaign + brand details in parallel for rich LLM context
   const [campaign, brand] = await Promise.all([
-    fetchCampaign(params.campaignId, params.orgId),
-    fetchBrand(params.brandId, params.orgId),
+    fetchCampaign(params.campaignId, params.orgId, serviceContext),
+    fetchBrand(params.brandId, params.orgId, serviceContext),
   ]);
 
   // Build rich context string from campaign, brand, and raw searchParams
@@ -63,6 +65,7 @@ async function fillBufferFromSearch(params: {
     brandId: params.brandId,
     campaignId: params.campaignId,
     orgId: params.orgId,
+    userId: params.userId,
     workflowName: params.workflowName,
   });
 
@@ -76,6 +79,7 @@ async function fillBufferFromSearch(params: {
       searchParams: validatedParams,
       runId: params.pushRunId,
       orgId: params.orgId,
+      userId: params.userId,
       workflowName: params.workflowName,
     });
 
@@ -142,7 +146,11 @@ async function fillBufferFromSearch(params: {
 
     const deliveredMap =
       itemsWithEmails.length > 0
-        ? await checkDelivered(params.brandId, params.campaignId, itemsWithEmails)
+        ? await checkDelivered(params.brandId, params.campaignId, itemsWithEmails, {
+            orgId: params.orgId,
+            userId: params.userId ?? undefined,
+            runId: params.pushRunId ?? undefined,
+          })
         : new Map<string, boolean>();
 
     let pageFilled = 0;
@@ -272,6 +280,7 @@ export async function pullNext(params: {
         const enrichResult = await apolloEnrich(row.externalId, {
           runId: params.runId,
           orgId: params.orgId,
+          userId: params.userId,
           brandId: params.brandId,
           campaignId: params.campaignId,
           workflowName: params.workflowName,
@@ -346,7 +355,11 @@ export async function pullNext(params: {
     // Check delivery status via email-gateway
     const deliveredMap = await checkDelivered(params.brandId, params.campaignId, [
       { leadId, email },
-    ]);
+    ], {
+      orgId: params.orgId,
+      userId: params.userId ?? undefined,
+      runId: params.runId ?? undefined,
+    });
 
     if (deliveredMap.get(email)) {
       await db

--- a/src/lib/campaign-client.ts
+++ b/src/lib/campaign-client.ts
@@ -11,7 +11,8 @@ export interface CampaignDetails {
 
 export async function fetchCampaign(
   campaignId: string,
-  orgId?: string | null
+  orgId?: string | null,
+  context?: { userId?: string; runId?: string }
 ): Promise<CampaignDetails | null> {
   try {
     const headers: Record<string, string> = {
@@ -19,6 +20,8 @@ export async function fetchCampaign(
       "X-API-Key": CAMPAIGN_SERVICE_API_KEY,
     };
     if (orgId) headers["x-org-id"] = orgId;
+    if (context?.userId) headers["x-user-id"] = context.userId;
+    if (context?.runId) headers["x-run-id"] = context.runId;
 
     const response = await fetch(`${CAMPAIGN_SERVICE_URL}/campaigns/${campaignId}`, {
       headers,

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -15,11 +15,12 @@ import {
 export async function checkDelivered(
   brandId: string,
   campaignId: string,
-  items: DeliveryStatusItem[]
+  items: DeliveryStatusItem[],
+  context?: { orgId?: string; userId?: string; runId?: string }
 ): Promise<Map<string, boolean>> {
   const result = new Map<string, boolean>();
 
-  const statusResponse = await checkDeliveryStatus(brandId, campaignId, items);
+  const statusResponse = await checkDeliveryStatus(brandId, campaignId, items, context);
 
   if (statusResponse) {
     for (const sr of statusResponse.results) {

--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -52,18 +52,24 @@ export interface DeliveryStatusResponse {
 export async function checkDeliveryStatus(
   brandId: string,
   campaignId: string | undefined,
-  items: DeliveryStatusItem[]
+  items: DeliveryStatusItem[],
+  context?: { orgId?: string; userId?: string; runId?: string }
 ): Promise<DeliveryStatusResponse | null> {
   try {
     const body: Record<string, unknown> = { brandId, items };
     if (campaignId) body.campaignId = campaignId;
 
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-API-Key": EMAIL_GATEWAY_SERVICE_API_KEY,
+    };
+    if (context?.orgId) headers["x-org-id"] = context.orgId;
+    if (context?.userId) headers["x-user-id"] = context.userId;
+    if (context?.runId) headers["x-run-id"] = context.runId;
+
     const response = await fetch(`${EMAIL_GATEWAY_SERVICE_URL}/status`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-API-Key": EMAIL_GATEWAY_SERVICE_API_KEY,
-      },
+      headers,
       body: JSON.stringify(body),
     });
 

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -4,14 +4,16 @@ const RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY || "";
 async function callRunsService(path: string, options: {
   method?: string;
   body?: unknown;
+  headers?: Record<string, string>;
 } = {}): Promise<unknown> {
-  const { method = "GET", body } = options;
+  const { method = "GET", body, headers: extraHeaders } = options;
 
   const response = await fetch(`${RUNS_SERVICE_URL}/v1${path}`, {
     method,
     headers: {
       "Content-Type": "application/json",
       "X-API-Key": RUNS_SERVICE_API_KEY,
+      ...extraHeaders,
     },
     body: body ? JSON.stringify(body) : undefined,
   });
@@ -34,38 +36,57 @@ export async function createRun(params: {
   campaignId?: string;
   workflowName?: string;
 }): Promise<{ id: string }> {
+  const headers: Record<string, string> = {
+    "x-org-id": params.orgId,
+  };
+  if (params.userId) headers["x-user-id"] = params.userId;
+  if (params.parentRunId) headers["x-run-id"] = params.parentRunId;
+
   return callRunsService("/runs", {
     method: "POST",
     body: {
-      orgId: params.orgId,
       serviceName: params.serviceName,
       taskName: params.taskName,
-      parentRunId: params.parentRunId,
-      userId: params.userId,
       brandId: params.brandId,
       campaignId: params.campaignId,
       workflowName: params.workflowName,
     },
+    headers,
   }) as Promise<{ id: string }>;
 }
 
 export async function updateRun(
   runId: string,
-  status: "completed" | "failed"
+  status: "completed" | "failed",
+  context?: { orgId?: string; userId?: string }
 ): Promise<void> {
+  const headers: Record<string, string> = {};
+  if (context?.orgId) headers["x-org-id"] = context.orgId;
+  if (context?.userId) headers["x-user-id"] = context.userId;
+  headers["x-run-id"] = runId;
+
   await callRunsService(`/runs/${runId}`, {
     method: "PATCH",
     body: { status },
+    headers,
   });
 }
 
 export async function addCosts(
   runId: string,
-  items: Array<{ costName: string; quantity: number; costSource: "platform" | "org" }>
+  items: Array<{ costName: string; quantity: number; costSource: "platform" | "org" }>,
+  context?: { orgId?: string; userId?: string }
 ): Promise<void> {
   if (items.length === 0) return;
+
+  const headers: Record<string, string> = {};
+  if (context?.orgId) headers["x-org-id"] = context.orgId;
+  if (context?.userId) headers["x-user-id"] = context.userId;
+  headers["x-run-id"] = runId;
+
   await callRunsService(`/runs/${runId}/costs`, {
     method: "POST",
     body: { items },
+    headers,
   });
 }

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -84,7 +84,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
     }
 
     try {
-      await updateRun(serveRunId, "completed");
+      await updateRun(serveRunId, "completed", { orgId: req.orgId, userId: req.userId });
     } catch (err) {
       console.error("[buffer/next] Failed to update run:", err);
     }

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -54,7 +54,7 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
     const [servedResult, bufferRows, apollo] = await Promise.all([
       db.select({ count: count() }).from(servedLeads).where(and(...servedConditions)).then(([r]) => r),
       db.select({ status: leadBuffer.status, count: count() }).from(leadBuffer).where(and(...bufferConditions)).groupBy(leadBuffer.status),
-      fetchApolloStats(apolloFilters as Parameters<typeof fetchApolloStats>[0], orgIdStr ?? req.orgId),
+      fetchApolloStats(apolloFilters as Parameters<typeof fetchApolloStats>[0], orgIdStr ?? req.orgId, { userId: req.userId, runId: req.runId }),
     ]);
 
     const bufferByStatus = Object.fromEntries(bufferRows.map((r) => [r.status, r.count]));

--- a/tests/unit/dedup.test.ts
+++ b/tests/unit/dedup.test.ts
@@ -41,7 +41,7 @@ describe("dedup", () => {
       expect(result.get("alice@acme.com")).toBe(true);
       expect(checkDeliveryStatus).toHaveBeenCalledWith("brand-1", "campaign-1", [
         { leadId: "lead-1", email: "alice@acme.com" },
-      ]);
+      ], undefined);
     });
 
     it("returns delivered=false for emails not yet delivered", async () => {

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -23,29 +23,32 @@ function jsonResponse(body: unknown, status = 200) {
 
 describe("service client headers", () => {
   describe("apollo-client", () => {
-    it("sends x-org-id header (not x-clerk-org-id) for fetchApolloStats", async () => {
+    it("sends x-org-id and x-user-id headers for fetchApolloStats", async () => {
       fetchSpy.mockReturnValue(
         jsonResponse({ stats: { enrichedLeadsCount: 0, searchCount: 0, fetchedPeopleCount: 0, totalMatchingPeople: 0 } })
       );
 
       const { fetchApolloStats } = await import("../../src/lib/apollo-client.js");
-      await fetchApolloStats({}, "org-uuid-123");
+      await fetchApolloStats({}, "org-uuid-123", { userId: "user-1", runId: "run-1" });
 
       expect(fetchSpy).toHaveBeenCalledOnce();
       const [, opts] = fetchSpy.mock.calls[0];
       expect(opts.headers["x-org-id"]).toBe("org-uuid-123");
+      expect(opts.headers["x-user-id"]).toBe("user-1");
+      expect(opts.headers["x-run-id"]).toBe("run-1");
       expect(opts.headers).not.toHaveProperty("x-clerk-org-id");
     });
 
-    it("sends x-org-id header for apolloSearch", async () => {
+    it("sends x-org-id and x-user-id headers for apolloSearch", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ people: [], pagination: { page: 1, totalPages: 1, totalEntries: 0 } }));
 
       const { apolloSearch } = await import("../../src/lib/apollo-client.js");
-      await apolloSearch({ personTitles: ["CEO"] }, 1, { orgId: "org-uuid-456" });
+      await apolloSearch({ personTitles: ["CEO"] }, 1, { orgId: "org-uuid-456", userId: "user-456" });
 
       expect(fetchSpy).toHaveBeenCalledOnce();
       const [, opts] = fetchSpy.mock.calls[0];
       expect(opts.headers["x-org-id"]).toBe("org-uuid-456");
+      expect(opts.headers["x-user-id"]).toBe("user-456");
       expect(opts.headers).not.toHaveProperty("x-clerk-org-id");
     });
 
@@ -102,39 +105,72 @@ describe("service client headers", () => {
     });
   });
 
+  describe("email-gateway-client", () => {
+    it("forwards x-org-id, x-user-id, x-run-id headers", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ results: [] }));
+
+      const { checkDeliveryStatus } = await import("../../src/lib/email-gateway-client.js");
+      await checkDeliveryStatus("brand-1", "camp-1", [{ leadId: "l1", email: "a@b.com" }], {
+        orgId: "org-1", userId: "user-1", runId: "run-1",
+      });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-org-id"]).toBe("org-1");
+      expect(opts.headers["x-user-id"]).toBe("user-1");
+      expect(opts.headers["x-run-id"]).toBe("run-1");
+    });
+  });
+
   describe("campaign-client", () => {
-    it("sends x-org-id header (not x-clerk-org-id) for fetchCampaign", async () => {
+    it("sends x-org-id, x-user-id, x-run-id headers for fetchCampaign", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ campaign: { id: "c1", name: "Test", targetAudience: null, targetOutcome: null, valueForTarget: null } }));
 
       const { fetchCampaign } = await import("../../src/lib/campaign-client.js");
-      await fetchCampaign("campaign-123", "org-uuid-abc");
+      await fetchCampaign("campaign-123", "org-uuid-abc", { userId: "user-abc", runId: "run-abc" });
 
       expect(fetchSpy).toHaveBeenCalledOnce();
       const [, opts] = fetchSpy.mock.calls[0];
       expect(opts.headers["x-org-id"]).toBe("org-uuid-abc");
+      expect(opts.headers["x-user-id"]).toBe("user-abc");
+      expect(opts.headers["x-run-id"]).toBe("run-abc");
       expect(opts.headers).not.toHaveProperty("x-clerk-org-id");
     });
   });
 
   describe("brand-client", () => {
-    it("sends x-org-id header and orgId query param (not clerk variants)", async () => {
+    it("sends x-org-id, x-user-id, x-run-id headers and orgId query param", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ brand: { id: "b1", name: "Test", domain: null, elevatorPitch: null, bio: null, mission: null, location: null, categories: null } }));
 
       const { fetchBrand } = await import("../../src/lib/brand-client.js");
-      await fetchBrand("brand-123", "org-uuid-def");
+      await fetchBrand("brand-123", "org-uuid-def", { userId: "user-def", runId: "run-def" });
 
       expect(fetchSpy).toHaveBeenCalledOnce();
       const [url, opts] = fetchSpy.mock.calls[0];
       expect(opts.headers["x-org-id"]).toBe("org-uuid-def");
+      expect(opts.headers["x-user-id"]).toBe("user-def");
+      expect(opts.headers["x-run-id"]).toBe("run-def");
       expect(opts.headers).not.toHaveProperty("x-clerk-org-id");
-      // Query param should be orgId, not clerkOrgId
       expect(url).toContain("orgId=org-uuid-def");
       expect(url).not.toContain("clerkOrgId");
     });
   });
 
   describe("runs-client", () => {
-    it("sends orgId and userId in body (not clerkOrgId/clerkUserId)", async () => {
+    it("sends x-org-id, x-user-id, x-run-id headers for updateRun", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ id: "run-1", status: "completed" }));
+
+      const { updateRun } = await import("../../src/lib/runs-client.js");
+      await updateRun("run-1", "completed", { orgId: "org-1", userId: "user-1" });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-org-id"]).toBe("org-1");
+      expect(opts.headers["x-user-id"]).toBe("user-1");
+      expect(opts.headers["x-run-id"]).toBe("run-1");
+    });
+
+    it("sends orgId, userId, parentRunId as headers (not body)", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ id: "run-uuid-1" }, 201));
 
       const { createRun } = await import("../../src/lib/runs-client.js");
@@ -143,13 +179,19 @@ describe("service client headers", () => {
         serviceName: "lead-service",
         taskName: "test-task",
         userId: "user-uuid-run",
+        parentRunId: "parent-run-1",
       });
 
       expect(fetchSpy).toHaveBeenCalledOnce();
       const [, opts] = fetchSpy.mock.calls[0];
+      const headers = opts.headers;
+      expect(headers["x-org-id"]).toBe("org-uuid-run");
+      expect(headers["x-user-id"]).toBe("user-uuid-run");
+      expect(headers["x-run-id"]).toBe("parent-run-1");
       const body = JSON.parse(opts.body);
-      expect(body.orgId).toBe("org-uuid-run");
-      expect(body.userId).toBe("user-uuid-run");
+      expect(body).not.toHaveProperty("orgId");
+      expect(body).not.toHaveProperty("userId");
+      expect(body).not.toHaveProperty("parentRunId");
       expect(body).not.toHaveProperty("clerkOrgId");
       expect(body).not.toHaveProperty("clerkUserId");
       expect(body).not.toHaveProperty("appId");


### PR DESCRIPTION
## Summary
- Forward `x-org-id`, `x-user-id`, `x-run-id` headers to all 5 downstream services (runs, email-gateway, apollo, campaign, brand)
- Moved `orgId`/`userId`/`parentRunId` from runs-client request body to headers per updated runs-service spec
- Threaded header context through `buffer.ts`, `dedup.ts`, and route handlers so callers always pass identity downstream

## Test plan
- [x] All 70 unit tests pass (`npm run test:unit`)
- [x] TypeScript build succeeds (`npm run build`)
- [x] Added new tests for email-gateway header forwarding
- [x] Added new test for `updateRun` header forwarding
- [x] Updated existing tests to match new signatures (runs-client body→headers, dedup context param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)