### PR TITLE
Fix missing feature_slug migration and null searchParams

### DIFF
--- a/drizzle/0010_add_feature_slug.sql
+++ b/drizzle/0010_add_feature_slug.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "served_leads" ADD COLUMN "feature_slug" text;--> statement-breakpoint
+ALTER TABLE "lead_buffer" ADD COLUMN "feature_slug" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1773619200000,
       "tag": "0009_add_workflow_name",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1774598400000,
+      "tag": "0010_add_feature_slug",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -447,6 +447,7 @@
           },
           "searchParams": {
             "type": "object",
+            "nullable": true,
             "additionalProperties": {
               "nullable": true
             }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -187,7 +187,7 @@ export const BufferNextRequestSchema = z
   .object({
     campaignId: z.string().min(1),
     brandId: z.string().min(1),
-    searchParams: z.record(z.string(), z.unknown()).optional(),
+    searchParams: z.record(z.string(), z.unknown()).nullish(),
     userId: z.string().optional(),
     workflowName: z.string().optional(),
     idempotencyKey: z.string().min(1).optional(),

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -61,6 +61,18 @@ describe("schema validation", () => {
       }
     });
 
+    it("accepts null searchParams", () => {
+      const result = BufferNextRequestSchema.safeParse({
+        campaignId: "c1",
+        brandId: "b1",
+        searchParams: null,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.searchParams).toBeNull();
+      }
+    });
+
     it("accepts request without workflowName", () => {
       const result = BufferNextRequestSchema.safeParse({
         campaignId: "c1",


### PR DESCRIPTION
## Summary
- Add migration `0010_add_feature_slug.sql` — the column was added to the Drizzle schema in #102 but the migration SQL was never generated/committed, causing `column "feature_slug" does not exist` 500s in prod
- Change `searchParams` validation from `.optional()` to `.nullish()` so workflows sending explicit `null` no longer get 400 (`expected record, received null`)
- Migration already applied manually to prod to stop the bleeding

## Test plan
- [x] New unit test: `accepts null searchParams`
- [x] All 93 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)