### PR TITLE
Use email-gateway for contacted count in stats

### DIFF
--- a/drizzle/0010_add_contacted_at.sql
+++ b/drizzle/0010_add_contacted_at.sql
@@ -1,1 +1,0 @@
-ALTER TABLE "served_leads" ADD COLUMN "contacted_at" timestamp with time zone;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,13 +71,6 @@
       "when": 1773619200000,
       "tag": "0009_add_workflow_name",
       "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1774012800000,
-      "tag": "0010_add_contacted_at",
-      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -49,7 +49,6 @@ export const servedLeads = pgTable(
     userId: text("user_id"),
     workflowName: text("workflow_name"),
     servedAt: timestamp("served_at", { withTimezone: true }).notNull().defaultNow(),
-    contactedAt: timestamp("contacted_at", { withTimezone: true }),
   },
   (table) => [
     uniqueIndex("idx_served_org_brand_email").on(table.orgId, table.brandId, table.email),

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,9 +1,14 @@
 import { Router } from "express";
-import { eq, and, count, countDistinct, inArray, isNotNull, or, sql, type SQL } from "drizzle-orm";
+import { eq, and, count, inArray, or, sql, type SQL } from "drizzle-orm";
 import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
 import { db } from "../db/index.js";
 import { servedLeads, leadBuffer } from "../db/schema.js";
 import { fetchApolloStats } from "../lib/apollo-client.js";
+import {
+  checkDeliveryStatus,
+  isContacted,
+  type DeliveryStatusItem,
+} from "../lib/email-gateway-client.js";
 
 const VALID_GROUP_BY = ["campaignId", "brandId"] as const;
 type GroupByField = (typeof VALID_GROUP_BY)[number];
@@ -57,6 +62,133 @@ function buildConditions(
   return { conds, runIdList, brandIdStr, campaignIdStr, orgIdStr };
 }
 
+/**
+ * Count distinct contacted leads by querying email-gateway for delivery status.
+ * Groups served leads by brandId+campaignId, calls email-gateway per group,
+ * and returns the count of unique leadIds confirmed contacted.
+ */
+async function countContacted(
+  servedConds: SQL[],
+  context: { orgId?: string; userId?: string; runId?: string },
+): Promise<number> {
+  const rows = await db
+    .select({
+      leadId: servedLeads.leadId,
+      email: servedLeads.email,
+      brandId: servedLeads.brandId,
+      campaignId: servedLeads.campaignId,
+    })
+    .from(servedLeads)
+    .where(and(...servedConds));
+
+  if (rows.length === 0) return 0;
+
+  // Group by brandId+campaignId since email-gateway scopes status per brand/campaign
+  const groups = new Map<string, { brandId: string; campaignId: string; items: DeliveryStatusItem[] }>();
+  for (const row of rows) {
+    if (!row.leadId) continue;
+    const key = `${row.brandId}::${row.campaignId}`;
+    if (!groups.has(key)) {
+      groups.set(key, { brandId: row.brandId, campaignId: row.campaignId, items: [] });
+    }
+    groups.get(key)!.items.push({ leadId: row.leadId, email: row.email });
+  }
+
+  const contactedLeadIds = new Set<string>();
+
+  await Promise.all(
+    Array.from(groups.values()).map(async (group) => {
+      const response = await checkDeliveryStatus(
+        group.brandId,
+        group.campaignId,
+        group.items,
+        context,
+      );
+      if (!response) return;
+      for (const result of response.results) {
+        if (isContacted(result)) {
+          // Find the leadId for this email
+          const item = group.items.find((i) => i.email === result.email);
+          if (item) contactedLeadIds.add(item.leadId);
+        }
+      }
+    }),
+  );
+
+  return contactedLeadIds.size;
+}
+
+/**
+ * Count contacted leads per groupBy dimension (brandId or campaignId).
+ */
+async function countContactedGrouped(
+  servedConds: SQL[],
+  groupByField: GroupByField,
+  context: { orgId?: string; userId?: string; runId?: string },
+): Promise<Map<string, number>> {
+  const groupCol = COLUMN_MAP[groupByField].served;
+
+  const rows = await db
+    .select({
+      leadId: servedLeads.leadId,
+      email: servedLeads.email,
+      brandId: servedLeads.brandId,
+      campaignId: servedLeads.campaignId,
+      groupKey: groupCol,
+    })
+    .from(servedLeads)
+    .where(and(...servedConds));
+
+  if (rows.length === 0) return new Map();
+
+  // Group by brandId+campaignId for email-gateway calls
+  const callGroups = new Map<string, { brandId: string; campaignId: string; items: (DeliveryStatusItem & { groupKey: string })[] }>();
+  for (const row of rows) {
+    if (!row.leadId) continue;
+    const key = `${row.brandId}::${row.campaignId}`;
+    if (!callGroups.has(key)) {
+      callGroups.set(key, { brandId: row.brandId, campaignId: row.campaignId, items: [] });
+    }
+    callGroups.get(key)!.items.push({
+      leadId: row.leadId,
+      email: row.email,
+      groupKey: row.groupKey ?? "unknown",
+    });
+  }
+
+  // Track contacted leadIds per groupBy key
+  const contactedPerGroup = new Map<string, Set<string>>();
+
+  await Promise.all(
+    Array.from(callGroups.values()).map(async (group) => {
+      const response = await checkDeliveryStatus(
+        group.brandId,
+        group.campaignId,
+        group.items,
+        context,
+      );
+      if (!response) return;
+      for (const result of response.results) {
+        if (isContacted(result)) {
+          const item = group.items.find((i) => i.email === result.email);
+          if (item) {
+            if (!contactedPerGroup.has(item.groupKey)) {
+              contactedPerGroup.set(item.groupKey, new Set());
+            }
+            contactedPerGroup.get(item.groupKey)!.add(item.leadId);
+          }
+        }
+      }
+    }),
+  );
+
+  const result = new Map<string, number>();
+  for (const [key, set] of contactedPerGroup) {
+    result.set(key, set.size);
+  }
+  return result;
+}
+
 router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const groupByParam =
@@ -71,6 +203,7 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
 
     const served = buildConditions(req, "served");
     const buffer = buildConditions(req, "buffer");
+    const egContext = { orgId: req.orgId, userId: req.userId, runId: req.runId };
 
     // --- Grouped response ---
     if (groupByParam) {
@@ -78,17 +211,13 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
       const servedCol = COLUMN_MAP[field].served;
       const bufferCol = COLUMN_MAP[field].buffer;
 
-      const [servedRows, contactedRows, bufferRows] = await Promise.all([
+      const [servedRows, contactedMap, bufferRows] = await Promise.all([
         db
           .select({ key: servedCol, count: count() })
           .from(servedLeads)
           .where(and(...served.conds))
           .groupBy(servedCol),
-        db
-          .select({ key: servedCol, count: countDistinct(servedLeads.leadId) })
-          .from(servedLeads)
-          .where(and(...served.conds, isNotNull(servedLeads.contactedAt)))
-          .groupBy(servedCol),
+        countContactedGrouped(served.conds, field, egContext),
         db
           .select({ key: bufferCol, status: leadBuffer.status, count: count() })
           .from(leadBuffer)
@@ -112,8 +241,8 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
       for (const row of servedRows) {
         getGroup(row.key).served = row.count;
       }
-      for (const row of contactedRows) {
-        getGroup(row.key).contacted = row.count;
+      for (const [key, contacted] of contactedMap) {
+        getGroup(key).contacted = contacted;
       }
       for (const row of bufferRows) {
         const g = getGroup(row.key);
@@ -130,23 +259,19 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
       return;
     }
 
-    // --- Flat response (existing behavior) ---
+    // --- Flat response ---
     const apolloFilters: Record<string, unknown> = {};
     if (served.brandIdStr) apolloFilters.brandId = served.brandIdStr;
     if (served.campaignIdStr) apolloFilters.campaignId = served.campaignIdStr;
     if (served.runIdList.length > 0) apolloFilters.runIds = served.runIdList;
 
-    const [servedResult, contactedResult, bufferRows, apollo] = await Promise.all([
+    const [servedResult, contacted, bufferRows, apollo] = await Promise.all([
       db
         .select({ count: count() })
         .from(servedLeads)
         .where(and(...served.conds))
         .then(([r]) => r),
-      db
-        .select({ count: countDistinct(servedLeads.leadId) })
-        .from(servedLeads)
-        .where(and(...served.conds, isNotNull(servedLeads.contactedAt)))
-        .then(([r]) => r),
+      countContacted(served.conds, egContext),
       db
         .select({ status: leadBuffer.status, count: count() })
         .from(leadBuffer)
@@ -165,7 +290,7 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
 
     res.json({
       served: servedResult?.count ?? 0,
-      contacted: contactedResult?.count ?? 0,
+      contacted,
       buffered: bufferByStatus["buffered"] ?? 0,
       skipped: bufferByStatus["skipped"] ?? 0,
       apollo,

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Response } from "express";
 
-// Mock db
+// Mock db — where() returns whatever mockWhere returns
 const mockFrom = vi.fn();
 const mockWhere = vi.fn();
 const mockGroupBy = vi.fn();
 const mockSelect = vi.fn();
-const mockThen = vi.fn();
 
 vi.mock("../../src/db/index.js", () => ({
   db: {
@@ -16,16 +15,7 @@ vi.mock("../../src/db/index.js", () => ({
         from: (...fArgs: unknown[]) => {
           mockFrom(...fArgs);
           return {
-            where: (...wArgs: unknown[]) => {
-              mockWhere(...wArgs);
-              return {
-                then: mockThen,
-                groupBy: (...gArgs: unknown[]) => {
-                  mockGroupBy(...gArgs);
-                  return Promise.resolve([]);
-                },
-              };
-            },
+            where: (...wArgs: unknown[]) => mockWhere(...wArgs),
           };
         },
       };
@@ -40,6 +30,13 @@ vi.mock("../../src/lib/apollo-client.js", () => ({
     fetchedPeopleCount: 0,
     totalMatchingPeople: 0,
   }),
+}));
+
+const mockCheckDeliveryStatus = vi.fn();
+vi.mock("../../src/lib/email-gateway-client.js", () => ({
+  checkDeliveryStatus: (...args: unknown[]) => mockCheckDeliveryStatus(...args),
+  isContacted: (result: { broadcast?: { campaign: { lead: { contacted: boolean } } } }) =>
+    !!(result.broadcast?.campaign.lead.contacted),
 }));
 
 vi.mock("../../src/middleware/auth.js", () => ({
@@ -62,13 +59,20 @@ function createApp() {
   return app;
 }
 
+/** Helper: create a thenable that also has .groupBy() */
+function queryResult(data: unknown[]) {
+  return {
+    then: (fn: (rows: unknown[]) => unknown) => Promise.resolve(fn(data)),
+    groupBy: () => Promise.resolve([]),
+  };
+}
+
 describe("GET /stats", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: flat query returns served=0, buffer=[]
-    mockThen.mockImplementation((fn: (rows: unknown[]) => unknown) =>
-      Promise.resolve(fn([{ count: 0 }])),
-    );
+    // Default: all queries return zero/empty
+    mockWhere.mockReturnValue(queryResult([{ count: 0 }]));
+    mockCheckDeliveryStatus.mockResolvedValue(null);
   });
 
   it("returns 400 for invalid groupBy value", async () => {
@@ -80,12 +84,6 @@ describe("GET /stats", () => {
 
   it("accepts groupBy=campaignId", async () => {
     const app = createApp();
-    // Mock grouped queries to return empty arrays
-    mockGroupBy.mockReturnValue(Promise.resolve([]));
-    mockThen.mockImplementation((fn: (rows: unknown[]) => unknown) =>
-      Promise.resolve(fn([{ count: 0 }])),
-    );
-
     const res = await request(app).get("/stats?groupBy=campaignId");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
@@ -94,14 +92,12 @@ describe("GET /stats", () => {
 
   it("accepts groupBy=brandId", async () => {
     const app = createApp();
-    mockGroupBy.mockReturnValue(Promise.resolve([]));
-
     const res = await request(app).get("/stats?groupBy=brandId");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
   });
 
-  it("returns flat response without groupBy", async () => {
+  it("returns flat response without groupBy including contacted=0", async () => {
     const app = createApp();
     const res = await request(app).get("/stats");
     expect(res.status).toBe(200);
@@ -111,5 +107,84 @@ describe("GET /stats", () => {
     expect(res.body).toHaveProperty("skipped");
     expect(res.body).toHaveProperty("apollo");
     expect(res.body).not.toHaveProperty("groups");
+    expect(res.body.contacted).toBe(0);
+  });
+
+  it("counts contacted leads via email-gateway", async () => {
+    const app = createApp();
+
+    const servedLeadRows = [
+      { leadId: "lead-1", email: "alice@acme.com", brandId: "b1", campaignId: "c1" },
+      { leadId: "lead-2", email: "bob@acme.com", brandId: "b1", campaignId: "c1" },
+    ];
+
+    // Flat response Promise.all order:
+    //   1. served count: .where().then(([r]) => r)
+    //   2. countContacted: await .where()
+    //   3. buffer: .where().groupBy()
+    let whereCall = 0;
+    mockWhere.mockImplementation(() => {
+      whereCall++;
+      const c = whereCall;
+      if (c === 1) return queryResult([{ count: 2 }]);
+      if (c === 2) return queryResult(servedLeadRows);
+      return queryResult([]);
+    });
+
+    mockCheckDeliveryStatus.mockResolvedValue({
+      results: [
+        {
+          leadId: "lead-1",
+          email: "alice@acme.com",
+          broadcast: {
+            campaign: { lead: { contacted: true }, email: { contacted: true } },
+            brand: { lead: { contacted: false }, email: { contacted: false } },
+            global: { email: { contacted: false } },
+          },
+        },
+        {
+          leadId: "lead-2",
+          email: "bob@acme.com",
+          broadcast: {
+            campaign: { lead: { contacted: false }, email: { contacted: false } },
+            brand: { lead: { contacted: false }, email: { contacted: false } },
+            global: { email: { contacted: false } },
+          },
+        },
+      ],
+    });
+
+    const res = await request(app).get("/stats");
+    expect(res.status).toBe(200);
+    expect(res.body.served).toBe(2);
+    expect(res.body.contacted).toBe(1);
+    expect(mockCheckDeliveryStatus).toHaveBeenCalledWith(
+      "b1", "c1",
+      [{ leadId: "lead-1", email: "alice@acme.com" }, { leadId: "lead-2", email: "bob@acme.com" }],
+      expect.objectContaining({ orgId: "org-1" }),
+    );
+  });
+
+  it("returns contacted=0 when email-gateway is unreachable", async () => {
+    const app = createApp();
+
+    let whereCall = 0;
+    mockWhere.mockImplementation(() => {
+      whereCall++;
+      if (whereCall === 1) return queryResult([{ count: 1 }]);
+      if (whereCall === 2) {
+        return queryResult([
+          { leadId: "lead-1", email: "alice@acme.com", brandId: "b1", campaignId: "c1" },
+        ]);
+      }
+      return queryResult([]);
+    });
+
+    mockCheckDeliveryStatus.mockResolvedValue(null);
+
+    const res = await request(app).get("/stats");
+    expect(res.status).toBe(200);
+    expect(res.body.served).toBe(1);
+    expect(res.body.contacted).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Replaces the `contacted_at` column approach (#96) with live email-gateway queries
- `countContacted()` fetches served leads, calls `checkDeliveryStatus` per brand+campaign group, counts distinct contacted leadIds
- Works for both flat and grouped (`groupBy=campaignId`/`brandId`) responses
- Removes the unused `contacted_at` migration — no DB changes needed
- Gracefully returns `contacted: 0` if email-gateway is unreachable

## Test plan
- [x] New test: counts contacted leads via email-gateway mock (1/2 contacted → contacted=1)
- [x] New test: returns contacted=0 when email-gateway unreachable
- [x] Existing tests pass (flat, grouped, validation)
- [x] Build + OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)