### PR TITLE
Accept and forward workflow tracking headers

### DIFF
--- a/drizzle/0009_add_workflow_name.sql
+++ b/drizzle/0009_add_workflow_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "served_leads" ADD COLUMN "workflow_name" text;--> statement-breakpoint
+ALTER TABLE "lead_buffer" ADD COLUMN "workflow_name" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1772640000000,
       "tag": "0008_remove_appid_org_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1773619200000,
+      "tag": "0009_add_workflow_name",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -689,6 +689,33 @@
               "type": "string"
             },
             "description": "The caller's run ID (used as parentRunId when creating this service's own run)"
+          },
+          {
+            "in": "header",
+            "name": "x-campaign-id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign identifier (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-brand-id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand identifier (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-workflow-name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name (auto-injected by workflow-service)"
           }
         ],
         "requestBody": {
@@ -768,6 +795,33 @@
             "description": "The caller's run ID (used as parentRunId when creating this service's own run)"
           },
           {
+            "in": "header",
+            "name": "x-campaign-id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign identifier (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-brand-id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand identifier (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-workflow-name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name (auto-injected by workflow-service)"
+          },
+          {
             "schema": {
               "type": "string"
             },
@@ -830,6 +884,33 @@
               "type": "string"
             },
             "description": "The caller's run ID (used as parentRunId when creating this service's own run)"
+          },
+          {
+            "in": "header",
+            "name": "x-campaign-id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign identifier (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-brand-id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand identifier (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-workflow-name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name (auto-injected by workflow-service)"
           },
           {
             "schema": {
@@ -915,6 +996,33 @@
               "type": "string"
             },
             "description": "The caller's run ID (used as parentRunId when creating this service's own run)"
+          },
+          {
+            "in": "header",
+            "name": "x-campaign-id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign identifier (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-brand-id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand identifier (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-workflow-name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name (auto-injected by workflow-service)"
           },
           {
             "in": "query",
@@ -1006,6 +1114,33 @@
               "type": "string"
             },
             "description": "The caller's run ID (used as parentRunId when creating this service's own run)"
+          },
+          {
+            "in": "header",
+            "name": "x-campaign-id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign identifier (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-brand-id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand identifier (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-workflow-name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow name (auto-injected by workflow-service)"
           },
           {
             "in": "query",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -47,6 +47,7 @@ export const servedLeads = pgTable(
     campaignId: text("campaign_id").notNull(),
     orgId: text("org_id").notNull(),
     userId: text("user_id"),
+    workflowName: text("workflow_name"),
     servedAt: timestamp("served_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
@@ -73,6 +74,7 @@ export const leadBuffer = pgTable(
     brandId: text("brand_id"),
     orgId: text("org_id").notNull(),
     userId: text("user_id"),
+    workflowName: text("workflow_name"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -15,7 +15,7 @@ export interface BrandDetails {
 export async function fetchBrand(
   brandId: string,
   orgId?: string | null,
-  context?: { userId?: string; runId?: string }
+  context?: { userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string }
 ): Promise<BrandDetails | null> {
   try {
     const headers: Record<string, string> = {
@@ -25,6 +25,9 @@ export async function fetchBrand(
     if (orgId) headers["x-org-id"] = orgId;
     if (context?.userId) headers["x-user-id"] = context.userId;
     if (context?.runId) headers["x-run-id"] = context.runId;
+    if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
+    if (context?.brandId) headers["x-brand-id"] = context.brandId;
+    if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
 
     const url = new URL(`${BRAND_SERVICE_URL}/brands/${brandId}`);
     if (orgId) url.searchParams.set("orgId", orgId);

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -29,7 +29,13 @@ async function fillBufferFromSearch(params: {
   userId?: string | null;
   workflowName?: string;
 }): Promise<{ filled: number }> {
-  const serviceContext = { userId: params.userId ?? undefined, runId: params.pushRunId ?? undefined };
+  const serviceContext = {
+    userId: params.userId ?? undefined,
+    runId: params.pushRunId ?? undefined,
+    campaignId: params.campaignId,
+    brandId: params.brandId,
+    workflowName: params.workflowName,
+  };
 
   // Fetch campaign + brand details in parallel for rich LLM context
   const [campaign, brand] = await Promise.all([
@@ -150,6 +156,9 @@ async function fillBufferFromSearch(params: {
             orgId: params.orgId,
             userId: params.userId ?? undefined,
             runId: params.pushRunId ?? undefined,
+            campaignId: params.campaignId,
+            brandId: params.brandId,
+            workflowName: params.workflowName,
           })
         : new Map<string, boolean>();
 
@@ -169,6 +178,7 @@ async function fillBufferFromSearch(params: {
         brandId: params.brandId,
         orgId: params.orgId,
         userId: params.userId ?? null,
+        workflowName: params.workflowName ?? null,
       });
       pageFilled++;
     }
@@ -382,6 +392,9 @@ export async function pullNext(params: {
       orgId: params.orgId,
       userId: params.userId ?? undefined,
       runId: params.runId ?? undefined,
+      campaignId: params.campaignId,
+      brandId: params.brandId,
+      workflowName: params.workflowName,
     });
 
     if (contactedMap.get(email)) {
@@ -403,6 +416,7 @@ export async function pullNext(params: {
       metadata: enrichedData,
       runId: params.runId ?? null,
       userId: row.userId,
+      workflowName: params.workflowName ?? null,
     });
 
     if (!inserted) {

--- a/src/lib/campaign-client.ts
+++ b/src/lib/campaign-client.ts
@@ -12,7 +12,7 @@ export interface CampaignDetails {
 export async function fetchCampaign(
   campaignId: string,
   orgId?: string | null,
-  context?: { userId?: string; runId?: string }
+  context?: { userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string }
 ): Promise<CampaignDetails | null> {
   try {
     const headers: Record<string, string> = {
@@ -22,6 +22,9 @@ export async function fetchCampaign(
     if (orgId) headers["x-org-id"] = orgId;
     if (context?.userId) headers["x-user-id"] = context.userId;
     if (context?.runId) headers["x-run-id"] = context.runId;
+    if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
+    if (context?.brandId) headers["x-brand-id"] = context.brandId;
+    if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
 
     const response = await fetch(`${CAMPAIGN_SERVICE_URL}/campaigns/${campaignId}`, {
       headers,

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -16,7 +16,7 @@ export async function checkContacted(
   brandId: string,
   campaignId: string,
   items: DeliveryStatusItem[],
-  context?: { orgId?: string; userId?: string; runId?: string }
+  context?: { orgId?: string; userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string }
 ): Promise<Map<string, boolean>> {
   const result = new Map<string, boolean>();
 
@@ -57,6 +57,7 @@ export async function markServed(params: {
   metadata?: unknown;
   runId?: string | null;
   userId?: string | null;
+  workflowName?: string | null;
 }): Promise<{ inserted: boolean }> {
   const result = await db
     .insert(servedLeads)
@@ -71,6 +72,7 @@ export async function markServed(params: {
       brandId: params.brandId,
       campaignId: params.campaignId,
       userId: params.userId ?? null,
+      workflowName: params.workflowName ?? null,
     })
     .onConflictDoNothing()
     .returning();

--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -53,7 +53,7 @@ export async function checkDeliveryStatus(
   brandId: string,
   campaignId: string | undefined,
   items: DeliveryStatusItem[],
-  context?: { orgId?: string; userId?: string; runId?: string }
+  context?: { orgId?: string; userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string }
 ): Promise<DeliveryStatusResponse | null> {
   try {
     const body: Record<string, unknown> = { brandId, items };
@@ -66,6 +66,9 @@ export async function checkDeliveryStatus(
     if (context?.orgId) headers["x-org-id"] = context.orgId;
     if (context?.userId) headers["x-user-id"] = context.userId;
     if (context?.runId) headers["x-run-id"] = context.runId;
+    if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
+    if (context?.brandId) headers["x-brand-id"] = context.brandId;
+    if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
 
     const response = await fetch(`${EMAIL_GATEWAY_SERVICE_URL}/status`, {
       method: "POST",

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -41,6 +41,9 @@ export async function createRun(params: {
   };
   if (params.userId) headers["x-user-id"] = params.userId;
   if (params.parentRunId) headers["x-run-id"] = params.parentRunId;
+  if (params.campaignId) headers["x-campaign-id"] = params.campaignId;
+  if (params.brandId) headers["x-brand-id"] = params.brandId;
+  if (params.workflowName) headers["x-workflow-name"] = params.workflowName;
 
   return callRunsService("/runs", {
     method: "POST",
@@ -58,12 +61,15 @@ export async function createRun(params: {
 export async function updateRun(
   runId: string,
   status: "completed" | "failed",
-  context?: { orgId?: string; userId?: string }
+  context?: { orgId?: string; userId?: string; campaignId?: string; brandId?: string; workflowName?: string }
 ): Promise<void> {
   const headers: Record<string, string> = {};
   if (context?.orgId) headers["x-org-id"] = context.orgId;
   if (context?.userId) headers["x-user-id"] = context.userId;
   headers["x-run-id"] = runId;
+  if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
+  if (context?.brandId) headers["x-brand-id"] = context.brandId;
+  if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
 
   await callRunsService(`/runs/${runId}`, {
     method: "PATCH",
@@ -75,7 +81,7 @@ export async function updateRun(
 export async function addCosts(
   runId: string,
   items: Array<{ costName: string; quantity: number; costSource: "platform" | "org" }>,
-  context?: { orgId?: string; userId?: string }
+  context?: { orgId?: string; userId?: string; campaignId?: string; brandId?: string; workflowName?: string }
 ): Promise<void> {
   if (items.length === 0) return;
 
@@ -83,6 +89,9 @@ export async function addCosts(
   if (context?.orgId) headers["x-org-id"] = context.orgId;
   if (context?.userId) headers["x-user-id"] = context.userId;
   headers["x-run-id"] = runId;
+  if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
+  if (context?.brandId) headers["x-brand-id"] = context.brandId;
+  if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
 
   await callRunsService(`/runs/${runId}/costs`, {
     method: "POST",

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -4,6 +4,9 @@ export interface AuthenticatedRequest extends Request {
   orgId?: string;
   userId?: string;
   runId?: string;
+  campaignId?: string;
+  brandId?: string;
+  workflowName?: string;
 }
 
 export async function authenticate(
@@ -28,6 +31,15 @@ export async function authenticate(
     req.orgId = orgId;
     req.userId = userId;
     req.runId = runId;
+
+    // Optional workflow tracking headers (injected by workflow-service)
+    const campaignId = req.headers["x-campaign-id"] as string | undefined;
+    const brandId = req.headers["x-brand-id"] as string | undefined;
+    const workflowName = req.headers["x-workflow-name"] as string | undefined;
+    if (campaignId) req.campaignId = campaignId;
+    if (brandId) req.brandId = brandId;
+    if (workflowName) req.workflowName = workflowName;
+
     next();
   } catch (error) {
     console.error("[auth] Error:", error);

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -32,7 +32,10 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
   }
 
   try {
-    const { campaignId, brandId, searchParams, userId, workflowName, idempotencyKey } = parsed.data;
+    const { campaignId, brandId, searchParams, userId, idempotencyKey } = parsed.data;
+
+    // Body workflowName takes precedence; fall back to header injected by workflow-service
+    const workflowName = parsed.data.workflowName ?? req.workflowName;
 
     // Idempotency: return cached response if this key was already processed
     if (idempotencyKey) {
@@ -84,7 +87,13 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
     }
 
     try {
-      await updateRun(serveRunId, "completed", { orgId: req.orgId, userId: req.userId });
+      await updateRun(serveRunId, "completed", {
+        orgId: req.orgId,
+        userId: req.userId,
+        campaignId,
+        brandId,
+        workflowName,
+      });
     } catch (err) {
       console.error("[buffer/next] Failed to update run:", err);
     }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -43,6 +43,27 @@ const AuthHeaders = [
     schema: { type: "string" as const },
     description: "The caller's run ID (used as parentRunId when creating this service's own run)",
   },
+  {
+    in: "header" as const,
+    name: "x-campaign-id",
+    required: false,
+    schema: { type: "string" as const },
+    description: "Campaign identifier (auto-injected by workflow-service)",
+  },
+  {
+    in: "header" as const,
+    name: "x-brand-id",
+    required: false,
+    schema: { type: "string" as const },
+    description: "Brand identifier (auto-injected by workflow-service)",
+  },
+  {
+    in: "header" as const,
+    name: "x-workflow-name",
+    required: false,
+    schema: { type: "string" as const },
+    description: "Workflow name (auto-injected by workflow-service)",
+  },
 ];
 
 // --- Health ---

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -120,6 +120,21 @@ describe("service client headers", () => {
       expect(opts.headers["x-user-id"]).toBe("user-1");
       expect(opts.headers["x-run-id"]).toBe("run-1");
     });
+
+    it("forwards x-campaign-id, x-brand-id, x-workflow-name headers when provided", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ results: [] }));
+
+      const { checkDeliveryStatus } = await import("../../src/lib/email-gateway-client.js");
+      await checkDeliveryStatus("brand-1", "camp-1", [{ leadId: "l1", email: "a@b.com" }], {
+        orgId: "org-1", userId: "user-1", runId: "run-1",
+        campaignId: "camp-1", brandId: "brand-1", workflowName: "wf-test",
+      });
+
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-campaign-id"]).toBe("camp-1");
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
+      expect(opts.headers["x-workflow-name"]).toBe("wf-test");
+    });
   });
 
   describe("campaign-client", () => {
@@ -135,6 +150,21 @@ describe("service client headers", () => {
       expect(opts.headers["x-user-id"]).toBe("user-abc");
       expect(opts.headers["x-run-id"]).toBe("run-abc");
       expect(opts.headers).not.toHaveProperty("x-clerk-org-id");
+    });
+
+    it("forwards workflow tracking headers when provided", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ campaign: { id: "c1", name: "Test", targetAudience: null, targetOutcome: null, valueForTarget: null } }));
+
+      const { fetchCampaign } = await import("../../src/lib/campaign-client.js");
+      await fetchCampaign("campaign-123", "org-1", {
+        userId: "user-1", runId: "run-1",
+        campaignId: "camp-1", brandId: "brand-1", workflowName: "wf-test",
+      });
+
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-campaign-id"]).toBe("camp-1");
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
+      expect(opts.headers["x-workflow-name"]).toBe("wf-test");
     });
   });
 
@@ -153,6 +183,21 @@ describe("service client headers", () => {
       expect(opts.headers).not.toHaveProperty("x-clerk-org-id");
       expect(url).toContain("orgId=org-uuid-def");
       expect(url).not.toContain("clerkOrgId");
+    });
+
+    it("forwards workflow tracking headers when provided", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ brand: { id: "b1", name: "Test", domain: null, elevatorPitch: null, bio: null, mission: null, location: null, categories: null } }));
+
+      const { fetchBrand } = await import("../../src/lib/brand-client.js");
+      await fetchBrand("brand-123", "org-1", {
+        userId: "user-1", runId: "run-1",
+        campaignId: "camp-1", brandId: "brand-1", workflowName: "wf-test",
+      });
+
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-campaign-id"]).toBe("camp-1");
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
+      expect(opts.headers["x-workflow-name"]).toBe("wf-test");
     });
   });
 
@@ -195,6 +240,40 @@ describe("service client headers", () => {
       expect(body).not.toHaveProperty("clerkOrgId");
       expect(body).not.toHaveProperty("clerkUserId");
       expect(body).not.toHaveProperty("appId");
+    });
+
+    it("forwards workflow tracking headers for createRun", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ id: "run-uuid-2" }, 201));
+
+      const { createRun } = await import("../../src/lib/runs-client.js");
+      await createRun({
+        orgId: "org-1",
+        serviceName: "lead-service",
+        taskName: "test-task",
+        campaignId: "camp-1",
+        brandId: "brand-1",
+        workflowName: "wf-test",
+      });
+
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-campaign-id"]).toBe("camp-1");
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
+      expect(opts.headers["x-workflow-name"]).toBe("wf-test");
+    });
+
+    it("forwards workflow tracking headers for updateRun", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ id: "run-1", status: "completed" }));
+
+      const { updateRun } = await import("../../src/lib/runs-client.js");
+      await updateRun("run-1", "completed", {
+        orgId: "org-1", userId: "user-1",
+        campaignId: "camp-1", brandId: "brand-1", workflowName: "wf-test",
+      });
+
+      const [, opts] = fetchSpy.mock.calls[0];
+      expect(opts.headers["x-campaign-id"]).toBe("camp-1");
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
+      expect(opts.headers["x-workflow-name"]).toBe("wf-test");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Read `x-campaign-id`, `x-brand-id`, `x-workflow-name` as optional headers in auth middleware
- Add `workflow_name` nullable column to `served_leads` and `lead_buffer` tables (migration 0009)
- Forward all three headers to every downstream service call (runs, email-gateway, campaign, brand, apollo)
- Update OpenAPI spec with the three new optional header parameters
- Add 5 new tests verifying header forwarding on all clients

## Test plan
- [x] All 87 unit tests pass (`npm run test:unit`)
- [x] Build succeeds with updated OpenAPI spec
- [ ] Verify migration runs on staging DB
- [ ] Confirm headers flow through in a real workflow execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)