### PR TITLE
Add x-feature-slug header propagation

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -758,6 +758,15 @@
               "type": "string"
             },
             "description": "Workflow name (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-feature-slug",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug for tracking (propagated through the call chain)"
           }
         ],
         "requestBody": {
@@ -864,6 +873,15 @@
             "description": "Workflow name (auto-injected by workflow-service)"
           },
           {
+            "in": "header",
+            "name": "x-feature-slug",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug for tracking (propagated through the call chain)"
+          },
+          {
             "schema": {
               "type": "string"
             },
@@ -953,6 +971,15 @@
               "type": "string"
             },
             "description": "Workflow name (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-feature-slug",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug for tracking (propagated through the call chain)"
           },
           {
             "schema": {
@@ -1065,6 +1092,15 @@
               "type": "string"
             },
             "description": "Workflow name (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-feature-slug",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug for tracking (propagated through the call chain)"
           },
           {
             "in": "query",
@@ -1183,6 +1219,15 @@
               "type": "string"
             },
             "description": "Workflow name (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-feature-slug",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug for tracking (propagated through the call chain)"
           },
           {
             "in": "query",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -48,6 +48,7 @@ export const servedLeads = pgTable(
     orgId: text("org_id").notNull(),
     userId: text("user_id"),
     workflowName: text("workflow_name"),
+    featureSlug: text("feature_slug"),
     servedAt: timestamp("served_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
@@ -75,6 +76,7 @@ export const leadBuffer = pgTable(
     orgId: text("org_id").notNull(),
     userId: text("user_id"),
     workflowName: text("workflow_name"),
+    featureSlug: text("feature_slug"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -139,7 +139,7 @@ interface ApolloSearchRawResponse {
 export async function apolloSearch(
   params: ApolloSearchParams,
   page: number = 1,
-  options?: { runId?: string | null; orgId?: string | null; userId?: string | null; brandId?: string; campaignId?: string; workflowName?: string }
+  options?: { runId?: string | null; orgId?: string | null; userId?: string | null; brandId?: string; campaignId?: string; workflowName?: string; featureSlug?: string }
 ): Promise<ApolloSearchResult | null> {
   try {
     const headers: Record<string, string> = {};
@@ -149,6 +149,7 @@ export async function apolloSearch(
     if (options?.brandId) headers["x-brand-id"] = options.brandId;
     if (options?.campaignId) headers["x-campaign-id"] = options.campaignId;
     if (options?.workflowName) headers["x-workflow-name"] = options.workflowName;
+    if (options?.featureSlug) headers["x-feature-slug"] = options.featureSlug;
 
     const raw = await callApolloService<ApolloSearchRawResponse>("/search", {
       method: "POST",
@@ -190,6 +191,7 @@ export async function apolloSearchNext(options: {
   orgId?: string | null;
   userId?: string | null;
   workflowName?: string;
+  featureSlug?: string;
 }): Promise<ApolloSearchNextResult | null> {
   try {
     const headers: Record<string, string> = {};
@@ -199,6 +201,7 @@ export async function apolloSearchNext(options: {
     headers["x-brand-id"] = options.brandId;
     headers["x-campaign-id"] = options.campaignId;
     if (options.workflowName) headers["x-workflow-name"] = options.workflowName;
+    if (options.featureSlug) headers["x-feature-slug"] = options.featureSlug;
 
     const body: Record<string, unknown> = {};
     if (options.searchParams) body.searchParams = options.searchParams;
@@ -230,6 +233,7 @@ export async function apolloSearchParams(options: {
   orgId?: string | null;
   userId?: string | null;
   workflowName?: string;
+  featureSlug?: string;
 }): Promise<ApolloSearchParamsResult> {
   const headers: Record<string, string> = {};
   if (options.orgId) headers["x-org-id"] = options.orgId;
@@ -238,6 +242,7 @@ export async function apolloSearchParams(options: {
   headers["x-brand-id"] = options.brandId;
   headers["x-campaign-id"] = options.campaignId;
   if (options.workflowName) headers["x-workflow-name"] = options.workflowName;
+  if (options.featureSlug) headers["x-feature-slug"] = options.featureSlug;
 
   return callApolloService<ApolloSearchParamsResult>("/search/params", {
     method: "POST",
@@ -289,7 +294,7 @@ export interface ApolloEnrichResult {
 
 export async function apolloEnrich(
   personId: string,
-  options?: { runId?: string | null; orgId?: string | null; userId?: string | null; brandId?: string; campaignId?: string; workflowName?: string }
+  options?: { runId?: string | null; orgId?: string | null; userId?: string | null; brandId?: string; campaignId?: string; workflowName?: string; featureSlug?: string }
 ): Promise<ApolloEnrichResult | null> {
   try {
     const headers: Record<string, string> = {};
@@ -299,6 +304,7 @@ export async function apolloEnrich(
     if (options?.brandId) headers["x-brand-id"] = options.brandId;
     if (options?.campaignId) headers["x-campaign-id"] = options.campaignId;
     if (options?.workflowName) headers["x-workflow-name"] = options.workflowName;
+    if (options?.featureSlug) headers["x-feature-slug"] = options.featureSlug;
 
     const result = await callApolloService<ApolloEnrichResult>("/enrich", {
       method: "POST",

--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -15,7 +15,7 @@ export interface BrandDetails {
 export async function fetchBrand(
   brandId: string,
   orgId?: string | null,
-  context?: { userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string }
+  context?: { userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string; featureSlug?: string }
 ): Promise<BrandDetails | null> {
   try {
     const headers: Record<string, string> = {
@@ -28,6 +28,7 @@ export async function fetchBrand(
     if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
     if (context?.brandId) headers["x-brand-id"] = context.brandId;
     if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
+    if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
 
     const url = new URL(`${BRAND_SERVICE_URL}/brands/${brandId}`);
     if (orgId) url.searchParams.set("orgId", orgId);

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -28,6 +28,7 @@ async function fillBufferFromSearch(params: {
   pushRunId?: string | null;
   userId?: string | null;
   workflowName?: string;
+  featureSlug?: string;
 }): Promise<{ filled: number }> {
   const serviceContext = {
     userId: params.userId ?? undefined,
@@ -35,6 +36,7 @@ async function fillBufferFromSearch(params: {
     campaignId: params.campaignId,
     brandId: params.brandId,
     workflowName: params.workflowName,
+    featureSlug: params.featureSlug,
   };
 
   // Fetch campaign + brand details in parallel for rich LLM context
@@ -73,6 +75,7 @@ async function fillBufferFromSearch(params: {
     orgId: params.orgId,
     userId: params.userId,
     workflowName: params.workflowName,
+    featureSlug: params.featureSlug,
   });
 
   let totalFilled = 0;
@@ -87,6 +90,7 @@ async function fillBufferFromSearch(params: {
       orgId: params.orgId,
       userId: params.userId,
       workflowName: params.workflowName,
+      featureSlug: params.featureSlug,
     });
 
     if (!result) {
@@ -159,6 +163,7 @@ async function fillBufferFromSearch(params: {
             campaignId: params.campaignId,
             brandId: params.brandId,
             workflowName: params.workflowName,
+            featureSlug: params.featureSlug,
           })
         : new Map<string, boolean>();
 
@@ -179,6 +184,7 @@ async function fillBufferFromSearch(params: {
         orgId: params.orgId,
         userId: params.userId ?? null,
         workflowName: params.workflowName ?? null,
+        featureSlug: params.featureSlug ?? null,
       });
       pageFilled++;
     }
@@ -210,6 +216,7 @@ export async function pullNext(params: {
   searchParams?: ApolloSearchParams;
   userId?: string | null;
   workflowName?: string;
+  featureSlug?: string;
 }): Promise<{
   found: boolean;
   lead?: {
@@ -274,6 +281,7 @@ export async function pullNext(params: {
           pushRunId: params.runId,
           userId: params.userId,
           workflowName: params.workflowName,
+          featureSlug: params.featureSlug,
         });
 
         if (filled > 0) {
@@ -314,6 +322,7 @@ export async function pullNext(params: {
           brandId: params.brandId,
           campaignId: params.campaignId,
           workflowName: params.workflowName,
+          featureSlug: params.featureSlug,
         });
 
         if (!enrichResult?.person?.email) {
@@ -390,6 +399,7 @@ export async function pullNext(params: {
       campaignId: params.campaignId,
       brandId: params.brandId,
       workflowName: params.workflowName,
+      featureSlug: params.featureSlug,
     });
 
     if (contactedMap.get(email)) {
@@ -412,6 +422,7 @@ export async function pullNext(params: {
       runId: params.runId ?? null,
       userId: row.userId,
       workflowName: params.workflowName ?? null,
+      featureSlug: params.featureSlug ?? null,
     });
 
     if (!inserted) {

--- a/src/lib/campaign-client.ts
+++ b/src/lib/campaign-client.ts
@@ -12,7 +12,7 @@ export interface CampaignDetails {
 export async function fetchCampaign(
   campaignId: string,
   orgId?: string | null,
-  context?: { userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string }
+  context?: { userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string; featureSlug?: string }
 ): Promise<CampaignDetails | null> {
   try {
     const headers: Record<string, string> = {
@@ -25,6 +25,7 @@ export async function fetchCampaign(
     if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
     if (context?.brandId) headers["x-brand-id"] = context.brandId;
     if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
+    if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
 
     const response = await fetch(`${CAMPAIGN_SERVICE_URL}/campaigns/${campaignId}`, {
       headers,

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -16,7 +16,7 @@ export async function checkContacted(
   brandId: string,
   campaignId: string,
   items: DeliveryStatusItem[],
-  context?: { orgId?: string; userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string }
+  context?: { orgId?: string; userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string; featureSlug?: string }
 ): Promise<Map<string, boolean>> {
   const result = new Map<string, boolean>();
 
@@ -54,6 +54,7 @@ export async function markServed(params: {
   runId?: string | null;
   userId?: string | null;
   workflowName?: string | null;
+  featureSlug?: string | null;
 }): Promise<{ inserted: boolean }> {
   const result = await db
     .insert(servedLeads)
@@ -69,6 +70,7 @@ export async function markServed(params: {
       campaignId: params.campaignId,
       userId: params.userId ?? null,
       workflowName: params.workflowName ?? null,
+      featureSlug: params.featureSlug ?? null,
     })
     .onConflictDoNothing()
     .returning();

--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -53,7 +53,7 @@ export async function checkDeliveryStatus(
   brandId: string,
   campaignId: string | undefined,
   items: DeliveryStatusItem[],
-  context?: { orgId?: string; userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string }
+  context?: { orgId?: string; userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string; featureSlug?: string }
 ): Promise<DeliveryStatusResponse | null> {
   try {
     const body: Record<string, unknown> = { brandId, items };
@@ -69,6 +69,7 @@ export async function checkDeliveryStatus(
     if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
     if (context?.brandId) headers["x-brand-id"] = context.brandId;
     if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
+    if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
 
     const response = await fetch(`${EMAIL_GATEWAY_SERVICE_URL}/status`, {
       method: "POST",

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -35,6 +35,7 @@ export async function createRun(params: {
   brandId?: string;
   campaignId?: string;
   workflowName?: string;
+  featureSlug?: string;
 }): Promise<{ id: string }> {
   const headers: Record<string, string> = {
     "x-org-id": params.orgId,
@@ -44,6 +45,7 @@ export async function createRun(params: {
   if (params.campaignId) headers["x-campaign-id"] = params.campaignId;
   if (params.brandId) headers["x-brand-id"] = params.brandId;
   if (params.workflowName) headers["x-workflow-name"] = params.workflowName;
+  if (params.featureSlug) headers["x-feature-slug"] = params.featureSlug;
 
   return callRunsService("/runs", {
     method: "POST",
@@ -61,7 +63,7 @@ export async function createRun(params: {
 export async function updateRun(
   runId: string,
   status: "completed" | "failed",
-  context?: { orgId?: string; userId?: string; campaignId?: string; brandId?: string; workflowName?: string }
+  context?: { orgId?: string; userId?: string; campaignId?: string; brandId?: string; workflowName?: string; featureSlug?: string }
 ): Promise<void> {
   const headers: Record<string, string> = {};
   if (context?.orgId) headers["x-org-id"] = context.orgId;
@@ -70,6 +72,7 @@ export async function updateRun(
   if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
   if (context?.brandId) headers["x-brand-id"] = context.brandId;
   if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
+  if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
 
   await callRunsService(`/runs/${runId}`, {
     method: "PATCH",
@@ -81,7 +84,7 @@ export async function updateRun(
 export async function addCosts(
   runId: string,
   items: Array<{ costName: string; quantity: number; costSource: "platform" | "org" }>,
-  context?: { orgId?: string; userId?: string; campaignId?: string; brandId?: string; workflowName?: string }
+  context?: { orgId?: string; userId?: string; campaignId?: string; brandId?: string; workflowName?: string; featureSlug?: string }
 ): Promise<void> {
   if (items.length === 0) return;
 
@@ -92,6 +95,7 @@ export async function addCosts(
   if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
   if (context?.brandId) headers["x-brand-id"] = context.brandId;
   if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
+  if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
 
   await callRunsService(`/runs/${runId}/costs`, {
     method: "POST",

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -7,6 +7,7 @@ export interface AuthenticatedRequest extends Request {
   campaignId?: string;
   brandId?: string;
   workflowName?: string;
+  featureSlug?: string;
 }
 
 export async function authenticate(
@@ -36,9 +37,11 @@ export async function authenticate(
     const campaignId = req.headers["x-campaign-id"] as string | undefined;
     const brandId = req.headers["x-brand-id"] as string | undefined;
     const workflowName = req.headers["x-workflow-name"] as string | undefined;
+    const featureSlug = req.headers["x-feature-slug"] as string | undefined;
     if (campaignId) req.campaignId = campaignId;
     if (brandId) req.brandId = brandId;
     if (workflowName) req.workflowName = workflowName;
+    if (featureSlug) req.featureSlug = featureSlug;
 
     next();
   } catch (error) {

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -58,6 +58,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       brandId,
       campaignId,
       workflowName,
+      featureSlug: req.featureSlug,
     });
     const serveRunId = childRun.id;
 
@@ -69,6 +70,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       searchParams: searchParams ?? undefined,
       userId: userId ?? req.userId ?? null,
       workflowName,
+      featureSlug: req.featureSlug,
     });
 
     // Cache the response for idempotency + probabilistic TTL cleanup (~1% of requests)
@@ -93,6 +95,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
         campaignId,
         brandId,
         workflowName,
+        featureSlug: req.featureSlug,
       });
     } catch (err) {
       console.error("[buffer/next] Failed to update run:", err);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -64,6 +64,13 @@ const AuthHeaders = [
     schema: { type: "string" as const },
     description: "Workflow name (auto-injected by workflow-service)",
   },
+  {
+    in: "header" as const,
+    name: "x-feature-slug",
+    required: false,
+    schema: { type: "string" as const },
+    description: "Feature slug for tracking (propagated through the call chain)",
+  },
 ];
 
 // --- Health ---


### PR DESCRIPTION
## Summary
- Accept `x-feature-slug` header on all authenticated endpoints (auth middleware)
- Propagate it through all downstream service-to-service calls (runs, apollo, brand, campaign, email-gateway clients)
- Store `feature_slug` column in `served_leads` and `lead_buffer` tables
- Update OpenAPI spec with the new header parameter

## Test plan
- [x] All 92 unit tests pass
- [ ] Run DB migration (`npm run db:push` or `npm run db:migrate`) to add `feature_slug` columns
- [ ] Verify header propagation end-to-end with a test request

🤖 Generated with [Claude Code](https://claude.com/claude-code)