### PR TITLE
Register provider requirements with key-service on startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import bufferRoutes from "./routes/buffer.js";
 import cursorRoutes from "./routes/cursor.js";
 import leadsRoutes from "./routes/leads.js";
 import statsRoutes from "./routes/stats.js";
+import { registerProviders } from "./lib/register-providers.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -51,6 +52,9 @@ if (process.env.NODE_ENV !== "test") {
   migrate(db, { migrationsFolder: "./drizzle" })
     .then(() => {
       console.log("Migrations complete");
+      registerProviders().catch((err) =>
+        console.warn("[startup] Provider registration failed (non-fatal):", err)
+      );
       const server = app.listen(Number(PORT), "::", () => {
         console.log(`lead-service running on port ${PORT}`);
       });

--- a/src/lib/key-service-client.ts
+++ b/src/lib/key-service-client.ts
@@ -1,0 +1,58 @@
+const KEY_SERVICE_URL = process.env.KEY_SERVICE_URL || "http://localhost:3001";
+const KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY || "";
+
+export interface ProviderRequirement {
+  service: string;
+  method: string;
+  path: string;
+  provider: string;
+}
+
+export interface ProviderRequirementsResponse {
+  requirements: ProviderRequirement[];
+  providers: string[];
+}
+
+export async function queryProviderRequirements(
+  endpoints: Array<{ service: string; method: string; path: string }>
+): Promise<ProviderRequirementsResponse> {
+  const response = await fetch(`${KEY_SERVICE_URL}/provider-requirements`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-Key": KEY_SERVICE_API_KEY,
+    },
+    body: JSON.stringify({ endpoints }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Key service provider-requirements failed: ${response.status} - ${error}`);
+  }
+
+  return response.json() as Promise<ProviderRequirementsResponse>;
+}
+
+export async function registerProviderRequirement(
+  provider: string,
+  callerService: string,
+  callerMethod: string,
+  callerPath: string
+): Promise<void> {
+  const response = await fetch(`${KEY_SERVICE_URL}/keys/platform/${provider}/decrypt`, {
+    method: "GET",
+    headers: {
+      "X-API-Key": KEY_SERVICE_API_KEY,
+      "x-caller-service": callerService,
+      "x-caller-method": callerMethod,
+      "x-caller-path": callerPath,
+    },
+  });
+
+  // We only care about the side effect (provider requirement tracking).
+  // 404 (key not configured) is fine — the requirement is still recorded.
+  if (!response.ok && response.status !== 404) {
+    const error = await response.text();
+    throw new Error(`Key service registration failed: ${response.status} - ${error}`);
+  }
+}

--- a/src/lib/register-providers.ts
+++ b/src/lib/register-providers.ts
@@ -1,0 +1,64 @@
+import { queryProviderRequirements, registerProviderRequirement } from "./key-service-client.js";
+
+// Maps each lead-service endpoint to the downstream apollo endpoints it calls.
+// This is the source of truth for which lead routes proxy which apollo routes.
+const ENDPOINT_MAPPING: Array<{
+  lead: { method: string; path: string };
+  downstream: Array<{ service: string; method: string; path: string }>;
+}> = [
+  {
+    lead: { method: "POST", path: "/buffer/next" },
+    downstream: [
+      { service: "apollo", method: "POST", path: "/search" },
+      { service: "apollo", method: "POST", path: "/search/next" },
+      { service: "apollo", method: "POST", path: "/search/params" },
+      { service: "apollo", method: "POST", path: "/enrich" },
+    ],
+  },
+  {
+    lead: { method: "GET", path: "/stats" },
+    downstream: [
+      { service: "apollo", method: "POST", path: "/stats" },
+    ],
+  },
+];
+
+export async function registerProviders(): Promise<void> {
+  // Collect all unique downstream endpoints to query in one batch
+  const allDownstream = ENDPOINT_MAPPING.flatMap((m) => m.downstream);
+  const uniqueDownstream = allDownstream.filter(
+    (ep, i, arr) => arr.findIndex((e) => e.service === ep.service && e.method === ep.method && e.path === ep.path) === i
+  );
+
+  const { requirements } = await queryProviderRequirements(uniqueDownstream);
+  if (requirements.length === 0) {
+    console.log("[register-providers] No downstream provider requirements found");
+    return;
+  }
+
+  // For each lead endpoint, find which providers its downstream endpoints need
+  const registrations: Array<{ provider: string; method: string; path: string }> = [];
+
+  for (const mapping of ENDPOINT_MAPPING) {
+    const providers = new Set<string>();
+    for (const downstream of mapping.downstream) {
+      for (const req of requirements) {
+        if (req.service === downstream.service && req.method === downstream.method && req.path === downstream.path) {
+          providers.add(req.provider);
+        }
+      }
+    }
+    for (const provider of providers) {
+      registrations.push({ provider, method: mapping.lead.method, path: mapping.lead.path });
+    }
+  }
+
+  // Register each lead-service endpoint → provider mapping with key-service
+  await Promise.all(
+    registrations.map(({ provider, method, path }) =>
+      registerProviderRequirement(provider, "lead", method, path)
+        .then(() => console.log(`[register-providers] Registered lead ${method} ${path} → ${provider}`))
+        .catch((err) => console.warn(`[register-providers] Failed to register lead ${method} ${path} → ${provider}:`, err))
+    )
+  );
+}

--- a/tests/unit/register-providers.test.ts
+++ b/tests/unit/register-providers.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { queryProviderRequirements, registerProviderRequirement } from "../../src/lib/key-service-client.js";
+import { registerProviders } from "../../src/lib/register-providers.js";
+
+describe("key-service-client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("queryProviderRequirements", () => {
+    it("sends endpoints and returns requirements", async () => {
+      const response = {
+        requirements: [
+          { service: "apollo", method: "POST", path: "/search/next", provider: "apollo" },
+        ],
+        providers: ["apollo"],
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(response),
+      });
+
+      const result = await queryProviderRequirements([
+        { service: "apollo", method: "POST", path: "/search/next" },
+      ]);
+
+      expect(result).toEqual(response);
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain("/provider-requirements");
+      expect(opts.method).toBe("POST");
+      expect(JSON.parse(opts.body)).toEqual({
+        endpoints: [{ service: "apollo", method: "POST", path: "/search/next" }],
+      });
+    });
+
+    it("throws on non-ok response", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("Internal error"),
+      });
+
+      await expect(
+        queryProviderRequirements([{ service: "apollo", method: "POST", path: "/search" }])
+      ).rejects.toThrow("Key service provider-requirements failed: 500");
+    });
+  });
+
+  describe("registerProviderRequirement", () => {
+    it("calls decrypt endpoint with x-caller headers", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ provider: "apollo", key: "ak_123" }),
+      });
+
+      await registerProviderRequirement("apollo", "lead", "POST", "/buffer/next");
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toContain("/keys/platform/apollo/decrypt");
+      expect(opts.method).toBe("GET");
+      expect(opts.headers["x-caller-service"]).toBe("lead");
+      expect(opts.headers["x-caller-method"]).toBe("POST");
+      expect(opts.headers["x-caller-path"]).toBe("/buffer/next");
+    });
+
+    it("tolerates 404 (key not configured)", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("Not found"),
+      });
+
+      await expect(
+        registerProviderRequirement("apollo", "lead", "POST", "/buffer/next")
+      ).resolves.toBeUndefined();
+    });
+
+    it("throws on non-404 errors", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("Server error"),
+      });
+
+      await expect(
+        registerProviderRequirement("apollo", "lead", "POST", "/buffer/next")
+      ).rejects.toThrow("Key service registration failed: 500");
+    });
+  });
+});
+
+describe("registerProviders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("queries apollo endpoints and registers lead endpoints with discovered providers", async () => {
+    // First call: queryProviderRequirements
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          requirements: [
+            { service: "apollo", method: "POST", path: "/search", provider: "apollo" },
+            { service: "apollo", method: "POST", path: "/search/next", provider: "apollo" },
+            { service: "apollo", method: "POST", path: "/search/params", provider: "apollo" },
+            { service: "apollo", method: "POST", path: "/search/params", provider: "anthropic" },
+            { service: "apollo", method: "POST", path: "/enrich", provider: "apollo" },
+          ],
+          providers: ["apollo", "anthropic"],
+        }),
+    });
+
+    // Subsequent calls: registerProviderRequirement (decrypt calls)
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "apollo", key: "ak_123" }),
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await registerProviders();
+
+    // 1 query + N registration calls
+    // lead POST /buffer/next → apollo, anthropic (2 registrations)
+    // lead GET /stats → no requirements (apollo POST /stats had no requirements in response)
+    expect(mockFetch).toHaveBeenCalledTimes(3); // 1 query + 2 registrations
+
+    // Verify the query call includes all downstream endpoints
+    const queryBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(queryBody.endpoints).toHaveLength(5);
+    expect(queryBody.endpoints).toContainEqual({ service: "apollo", method: "POST", path: "/search" });
+    expect(queryBody.endpoints).toContainEqual({ service: "apollo", method: "POST", path: "/search/next" });
+    expect(queryBody.endpoints).toContainEqual({ service: "apollo", method: "POST", path: "/search/params" });
+    expect(queryBody.endpoints).toContainEqual({ service: "apollo", method: "POST", path: "/enrich" });
+    expect(queryBody.endpoints).toContainEqual({ service: "apollo", method: "POST", path: "/stats" });
+
+    // Verify registration calls have correct x-caller headers
+    const registrationCalls = mockFetch.mock.calls.slice(1);
+    const registeredPairs = registrationCalls.map(([url, opts]: [string, RequestInit & { headers: Record<string, string> }]) => ({
+      provider: url.match(/\/keys\/platform\/(.+)\/decrypt/)?.[1],
+      method: opts.headers["x-caller-method"],
+      path: opts.headers["x-caller-path"],
+      service: opts.headers["x-caller-service"],
+    }));
+
+    expect(registeredPairs).toContainEqual({ provider: "apollo", method: "POST", path: "/buffer/next", service: "lead" });
+    expect(registeredPairs).toContainEqual({ provider: "anthropic", method: "POST", path: "/buffer/next", service: "lead" });
+
+    logSpy.mockRestore();
+  });
+
+  it("handles no requirements gracefully", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ requirements: [], providers: [] }),
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await registerProviders();
+
+    // Only the query call, no registration calls
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith("[register-providers] No downstream provider requirements found");
+
+    logSpy.mockRestore();
+  });
+
+  it("continues when individual registrations fail", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          requirements: [
+            { service: "apollo", method: "POST", path: "/search", provider: "apollo" },
+            { service: "apollo", method: "POST", path: "/search/params", provider: "anthropic" },
+          ],
+          providers: ["apollo", "anthropic"],
+        }),
+    });
+
+    // First registration succeeds, second fails
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ provider: "apollo", key: "ak_123" }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("Server error"),
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await registerProviders();
+
+    // 1 query + 2 registration attempts
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Registered lead POST /buffer/next"));
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to register lead POST /buffer/next"),
+      expect.any(Error)
+    );
+
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- On startup, lead-service now queries key-service `POST /provider-requirements` with the apollo endpoints it wraps (`/search`, `/search/next`, `/search/params`, `/enrich`, `/stats`)
- Maps discovered providers back to lead-service endpoints (`POST /buffer/next`, `GET /stats`) and registers them via key-service's platform decrypt endpoint (which auto-records x-caller mappings)
- Fixes workflow DAGs not showing apollo/anthropic in the provider list when calling lead `POST /buffer/next`

## New files
- `src/lib/key-service-client.ts` — key-service client (query requirements + register via decrypt)
- `src/lib/register-providers.ts` — startup registration logic with endpoint mapping
- `tests/unit/register-providers.test.ts` — 8 tests covering query, registration, error handling

## Test plan
- [x] All 78 unit tests pass
- [x] TypeScript builds cleanly
- [ ] Deploy to staging and verify `POST /provider-requirements` for `lead POST /buffer/next` returns `apollo` and `anthropic`
- [ ] Verify workflow dashboard shows correct provider list for DAGs using lead-service

🤖 Generated with [Claude Code](https://claude.com/claude-code)