### PR TITLE
Fix feature_slug migration column conflict

### DIFF
--- a/drizzle/0010_add_feature_slug.sql
+++ b/drizzle/0010_add_feature_slug.sql
@@ -1,2 +1,2 @@
-ALTER TABLE "served_leads" ADD COLUMN "feature_slug" text;--> statement-breakpoint
-ALTER TABLE "lead_buffer" ADD COLUMN "feature_slug" text;
+ALTER TABLE "served_leads" ADD COLUMN IF NOT EXISTS "feature_slug" text;--> statement-breakpoint
+ALTER TABLE "lead_buffer" ADD COLUMN IF NOT EXISTS "feature_slug" text;


### PR DESCRIPTION
## Summary
- Migration `0010_add_feature_slug.sql` fails because the `feature_slug` column already exists in prod (likely added via `db:push`)
- Added `IF NOT EXISTS` to both `ALTER TABLE ADD COLUMN` statements to make the migration idempotent

## Test plan
- [x] All 93 unit tests pass
- [ ] Deploy and verify migration runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)