### PR TITLE
Fix billing to send items instead of required_cents

### DIFF
--- a/src/lib/billing-client.ts
+++ b/src/lib/billing-client.ts
@@ -1,10 +1,16 @@
+export interface CostItem {
+  costName: string;
+  quantity: number;
+}
+
 export interface AuthorizeCreditsResult {
   sufficient: boolean;
   balance_cents: number;
+  required_cents: number;
 }
 
 export async function authorizeCredits(params: {
-  requiredCents: number;
+  items: CostItem[];
   description: string;
   orgId: string;
   userId: string;
@@ -35,7 +41,7 @@ export async function authorizeCredits(params: {
     method: "POST",
     headers,
     body: JSON.stringify({
-      required_cents: params.requiredCents,
+      items: params.items,
       description: params.description,
     }),
   });

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -8,8 +8,6 @@ import { BufferNextRequestSchema } from "../schemas.js";
 import { db } from "../db/index.js";
 import { idempotencyCache } from "../db/schema.js";
 
-const LEAD_SERVE_COST_CENTS = 5;
-
 const router = Router();
 
 const IDEMPOTENCY_TTL_DAYS = 60;
@@ -66,8 +64,8 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
 
     // Credit authorization — block if insufficient balance
     try {
-      const { sufficient, balance_cents } = await authorizeCredits({
-        requiredCents: LEAD_SERVE_COST_CENTS,
+      const { sufficient, balance_cents, required_cents } = await authorizeCredits({
+        items: [{ costName: "lead-serve", quantity: 1 }],
         description: "lead-serve — apollo-search+enrich",
         orgId: req.orgId!,
         userId: req.userId!,
@@ -88,7 +86,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
         return res.status(402).json({
           error: "Insufficient credits",
           balance_cents,
-          required_cents: LEAD_SERVE_COST_CENTS,
+          required_cents,
         });
       }
     } catch (err) {

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -24,7 +24,7 @@ vi.mock("../../src/lib/email-gateway-client.js", () => ({
 }));
 
 vi.mock("../../src/lib/billing-client.js", () => ({
-  authorizeCredits: vi.fn().mockResolvedValue({ sufficient: true, balance_cents: 1000 }),
+  authorizeCredits: vi.fn().mockResolvedValue({ sufficient: true, balance_cents: 1000, required_cents: 5 }),
 }));
 
 describe("API Integration Tests", () => {
@@ -138,6 +138,7 @@ describe("API Integration Tests", () => {
       vi.mocked(authorizeCredits).mockResolvedValueOnce({
         sufficient: false,
         balance_cents: 2,
+        required_cents: 5,
       });
 
       await seedBuffer({

--- a/tests/unit/billing-client.test.ts
+++ b/tests/unit/billing-client.test.ts
@@ -16,14 +16,14 @@ describe("billing-client", () => {
 
   it("returns sufficient: true when balance is enough", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ sufficient: true, balance_cents: 500 }), {
+      new Response(JSON.stringify({ sufficient: true, balance_cents: 500, required_cents: 5 }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       })
     );
 
     const result = await authorizeCredits({
-      requiredCents: 5,
+      items: [{ costName: "lead-serve", quantity: 1 }],
       description: "lead-serve — apollo-search+enrich",
       orgId: "org-1",
       userId: "user-1",
@@ -32,18 +32,19 @@ describe("billing-client", () => {
 
     expect(result.sufficient).toBe(true);
     expect(result.balance_cents).toBe(500);
+    expect(result.required_cents).toBe(5);
   });
 
   it("returns sufficient: false when balance is insufficient", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ sufficient: false, balance_cents: 2 }), {
+      new Response(JSON.stringify({ sufficient: false, balance_cents: 2, required_cents: 5 }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       })
     );
 
     const result = await authorizeCredits({
-      requiredCents: 5,
+      items: [{ costName: "lead-serve", quantity: 1 }],
       description: "lead-serve — apollo-search+enrich",
       orgId: "org-1",
       userId: "user-1",
@@ -52,18 +53,19 @@ describe("billing-client", () => {
 
     expect(result.sufficient).toBe(false);
     expect(result.balance_cents).toBe(2);
+    expect(result.required_cents).toBe(5);
   });
 
   it("forwards all headers including optional campaign/brand/workflow", async () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ sufficient: true, balance_cents: 100 }), {
+      new Response(JSON.stringify({ sufficient: true, balance_cents: 100, required_cents: 5 }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       })
     );
 
     await authorizeCredits({
-      requiredCents: 5,
+      items: [{ costName: "lead-serve", quantity: 1 }],
       description: "test",
       orgId: "org-1",
       userId: "user-1",
@@ -84,16 +86,16 @@ describe("billing-client", () => {
     expect(headers["x-workflow-name"]).toBe("cold-email");
   });
 
-  it("sends required_cents and description in body", async () => {
+  it("sends items and description in body", async () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ sufficient: true, balance_cents: 100 }), {
+      new Response(JSON.stringify({ sufficient: true, balance_cents: 100, required_cents: 5 }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       })
     );
 
     await authorizeCredits({
-      requiredCents: 5,
+      items: [{ costName: "lead-serve", quantity: 1 }],
       description: "lead-serve — apollo-search+enrich",
       orgId: "org-1",
       userId: "user-1",
@@ -101,7 +103,7 @@ describe("billing-client", () => {
     });
 
     const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
-    expect(body.required_cents).toBe(5);
+    expect(body.items).toEqual([{ costName: "lead-serve", quantity: 1 }]);
     expect(body.description).toBe("lead-serve — apollo-search+enrich");
   });
 
@@ -112,7 +114,7 @@ describe("billing-client", () => {
 
     await expect(
       authorizeCredits({
-        requiredCents: 5,
+        items: [{ costName: "lead-serve", quantity: 1 }],
         description: "test",
         orgId: "org-1",
         userId: "user-1",
@@ -126,7 +128,7 @@ describe("billing-client", () => {
 
     await expect(
       authorizeCredits({
-        requiredCents: 5,
+        items: [{ costName: "lead-serve", quantity: 1 }],
         description: "test",
         orgId: "org-1",
         userId: "user-1",


### PR DESCRIPTION
## Summary
- Corrects the billing authorization contract per the correction memo
- Sends `items: [{ costName, quantity }]` instead of `required_cents` — billing-service resolves prices internally
- `required_cents` now comes from the billing-service response, not hardcoded

## Test plan
- [x] Updated billing-client unit tests (items in body, required_cents from response)
- [x] Updated integration test mocks
- [x] All 98 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)