### PR TITLE
Add billing credit authorization before lead-serve

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -792,6 +792,32 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "402": {
+            "description": "Insufficient credits",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "balance_cents": {
+                      "type": "number"
+                    },
+                    "required_cents": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "balance_cents",
+                    "required_cents"
+                  ]
+                }
+              }
+            }
           }
         }
       }

--- a/src/lib/billing-client.ts
+++ b/src/lib/billing-client.ts
@@ -1,0 +1,49 @@
+export interface AuthorizeCreditsResult {
+  sufficient: boolean;
+  balance_cents: number;
+}
+
+export async function authorizeCredits(params: {
+  requiredCents: number;
+  description: string;
+  orgId: string;
+  userId: string;
+  runId: string;
+  campaignId?: string;
+  brandId?: string;
+  workflowName?: string;
+}): Promise<AuthorizeCreditsResult> {
+  const billingUrl = process.env.BILLING_SERVICE_URL || "";
+  const billingApiKey = process.env.BILLING_SERVICE_API_KEY || "";
+
+  if (!billingUrl) {
+    throw new Error("BILLING_SERVICE_URL not configured");
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-API-Key": billingApiKey,
+    "x-org-id": params.orgId,
+    "x-user-id": params.userId,
+    "x-run-id": params.runId,
+  };
+  if (params.campaignId) headers["x-campaign-id"] = params.campaignId;
+  if (params.brandId) headers["x-brand-id"] = params.brandId;
+  if (params.workflowName) headers["x-workflow-name"] = params.workflowName;
+
+  const response = await fetch(`${billingUrl}/v1/credits/authorize`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      required_cents: params.requiredCents,
+      description: params.description,
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Billing service call failed: ${response.status} - ${error}`);
+  }
+
+  return response.json() as Promise<AuthorizeCreditsResult>;
+}

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -3,9 +3,12 @@ import { eq, lt } from "drizzle-orm";
 import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
 import { pullNext } from "../lib/buffer.js";
 import { createRun, updateRun } from "../lib/runs-client.js";
+import { authorizeCredits } from "../lib/billing-client.js";
 import { BufferNextRequestSchema } from "../schemas.js";
 import { db } from "../db/index.js";
 import { idempotencyCache } from "../db/schema.js";
+
+const LEAD_SERVE_COST_CENTS = 5;
 
 const router = Router();
 
@@ -60,6 +63,45 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       workflowName,
     });
     const serveRunId = childRun.id;
+
+    // Credit authorization — block if insufficient balance
+    try {
+      const { sufficient, balance_cents } = await authorizeCredits({
+        requiredCents: LEAD_SERVE_COST_CENTS,
+        description: "lead-serve — apollo-search+enrich",
+        orgId: req.orgId!,
+        userId: req.userId!,
+        runId: serveRunId,
+        campaignId,
+        brandId,
+        workflowName,
+      });
+
+      if (!sufficient) {
+        await updateRun(serveRunId, "failed", {
+          orgId: req.orgId,
+          userId: req.userId,
+          campaignId,
+          brandId,
+          workflowName,
+        });
+        return res.status(402).json({
+          error: "Insufficient credits",
+          balance_cents,
+          required_cents: LEAD_SERVE_COST_CENTS,
+        });
+      }
+    } catch (err) {
+      console.error("[buffer/next] Billing authorization failed:", err);
+      await updateRun(serveRunId, "failed", {
+        orgId: req.orgId,
+        userId: req.userId,
+        campaignId,
+        brandId,
+        workflowName,
+      });
+      return res.status(502).json({ error: "Billing service unavailable" });
+    }
 
     const result = await pullNext({
       orgId: req.orgId!,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -319,6 +319,18 @@ registry.registerPath({
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
     401: { description: "Unauthorized" },
+    402: {
+      description: "Insufficient credits",
+      content: {
+        "application/json": {
+          schema: z.object({
+            error: z.string(),
+            balance_cents: z.number(),
+            required_cents: z.number(),
+          }),
+        },
+      },
+    },
   },
 });
 

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./setup.js";
 import { createRun } from "../../src/lib/runs-client.js";
 import { checkDeliveryStatus, isContacted } from "../../src/lib/email-gateway-client.js";
+import { authorizeCredits } from "../../src/lib/billing-client.js";
 
 vi.mock("../../src/lib/runs-client.js", () => ({
   createRun: vi.fn().mockResolvedValue({ id: "mock-run-id" }),
@@ -20,6 +21,10 @@ vi.mock("../../src/lib/runs-client.js", () => ({
 vi.mock("../../src/lib/email-gateway-client.js", () => ({
   checkDeliveryStatus: vi.fn().mockResolvedValue({ results: [] }),
   isContacted: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../../src/lib/billing-client.js", () => ({
+  authorizeCredits: vi.fn().mockResolvedValue({ sufficient: true, balance_cents: 1000 }),
 }));
 
 describe("API Integration Tests", () => {
@@ -127,6 +132,49 @@ describe("API Integration Tests", () => {
 
       expect(res.status).toBe(400);
       expect(res.body.details.fieldErrors.brandId).toBeDefined();
+    });
+
+    it("returns 402 when credits are insufficient", async () => {
+      vi.mocked(authorizeCredits).mockResolvedValueOnce({
+        sufficient: false,
+        balance_cents: 2,
+      });
+
+      await seedBuffer({
+        campaignId: "campaign-billing-402",
+        brandId: "brand-billing-402",
+        leads: [{ email: "billing@example.com" }],
+      });
+
+      const res = await request(app)
+        .post("/buffer/next")
+        .set(getAuthHeaders())
+        .send({ campaignId: "campaign-billing-402", brandId: "brand-billing-402" });
+
+      expect(res.status).toBe(402);
+      expect(res.body.error).toBe("Insufficient credits");
+      expect(res.body.balance_cents).toBe(2);
+      expect(res.body.required_cents).toBe(5);
+    });
+
+    it("returns 502 when billing service is unreachable", async () => {
+      vi.mocked(authorizeCredits).mockRejectedValueOnce(
+        new Error("Billing service call failed: 500")
+      );
+
+      await seedBuffer({
+        campaignId: "campaign-billing-502",
+        brandId: "brand-billing-502",
+        leads: [{ email: "billing502@example.com" }],
+      });
+
+      const res = await request(app)
+        .post("/buffer/next")
+        .set(getAuthHeaders())
+        .send({ campaignId: "campaign-billing-502", brandId: "brand-billing-502" });
+
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBe("Billing service unavailable");
     });
 
     it("passes workflowName to createRun", async () => {

--- a/tests/unit/billing-client.test.ts
+++ b/tests/unit/billing-client.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { authorizeCredits } from "../../src/lib/billing-client.js";
+
+describe("billing-client", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.BILLING_SERVICE_URL = "http://billing.test";
+    process.env.BILLING_SERVICE_API_KEY = "test-billing-key";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it("returns sufficient: true when balance is enough", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ sufficient: true, balance_cents: 500 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const result = await authorizeCredits({
+      requiredCents: 5,
+      description: "lead-serve — apollo-search+enrich",
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    expect(result.sufficient).toBe(true);
+    expect(result.balance_cents).toBe(500);
+  });
+
+  it("returns sufficient: false when balance is insufficient", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ sufficient: false, balance_cents: 2 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const result = await authorizeCredits({
+      requiredCents: 5,
+      description: "lead-serve — apollo-search+enrich",
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    expect(result.sufficient).toBe(false);
+    expect(result.balance_cents).toBe(2);
+  });
+
+  it("forwards all headers including optional campaign/brand/workflow", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ sufficient: true, balance_cents: 100 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    await authorizeCredits({
+      requiredCents: 5,
+      description: "test",
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+      campaignId: "camp-1",
+      brandId: "brand-1",
+      workflowName: "cold-email",
+    });
+
+    const [url, opts] = fetchSpy.mock.calls[0];
+    expect(url).toBe("http://billing.test/v1/credits/authorize");
+    const headers = opts!.headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org-1");
+    expect(headers["x-user-id"]).toBe("user-1");
+    expect(headers["x-run-id"]).toBe("run-1");
+    expect(headers["x-campaign-id"]).toBe("camp-1");
+    expect(headers["x-brand-id"]).toBe("brand-1");
+    expect(headers["x-workflow-name"]).toBe("cold-email");
+  });
+
+  it("sends required_cents and description in body", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ sufficient: true, balance_cents: 100 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    await authorizeCredits({
+      requiredCents: 5,
+      description: "lead-serve — apollo-search+enrich",
+      orgId: "org-1",
+      userId: "user-1",
+      runId: "run-1",
+    });
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+    expect(body.required_cents).toBe(5);
+    expect(body.description).toBe("lead-serve — apollo-search+enrich");
+  });
+
+  it("throws when billing service returns non-OK status", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response("Internal Server Error", { status: 500 })
+    );
+
+    await expect(
+      authorizeCredits({
+        requiredCents: 5,
+        description: "test",
+        orgId: "org-1",
+        userId: "user-1",
+        runId: "run-1",
+      })
+    ).rejects.toThrow("Billing service call failed: 500");
+  });
+
+  it("throws when BILLING_SERVICE_URL is not configured", async () => {
+    process.env.BILLING_SERVICE_URL = "";
+
+    await expect(
+      authorizeCredits({
+        requiredCents: 5,
+        description: "test",
+        orgId: "org-1",
+        userId: "user-1",
+        runId: "run-1",
+      })
+    ).rejects.toThrow("BILLING_SERVICE_URL not configured");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds credit authorization via billing-service before executing `POST /buffer/next` (the only paid operation in lead-service)
- Returns **402** with `{ error, balance_cents, required_cents }` when credits are insufficient
- Returns **502** when billing-service is unreachable (mandatory — never silently proceed)
- Marks the child run as `failed` on both 402 and 502 paths
- Forwards all required headers (`x-org-id`, `x-user-id`, `x-run-id`, `x-campaign-id`, `x-brand-id`, `x-workflow-name`) to billing-service
- Updated OpenAPI spec with 402 response schema

## Test plan
- [x] Unit tests for `billing-client.ts` (sufficient/insufficient/headers/body/errors)
- [x] Integration tests for 402 (insufficient credits) and 502 (billing unavailable) on `POST /buffer/next`
- [x] All existing unit tests pass (98/98)

## Deploy requirements
Two new env vars on Railway:
- `BILLING_SERVICE_URL`
- `BILLING_SERVICE_API_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)