### PR TITLE
Make key-service config mandatory on startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,11 +50,9 @@ app.use((err: Error, req: express.Request, res: express.Response, next: express.
 
 if (process.env.NODE_ENV !== "test") {
   migrate(db, { migrationsFolder: "./drizzle" })
-    .then(() => {
+    .then(async () => {
       console.log("Migrations complete");
-      registerProviders().catch((err) =>
-        console.warn("[startup] Provider registration failed (non-fatal):", err)
-      );
+      await registerProviders();
       const server = app.listen(Number(PORT), "::", () => {
         console.log(`lead-service running on port ${PORT}`);
       });

--- a/src/lib/key-service-client.ts
+++ b/src/lib/key-service-client.ts
@@ -1,5 +1,11 @@
-const KEY_SERVICE_URL = process.env.KEY_SERVICE_URL || "http://localhost:3001";
-const KEY_SERVICE_API_KEY = process.env.KEY_SERVICE_API_KEY || "";
+function getKeyServiceConfig() {
+  const url = process.env.KEY_SERVICE_URL;
+  const apiKey = process.env.KEY_SERVICE_API_KEY;
+  if (!url || !apiKey) {
+    throw new Error("KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set");
+  }
+  return { url, apiKey };
+}
 
 export interface ProviderRequirement {
   service: string;
@@ -16,11 +22,12 @@ export interface ProviderRequirementsResponse {
 export async function queryProviderRequirements(
   endpoints: Array<{ service: string; method: string; path: string }>
 ): Promise<ProviderRequirementsResponse> {
-  const response = await fetch(`${KEY_SERVICE_URL}/provider-requirements`, {
+  const { url, apiKey } = getKeyServiceConfig();
+  const response = await fetch(`${url}/provider-requirements`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-API-Key": KEY_SERVICE_API_KEY,
+      "X-API-Key": apiKey,
     },
     body: JSON.stringify({ endpoints }),
   });
@@ -39,10 +46,11 @@ export async function registerProviderRequirement(
   callerMethod: string,
   callerPath: string
 ): Promise<void> {
-  const response = await fetch(`${KEY_SERVICE_URL}/keys/platform/${provider}/decrypt`, {
+  const { url, apiKey } = getKeyServiceConfig();
+  const response = await fetch(`${url}/keys/platform/${provider}/decrypt`, {
     method: "GET",
     headers: {
-      "X-API-Key": KEY_SERVICE_API_KEY,
+      "X-API-Key": apiKey,
       "x-caller-service": callerService,
       "x-caller-method": callerMethod,
       "x-caller-path": callerPath,

--- a/tests/unit/register-providers.test.ts
+++ b/tests/unit/register-providers.test.ts
@@ -3,6 +3,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+// Set env vars before importing modules that read them
+vi.stubEnv("KEY_SERVICE_URL", "http://key-service:3001");
+vi.stubEnv("KEY_SERVICE_API_KEY", "test-key-service-api-key");
+
 import { queryProviderRequirements, registerProviderRequirement } from "../../src/lib/key-service-client.js";
 import { registerProviders } from "../../src/lib/register-providers.js";
 
@@ -13,6 +17,28 @@ describe("key-service-client", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe("env var guard", () => {
+    it("throws when KEY_SERVICE_URL is missing", async () => {
+      vi.stubEnv("KEY_SERVICE_URL", "");
+
+      await expect(
+        queryProviderRequirements([{ service: "apollo", method: "POST", path: "/search" }])
+      ).rejects.toThrow("KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set");
+
+      vi.stubEnv("KEY_SERVICE_URL", "http://key-service:3001");
+    });
+
+    it("throws when KEY_SERVICE_API_KEY is missing", async () => {
+      vi.stubEnv("KEY_SERVICE_API_KEY", "");
+
+      await expect(
+        registerProviderRequirement("apollo", "lead", "POST", "/buffer/next")
+      ).rejects.toThrow("KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set");
+
+      vi.stubEnv("KEY_SERVICE_API_KEY", "test-key-service-api-key");
+    });
   });
 
   describe("queryProviderRequirements", () => {


### PR DESCRIPTION
## Summary
- `KEY_SERVICE_URL` and `KEY_SERVICE_API_KEY` are now validated at call time — throws immediately if unset
- `registerProviders()` is now `await`ed during startup — service crashes if key-service is unreachable
- Adds 2 new tests for the env var guard (10 total)

## Test plan
- [x] 80/80 unit tests pass
- [x] TypeScript builds cleanly
- [ ] Verify Railway has `KEY_SERVICE_URL` and `KEY_SERVICE_API_KEY` set before deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)