### PR TITLE
Remove verbose per-lead console logs

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -192,7 +192,6 @@ async function fillBufferFromSearch(params: {
     }
 
     // All people on this page were dupes — continue to next page
-    console.log(`[fillBuffer] Page ${page}: all ${result.people.length} people already seen, continuing`);
 
     if (result.done) {
       console.log(`[fillBuffer] Apollo exhausted all pages, no new leads found`);
@@ -299,10 +298,8 @@ export async function pullNext(params: {
           // Use cached enrichment — no apollo-service call needed
           email = cached.email;
           enrichedData = cached.responseRaw ?? row.data;
-          console.log(`[pullNext] Enrichment cache hit for personId=${row.externalId}`);
         } else {
           // Previously enriched but no email found — skip without calling Apollo
-          console.log(`[pullNext] Enrichment cache hit (no email) for personId=${row.externalId}, skipping`);
           await db
             .update(leadBuffer)
             .set({ status: "skipped" })
@@ -320,7 +317,6 @@ export async function pullNext(params: {
         });
 
         if (!enrichResult?.person?.email) {
-          console.log(`[pullNext] Enrichment returned no email for personId=${row.externalId}`);
           // Cache the no-email result to avoid re-enriching this person
           await db.insert(enrichments).values({
             email: null,
@@ -370,7 +366,6 @@ export async function pullNext(params: {
 
     // Skip leads with no email — found: true must always have a usable email
     if (!email) {
-      console.log(`[pullNext] No email after enrichment for buffer row ${row.id}, skipping`);
       await db
         .update(leadBuffer)
         .set({ status: "skipped" })
@@ -421,7 +416,7 @@ export async function pullNext(params: {
 
     if (!inserted) {
       // Another request already served this email for this org+brand — skip
-      console.log(`[pullNext] markServed conflict for ${email}, already served — skipping`);
+      // Another concurrent request already served this email — skip
       await db
         .update(leadBuffer)
         .set({ status: "skipped" })
@@ -440,7 +435,6 @@ export async function pullNext(params: {
         ? { ...(enrichedData as Record<string, unknown>), email }
         : { email };
 
-    console.log(`[pullNext] Served lead: ${email} (leadId=${leadId})`);
 
     return {
       found: true,

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -24,11 +24,7 @@ export async function checkContacted(
 
   if (statusResponse) {
     for (const sr of statusResponse.results) {
-      const contacted = isContacted(sr);
-      console.log(
-        `[dedup] contacted check: email=${sr.email} contacted=${contacted} brandId=${brandId} campaignId=${campaignId}`
-      );
-      result.set(sr.email, contacted);
+      result.set(sr.email, isContacted(sr));
     }
   } else {
     console.warn(

--- a/src/lib/register-providers.ts
+++ b/src/lib/register-providers.ts
@@ -57,7 +57,6 @@ export async function registerProviders(): Promise<void> {
   await Promise.all(
     registrations.map(({ provider, method, path }) =>
       registerProviderRequirement(provider, "lead", method, path)
-        .then(() => console.log(`[register-providers] Registered lead ${method} ${path} → ${provider}`))
         .catch((err) => console.warn(`[register-providers] Failed to register lead ${method} ${path} → ${provider}:`, err))
     )
   );

--- a/tests/unit/dedup.test.ts
+++ b/tests/unit/dedup.test.ts
@@ -71,25 +71,6 @@ describe("dedup", () => {
       expect(result.get("bob@acme.com")).toBe(false);
     });
 
-    it("logs contacted status for each email", async () => {
-      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-      vi.mocked(checkDeliveryStatus).mockResolvedValue({
-        results: [
-          { leadId: "lead-1", email: "alice@acme.com" } as never,
-        ],
-      });
-      vi.mocked(isContacted).mockReturnValue(true);
-
-      await checkContacted("brand-1", "campaign-1", [
-        { leadId: "lead-1", email: "alice@acme.com" },
-      ]);
-
-      expect(logSpy).toHaveBeenCalledWith(
-        "[dedup] contacted check: email=alice@acme.com contacted=true brandId=brand-1 campaignId=campaign-1"
-      );
-      logSpy.mockRestore();
-    });
-
     it("handles batch of multiple emails with mixed results", async () => {
       vi.mocked(checkDeliveryStatus).mockResolvedValue({
         results: [

--- a/tests/unit/register-providers.test.ts
+++ b/tests/unit/register-providers.test.ts
@@ -232,20 +232,17 @@ describe("registerProviders", () => {
       text: () => Promise.resolve("Server error"),
     });
 
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await registerProviders();
 
     // 1 query + 2 registration attempts
     expect(mockFetch).toHaveBeenCalledTimes(3);
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Registered lead POST /buffer/next"));
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("Failed to register lead POST /buffer/next"),
       expect.any(Error)
     );
 
-    logSpy.mockRestore();
     warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Remove per-email contacted check logs from `dedup.ts` (the `[dedup] contacted check: email=...` lines)
- Remove per-person enrichment cache hit/miss logs from `buffer.ts`
- Remove per-lead served/skipped logs from `buffer.ts`
- Remove per-registration success logs from `register-providers.ts`
- Keep all warnings, errors, and summary-level logs (e.g. "Buffered N leads from page X", "Apollo exhausted all pages")

## Test plan
- [x] Unit tests pass (`npm test`)
- [x] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)