### PR TITLE
Add contacted count to GET /stats endpoint

### DIFF
--- a/drizzle/0010_add_contacted_at.sql
+++ b/drizzle/0010_add_contacted_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "served_leads" ADD COLUMN "contacted_at" timestamp with time zone;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1773619200000,
       "tag": "0009_add_workflow_name",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1774012800000,
+      "tag": "0010_add_contacted_at",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -584,6 +584,9 @@
           "served": {
             "type": "number"
           },
+          "contacted": {
+            "type": "number"
+          },
           "buffered": {
             "type": "number"
           },
@@ -616,6 +619,7 @@
         },
         "required": [
           "served",
+          "contacted",
           "buffered",
           "skipped",
           "apollo"
@@ -635,6 +639,9 @@
                 "served": {
                   "type": "number"
                 },
+                "contacted": {
+                  "type": "number"
+                },
                 "buffered": {
                   "type": "number"
                 },
@@ -645,6 +652,7 @@
               "required": [
                 "key",
                 "served",
+                "contacted",
                 "buffered",
                 "skipped"
               ]
@@ -1111,7 +1119,7 @@
     "/stats": {
       "get": {
         "summary": "Get lead stats by status",
-        "description": "Returns counts of leads by status: served (delivered with verified email), buffered (awaiting enrichment), and skipped (no email found).",
+        "description": "Returns counts of leads by status: served (delivered with verified email), contacted (unique leads with at least one successful email send), buffered (awaiting enrichment), and skipped (no email found).",
         "parameters": [
           {
             "in": "header",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -49,6 +49,7 @@ export const servedLeads = pgTable(
     userId: text("user_id"),
     workflowName: text("workflow_name"),
     servedAt: timestamp("served_at", { withTimezone: true }).notNull().defaultNow(),
+    contactedAt: timestamp("contacted_at", { withTimezone: true }),
   },
   (table) => [
     uniqueIndex("idx_served_org_brand_email").on(table.orgId, table.brandId, table.email),

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { eq, and, count, inArray, or, sql, type SQL } from "drizzle-orm";
+import { eq, and, count, countDistinct, inArray, isNotNull, or, sql, type SQL } from "drizzle-orm";
 import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
 import { db } from "../db/index.js";
 import { servedLeads, leadBuffer } from "../db/schema.js";
@@ -78,11 +78,16 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
       const servedCol = COLUMN_MAP[field].served;
       const bufferCol = COLUMN_MAP[field].buffer;
 
-      const [servedRows, bufferRows] = await Promise.all([
+      const [servedRows, contactedRows, bufferRows] = await Promise.all([
         db
           .select({ key: servedCol, count: count() })
           .from(servedLeads)
           .where(and(...served.conds))
+          .groupBy(servedCol),
+        db
+          .select({ key: servedCol, count: countDistinct(servedLeads.leadId) })
+          .from(servedLeads)
+          .where(and(...served.conds, isNotNull(servedLeads.contactedAt)))
           .groupBy(servedCol),
         db
           .select({ key: bufferCol, status: leadBuffer.status, count: count() })
@@ -94,18 +99,21 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
       // Merge into a map keyed by groupBy value
       const groups = new Map<
         string,
-        { served: number; buffered: number; skipped: number }
+        { served: number; contacted: number; buffered: number; skipped: number }
       >();
 
       const getGroup = (key: string | null) => {
         const k = key ?? "unknown";
         if (!groups.has(k))
-          groups.set(k, { served: 0, buffered: 0, skipped: 0 });
+          groups.set(k, { served: 0, contacted: 0, buffered: 0, skipped: 0 });
         return groups.get(k)!;
       };
 
       for (const row of servedRows) {
         getGroup(row.key).served = row.count;
+      }
+      for (const row of contactedRows) {
+        getGroup(row.key).contacted = row.count;
       }
       for (const row of bufferRows) {
         const g = getGroup(row.key);
@@ -128,11 +136,16 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
     if (served.campaignIdStr) apolloFilters.campaignId = served.campaignIdStr;
     if (served.runIdList.length > 0) apolloFilters.runIds = served.runIdList;
 
-    const [servedResult, bufferRows, apollo] = await Promise.all([
+    const [servedResult, contactedResult, bufferRows, apollo] = await Promise.all([
       db
         .select({ count: count() })
         .from(servedLeads)
         .where(and(...served.conds))
+        .then(([r]) => r),
+      db
+        .select({ count: countDistinct(servedLeads.leadId) })
+        .from(servedLeads)
+        .where(and(...served.conds, isNotNull(servedLeads.contactedAt)))
         .then(([r]) => r),
       db
         .select({ status: leadBuffer.status, count: count() })
@@ -152,6 +165,7 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
 
     res.json({
       served: servedResult?.count ?? 0,
+      contacted: contactedResult?.count ?? 0,
       buffered: bufferByStatus["buffered"] ?? 0,
       skipped: bufferByStatus["skipped"] ?? 0,
       apollo,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -263,6 +263,7 @@ const ApolloStatsSchema = z.object({
 const StatsResponseSchema = z
   .object({
     served: z.number(),
+    contacted: z.number(),
     buffered: z.number(),
     skipped: z.number(),
     apollo: ApolloStatsSchema,
@@ -272,6 +273,7 @@ const StatsResponseSchema = z
 const StatsGroupSchema = z.object({
   key: z.string(),
   served: z.number(),
+  contacted: z.number(),
   buffered: z.number(),
   skipped: z.number(),
 });
@@ -406,7 +408,7 @@ registry.registerPath({
   path: "/stats",
   summary: "Get lead stats by status",
   description:
-    "Returns counts of leads by status: served (delivered with verified email), buffered (awaiting enrichment), and skipped (no email found).",
+    "Returns counts of leads by status: served (delivered with verified email), contacted (unique leads with at least one successful email send), buffered (awaiting enrichment), and skipped (no email found).",
   parameters: [
     ...AuthHeaders,
     {

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -106,6 +106,7 @@ describe("GET /stats", () => {
     const res = await request(app).get("/stats");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("served");
+    expect(res.body).toHaveProperty("contacted");
     expect(res.body).toHaveProperty("buffered");
     expect(res.body).toHaveProperty("skipped");
     expect(res.body).toHaveProperty("apollo");


### PR DESCRIPTION
## Summary
- Adds `contacted` field to `StatsResponse` and `StatsGroupedResponse` — counts distinct `lead_id`s with at least one successful email send (`contacted_at IS NOT NULL`)
- Adds `contacted_at` timestamp column to `served_leads` table (migration 0010)
- Available in both flat and grouped (`groupBy=campaignId` / `groupBy=brandId`) responses

## Note
The `contacted_at` column is nullable and unpopulated initially. A separate mechanism (webhook, cron, or endpoint) will be needed to set `contacted_at` on served leads when email delivery is confirmed. The stat will return 0 until then.

## Test plan
- [x] Unit tests pass — `contacted` field asserted in flat response
- [x] Grouped response includes `contacted` per group
- [x] Build + OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)