### PR TITLE
Add contacted status logging for debugging

### DIFF
--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -24,7 +24,11 @@ export async function checkContacted(
 
   if (statusResponse) {
     for (const sr of statusResponse.results) {
-      result.set(sr.email, isContacted(sr));
+      const contacted = isContacted(sr);
+      console.log(
+        `[dedup] contacted check: email=${sr.email} contacted=${contacted} brandId=${brandId} campaignId=${campaignId}`
+      );
+      result.set(sr.email, contacted);
     }
   } else {
     console.warn(

--- a/tests/unit/dedup.test.ts
+++ b/tests/unit/dedup.test.ts
@@ -71,6 +71,25 @@ describe("dedup", () => {
       expect(result.get("bob@acme.com")).toBe(false);
     });
 
+    it("logs contacted status for each email", async () => {
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({
+        results: [
+          { leadId: "lead-1", email: "alice@acme.com" } as never,
+        ],
+      });
+      vi.mocked(isContacted).mockReturnValue(true);
+
+      await checkContacted("brand-1", "campaign-1", [
+        { leadId: "lead-1", email: "alice@acme.com" },
+      ]);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        "[dedup] contacted check: email=alice@acme.com contacted=true brandId=brand-1 campaignId=campaign-1"
+      );
+      logSpy.mockRestore();
+    });
+
     it("handles batch of multiple emails with mixed results", async () => {
       vi.mocked(checkDeliveryStatus).mockResolvedValue({
         results: [


### PR DESCRIPTION
## Summary
- Adds `console.log` in `checkContacted` (dedup.ts) that logs each email's `contacted` boolean result after calling email-gateway
- Includes brandId and campaignId in the log line for filtering in production logs
- Adds unit test verifying the log output

## Test plan
- [x] Unit tests pass (82/82)
- [ ] Deploy and verify logs appear in Railway when `/buffer/next` is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)