### PR TITLE
Add groupBy support to GET /stats

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -620,6 +620,40 @@
           "skipped",
           "apollo"
         ]
+      },
+      "StatsGroupedResponse": {
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "served": {
+                  "type": "number"
+                },
+                "buffered": {
+                  "type": "number"
+                },
+                "skipped": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "key",
+                "served",
+                "buffered",
+                "skipped"
+              ]
+            }
+          }
+        },
+        "required": [
+          "groups"
+        ]
       }
     },
     "parameters": {},
@@ -1182,15 +1216,45 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "groupBy",
+            "required": false,
+            "description": "Group stats by this dimension. When set, returns { groups: [...] } instead of flat stats. Allowed values: campaignId, brandId",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "campaignId",
+                "brandId"
+              ]
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "Lead stats by status with Apollo metrics",
+            "description": "Lead stats by status. Without groupBy: flat stats with Apollo metrics. With groupBy: grouped stats array.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/StatsResponse"
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/StatsResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/StatsGroupedResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid groupBy value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,63 +1,154 @@
 import { Router } from "express";
-import { eq, and, count, inArray, or, type SQL } from "drizzle-orm";
+import { eq, and, count, inArray, or, sql, type SQL } from "drizzle-orm";
 import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
 import { db } from "../db/index.js";
 import { servedLeads, leadBuffer } from "../db/schema.js";
 import { fetchApolloStats } from "../lib/apollo-client.js";
 
+const VALID_GROUP_BY = ["campaignId", "brandId"] as const;
+type GroupByField = (typeof VALID_GROUP_BY)[number];
+
+const COLUMN_MAP = {
+  campaignId: { served: servedLeads.campaignId, buffer: leadBuffer.campaignId },
+  brandId: { served: servedLeads.brandId, buffer: leadBuffer.brandId },
+} as const;
+
 const router = Router();
+
+function buildConditions(
+  req: AuthenticatedRequest,
+  table: "served" | "buffer",
+) {
+  const { brandId, campaignId, orgId, userId, runIds } = req.query;
+  const str = (v: unknown): string | undefined =>
+    typeof v === "string" ? v : undefined;
+  const brandIdStr = str(brandId);
+  const campaignIdStr = str(campaignId);
+  const orgIdStr = str(orgId);
+  const userIdStr = str(userId);
+  const runIdList =
+    typeof runIds === "string" ? runIds.split(",").filter(Boolean) : [];
+
+  if (table === "served") {
+    const conds: SQL[] = [eq(servedLeads.orgId, req.orgId!)];
+    if (brandIdStr) conds.push(eq(servedLeads.brandId, brandIdStr));
+    if (campaignIdStr) conds.push(eq(servedLeads.campaignId, campaignIdStr));
+    if (orgIdStr) conds.push(eq(servedLeads.orgId, orgIdStr));
+    if (userIdStr) conds.push(eq(servedLeads.userId, userIdStr));
+    if (runIdList.length > 0) {
+      conds.push(
+        or(
+          inArray(servedLeads.parentRunId, runIdList),
+          inArray(servedLeads.runId, runIdList),
+        )!,
+      );
+    }
+    return { conds, runIdList, brandIdStr, campaignIdStr, orgIdStr };
+  }
+
+  const conds: SQL[] = [eq(leadBuffer.orgId, req.orgId!)];
+  if (brandIdStr) conds.push(eq(leadBuffer.brandId, brandIdStr));
+  if (campaignIdStr) conds.push(eq(leadBuffer.campaignId, campaignIdStr));
+  if (orgIdStr) conds.push(eq(leadBuffer.orgId, orgIdStr));
+  if (userIdStr) conds.push(eq(leadBuffer.userId, userIdStr));
+  if (runIdList.length > 0) {
+    conds.push(inArray(leadBuffer.pushRunId, runIdList));
+  }
+  return { conds, runIdList, brandIdStr, campaignIdStr, orgIdStr };
+}
 
 router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
-    const { brandId, campaignId, orgId, userId, runIds } = req.query;
-    const str = (v: unknown): string | undefined => typeof v === "string" ? v : undefined;
-    const brandIdStr = str(brandId);
-    const campaignIdStr = str(campaignId);
-    const orgIdStr = str(orgId);
-    const userIdStr = str(userId);
-    const runIdList = typeof runIds === "string" ? runIds.split(",").filter(Boolean) : [];
+    const groupByParam =
+      typeof req.query.groupBy === "string" ? req.query.groupBy : undefined;
 
-    const servedConditions: SQL[] = [eq(servedLeads.orgId, req.orgId!)];
-    const bufferConditions: SQL[] = [eq(leadBuffer.orgId, req.orgId!)];
-
-    if (brandIdStr) {
-      servedConditions.push(eq(servedLeads.brandId, brandIdStr));
-      bufferConditions.push(eq(leadBuffer.brandId, brandIdStr));
-    }
-    if (campaignIdStr) {
-      servedConditions.push(eq(servedLeads.campaignId, campaignIdStr));
-      bufferConditions.push(eq(leadBuffer.campaignId, campaignIdStr));
-    }
-    if (orgIdStr) {
-      servedConditions.push(eq(servedLeads.orgId, orgIdStr));
-      bufferConditions.push(eq(leadBuffer.orgId, orgIdStr));
-    }
-    if (userIdStr) {
-      servedConditions.push(eq(servedLeads.userId, userIdStr));
-      bufferConditions.push(eq(leadBuffer.userId, userIdStr));
-    }
-    if (runIdList.length > 0) {
-      servedConditions.push(
-        or(
-          inArray(servedLeads.parentRunId, runIdList),
-          inArray(servedLeads.runId, runIdList)
-        )!
-      );
-      bufferConditions.push(inArray(leadBuffer.pushRunId, runIdList));
+    if (groupByParam && !VALID_GROUP_BY.includes(groupByParam as GroupByField)) {
+      res.status(400).json({
+        error: `Invalid groupBy value. Allowed: ${VALID_GROUP_BY.join(", ")}`,
+      });
+      return;
     }
 
+    const served = buildConditions(req, "served");
+    const buffer = buildConditions(req, "buffer");
+
+    // --- Grouped response ---
+    if (groupByParam) {
+      const field = groupByParam as GroupByField;
+      const servedCol = COLUMN_MAP[field].served;
+      const bufferCol = COLUMN_MAP[field].buffer;
+
+      const [servedRows, bufferRows] = await Promise.all([
+        db
+          .select({ key: servedCol, count: count() })
+          .from(servedLeads)
+          .where(and(...served.conds))
+          .groupBy(servedCol),
+        db
+          .select({ key: bufferCol, status: leadBuffer.status, count: count() })
+          .from(leadBuffer)
+          .where(and(...buffer.conds))
+          .groupBy(bufferCol, leadBuffer.status),
+      ]);
+
+      // Merge into a map keyed by groupBy value
+      const groups = new Map<
+        string,
+        { served: number; buffered: number; skipped: number }
+      >();
+
+      const getGroup = (key: string | null) => {
+        const k = key ?? "unknown";
+        if (!groups.has(k))
+          groups.set(k, { served: 0, buffered: 0, skipped: 0 });
+        return groups.get(k)!;
+      };
+
+      for (const row of servedRows) {
+        getGroup(row.key).served = row.count;
+      }
+      for (const row of bufferRows) {
+        const g = getGroup(row.key);
+        if (row.status === "buffered") g.buffered = row.count;
+        if (row.status === "skipped") g.skipped = row.count;
+      }
+
+      res.json({
+        groups: Array.from(groups.entries()).map(([key, stats]) => ({
+          key,
+          ...stats,
+        })),
+      });
+      return;
+    }
+
+    // --- Flat response (existing behavior) ---
     const apolloFilters: Record<string, unknown> = {};
-    if (brandIdStr) apolloFilters.brandId = brandIdStr;
-    if (campaignIdStr) apolloFilters.campaignId = campaignIdStr;
-    if (runIdList.length > 0) apolloFilters.runIds = runIdList;
+    if (served.brandIdStr) apolloFilters.brandId = served.brandIdStr;
+    if (served.campaignIdStr) apolloFilters.campaignId = served.campaignIdStr;
+    if (served.runIdList.length > 0) apolloFilters.runIds = served.runIdList;
 
     const [servedResult, bufferRows, apollo] = await Promise.all([
-      db.select({ count: count() }).from(servedLeads).where(and(...servedConditions)).then(([r]) => r),
-      db.select({ status: leadBuffer.status, count: count() }).from(leadBuffer).where(and(...bufferConditions)).groupBy(leadBuffer.status),
-      fetchApolloStats(apolloFilters as Parameters<typeof fetchApolloStats>[0], orgIdStr ?? req.orgId, { userId: req.userId, runId: req.runId }),
+      db
+        .select({ count: count() })
+        .from(servedLeads)
+        .where(and(...served.conds))
+        .then(([r]) => r),
+      db
+        .select({ status: leadBuffer.status, count: count() })
+        .from(leadBuffer)
+        .where(and(...buffer.conds))
+        .groupBy(leadBuffer.status),
+      fetchApolloStats(
+        apolloFilters as Parameters<typeof fetchApolloStats>[0],
+        served.orgIdStr ?? req.orgId,
+        { userId: req.userId, runId: req.runId },
+      ),
     ]);
 
-    const bufferByStatus = Object.fromEntries(bufferRows.map((r) => [r.status, r.count]));
+    const bufferByStatus = Object.fromEntries(
+      bufferRows.map((r) => [r.status, r.count]),
+    );
 
     res.json({
       served: servedResult?.count ?? 0,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -269,6 +269,19 @@ const StatsResponseSchema = z
   })
   .openapi("StatsResponse");
 
+const StatsGroupSchema = z.object({
+  key: z.string(),
+  served: z.number(),
+  buffered: z.number(),
+  skipped: z.number(),
+});
+
+const StatsGroupedResponseSchema = z
+  .object({
+    groups: z.array(StatsGroupSchema),
+  })
+  .openapi("StatsGroupedResponse");
+
 // --- Register Paths ---
 
 registry.registerPath({
@@ -427,11 +440,28 @@ registry.registerPath({
       description: "Comma-separated list of run IDs",
       schema: { type: "string" as const },
     },
+    {
+      in: "query" as const,
+      name: "groupBy",
+      required: false,
+      description:
+        "Group stats by this dimension. When set, returns { groups: [...] } instead of flat stats. Allowed values: campaignId, brandId",
+      schema: { type: "string" as const, enum: ["campaignId", "brandId"] },
+    },
   ],
   responses: {
     200: {
-      description: "Lead stats by status with Apollo metrics",
-      content: { "application/json": { schema: StatsResponseSchema } },
+      description:
+        "Lead stats by status. Without groupBy: flat stats with Apollo metrics. With groupBy: grouped stats array.",
+      content: {
+        "application/json": {
+          schema: z.union([StatsResponseSchema, StatsGroupedResponseSchema]),
+        },
+      },
+    },
+    400: {
+      description: "Invalid groupBy value",
+      content: { "application/json": { schema: ErrorResponseSchema } },
     },
     401: { description: "Unauthorized" },
   },

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Response } from "express";
+
+// Mock db
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockGroupBy = vi.fn();
+const mockSelect = vi.fn();
+const mockThen = vi.fn();
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    select: (...args: unknown[]) => {
+      mockSelect(...args);
+      return {
+        from: (...fArgs: unknown[]) => {
+          mockFrom(...fArgs);
+          return {
+            where: (...wArgs: unknown[]) => {
+              mockWhere(...wArgs);
+              return {
+                then: mockThen,
+                groupBy: (...gArgs: unknown[]) => {
+                  mockGroupBy(...gArgs);
+                  return Promise.resolve([]);
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  },
+}));
+
+vi.mock("../../src/lib/apollo-client.js", () => ({
+  fetchApolloStats: vi.fn().mockResolvedValue({
+    enrichedLeadsCount: 0,
+    searchCount: 0,
+    fetchedPeopleCount: 0,
+    totalMatchingPeople: 0,
+  }),
+}));
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import request from "supertest";
+import express from "express";
+import statsRouter from "../../src/routes/stats.js";
+
+function createApp() {
+  const app = express();
+  app.use((req: any, _res, next) => {
+    req.orgId = "org-1";
+    req.userId = "user-1";
+    req.runId = "run-1";
+    next();
+  });
+  app.use(statsRouter);
+  return app;
+}
+
+describe("GET /stats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: flat query returns served=0, buffer=[]
+    mockThen.mockImplementation((fn: (rows: unknown[]) => unknown) =>
+      Promise.resolve(fn([{ count: 0 }])),
+    );
+  });
+
+  it("returns 400 for invalid groupBy value", async () => {
+    const app = createApp();
+    const res = await request(app).get("/stats?groupBy=invalid");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("Invalid groupBy");
+  });
+
+  it("accepts groupBy=campaignId", async () => {
+    const app = createApp();
+    // Mock grouped queries to return empty arrays
+    mockGroupBy.mockReturnValue(Promise.resolve([]));
+    mockThen.mockImplementation((fn: (rows: unknown[]) => unknown) =>
+      Promise.resolve(fn([{ count: 0 }])),
+    );
+
+    const res = await request(app).get("/stats?groupBy=campaignId");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("groups");
+    expect(Array.isArray(res.body.groups)).toBe(true);
+  });
+
+  it("accepts groupBy=brandId", async () => {
+    const app = createApp();
+    mockGroupBy.mockReturnValue(Promise.resolve([]));
+
+    const res = await request(app).get("/stats?groupBy=brandId");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("groups");
+  });
+
+  it("returns flat response without groupBy", async () => {
+    const app = createApp();
+    const res = await request(app).get("/stats");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("served");
+    expect(res.body).toHaveProperty("buffered");
+    expect(res.body).toHaveProperty("skipped");
+    expect(res.body).toHaveProperty("apollo");
+    expect(res.body).not.toHaveProperty("groups");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `groupBy` query parameter to `GET /stats` (allowed values: `campaignId`, `brandId`)
- When `groupBy` is set, returns `{ groups: [{ key, served, buffered, skipped }] }` instead of flat stats
- Existing flat response (without `groupBy`) is unchanged — no breaking changes
- Replaces N sequential stats calls with a single grouped call for batch-stats use case

## Examples

**Existing (unchanged):** `GET /stats?campaignId=X` → `{ served, buffered, skipped, apollo }`

**New:** `GET /stats?orgId=X&groupBy=campaignId` → `{ groups: [{ key: "campaign-uuid", served, buffered, skipped }, ...] }`

## Test plan
- [x] Unit tests for groupBy validation (rejects invalid values)
- [x] Unit tests for grouped response shape (campaignId, brandId)
- [x] Unit tests for flat response backward compatibility
- [x] All 91 existing tests pass
- [x] TypeScript builds cleanly
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)