### PR TITLE
Add journalist outreach lead source

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -445,6 +445,14 @@
             "type": "string",
             "minLength": 1
           },
+          "sourceType": {
+            "type": "string",
+            "enum": [
+              "apollo",
+              "journalist"
+            ],
+            "default": "apollo"
+          },
           "searchParams": {
             "type": "object",
             "nullable": true,

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -292,6 +292,45 @@ export interface ApolloEnrichResult {
   person: ApolloPersonResult;
 }
 
+// --- Person Match (by name + organization domain) ---
+
+export interface ApolloMatchResult {
+  enrichmentId: string | null;
+  person: ApolloPersonResult | null;
+  cached: boolean;
+}
+
+export async function apolloMatch(
+  params: { firstName: string; lastName: string; organizationDomain: string },
+  options?: { runId?: string | null; orgId?: string | null; userId?: string | null; brandId?: string; campaignId?: string; workflowName?: string; featureSlug?: string }
+): Promise<ApolloMatchResult | null> {
+  try {
+    const headers: Record<string, string> = {};
+    if (options?.orgId) headers["x-org-id"] = options.orgId;
+    if (options?.userId) headers["x-user-id"] = options.userId;
+    if (options?.runId) headers["x-run-id"] = options.runId;
+    if (options?.brandId) headers["x-brand-id"] = options.brandId;
+    if (options?.campaignId) headers["x-campaign-id"] = options.campaignId;
+    if (options?.workflowName) headers["x-workflow-name"] = options.workflowName;
+    if (options?.featureSlug) headers["x-feature-slug"] = options.featureSlug;
+
+    return await callApolloService<ApolloMatchResult>("/match", {
+      method: "POST",
+      body: {
+        firstName: params.firstName,
+        lastName: params.lastName,
+        organizationDomain: params.organizationDomain,
+      },
+      headers,
+    });
+  } catch (error) {
+    console.error(`[apollo-client] Match failed for ${params.firstName} ${params.lastName} @ ${params.organizationDomain}:`, error);
+    return null;
+  }
+}
+
+// --- Enrichment ---
+
 export async function apolloEnrich(
   personId: string,
   options?: { runId?: string | null; orgId?: string | null; userId?: string | null; brandId?: string; campaignId?: string; workflowName?: string; featureSlug?: string }

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -1,11 +1,13 @@
 import { eq, and, sql } from "drizzle-orm";
 import { db, sql as pgSql } from "../db/index.js";
-import { leadBuffer, enrichments } from "../db/schema.js";
+import { leadBuffer, enrichments, cursors } from "../db/schema.js";
 import { checkContacted, markServed } from "./dedup.js";
 import { resolveOrCreateLead, findLeadByApolloPersonId } from "./leads-registry.js";
-import { apolloSearchNext, apolloEnrich, apolloSearchParams, type ApolloSearchParams } from "./apollo-client.js";
+import { apolloSearchNext, apolloEnrich, apolloMatch, apolloSearchParams, type ApolloSearchParams } from "./apollo-client.js";
 import { fetchCampaign } from "./campaign-client.js";
 import { fetchBrand } from "./brand-client.js";
+import { fetchOutletsByCampaign } from "./outlet-client.js";
+import { fetchJournalistsByOutlet } from "./journalist-client.js";
 
 async function isInBuffer(orgId: string, campaignId: string, externalId: string): Promise<boolean> {
   const row = await db.query.leadBuffer.findFirst({
@@ -208,6 +210,142 @@ async function fillBufferFromSearch(params: {
   return { filled: totalFilled };
 }
 
+// --- Journalist source helpers ---
+
+function extractDomain(url: string): string {
+  try {
+    const parsed = new URL(url.startsWith("http") ? url : `https://${url}`);
+    return parsed.hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+async function saveCursor(orgId: string, namespace: string, state: unknown): Promise<void> {
+  const existing = await db.query.cursors.findFirst({
+    where: and(eq(cursors.orgId, orgId), eq(cursors.namespace, namespace)),
+  });
+  if (existing) {
+    await db.update(cursors).set({ state, updatedAt: new Date() }).where(eq(cursors.id, existing.id));
+  } else {
+    await db.insert(cursors).values({ orgId, namespace, state });
+  }
+}
+
+async function fillBufferFromJournalists(params: {
+  orgId: string;
+  campaignId: string;
+  brandId: string;
+  pushRunId?: string | null;
+  userId?: string | null;
+  workflowName?: string;
+  featureSlug?: string;
+}): Promise<{ filled: number }> {
+  const serviceContext = {
+    userId: params.userId ?? undefined,
+    runId: params.pushRunId ?? undefined,
+    campaignId: params.campaignId,
+    brandId: params.brandId,
+    workflowName: params.workflowName,
+    featureSlug: params.featureSlug,
+  };
+
+  // Load cursor state
+  const cursorNamespace = `journalist:${params.campaignId}`;
+  const existingCursor = await db.query.cursors.findFirst({
+    where: and(
+      eq(cursors.orgId, params.orgId),
+      eq(cursors.namespace, cursorNamespace)
+    ),
+  });
+  const cursorState = (existingCursor?.state as { outletIndex: number; journalistIndex: number } | null)
+    ?? { outletIndex: 0, journalistIndex: 0 };
+
+  // Fetch outlets for this campaign
+  const outlets = await fetchOutletsByCampaign(params.campaignId, params.orgId, serviceContext);
+  if (!outlets || outlets.length === 0) {
+    console.log(`[fillBufferFromJournalists] No outlets for campaign=${params.campaignId}`);
+    return { filled: 0 };
+  }
+
+  let totalFilled = 0;
+
+  for (let oi = cursorState.outletIndex; oi < outlets.length; oi++) {
+    const outlet = outlets[oi];
+
+    const journalists = await fetchJournalistsByOutlet(outlet.id, {
+      ...serviceContext,
+      campaignId: params.campaignId,
+      orgId: params.orgId,
+    });
+
+    if (!journalists || journalists.length === 0) {
+      // No journalists for this outlet — advance to next
+      continue;
+    }
+
+    const startJ = oi === cursorState.outletIndex ? cursorState.journalistIndex : 0;
+
+    for (let ji = startJ; ji < journalists.length; ji++) {
+      const journalist = journalists[ji];
+
+      // Skip organization-type entities (we need individual people)
+      if (journalist.entityType === "organization") continue;
+
+      const externalId = `journalist:${journalist.id}`;
+
+      if (await isInBuffer(params.orgId, params.campaignId, externalId)) continue;
+
+      // Pick the best valid email if available
+      const validEmail = journalist.emails
+        ?.filter(e => e.isValid)
+        ?.sort((a, b) => b.confidence - a.confidence)
+        ?.[0]?.email ?? null;
+
+      const organizationDomain = extractDomain(outlet.outletUrl);
+
+      const data: Record<string, unknown> = {
+        firstName: journalist.firstName,
+        lastName: journalist.lastName,
+        journalistName: journalist.journalistName,
+        organizationDomain,
+        organizationName: outlet.name,
+        outletUrl: outlet.outletUrl,
+        outletId: outlet.id,
+        journalistId: journalist.id,
+        sourceType: "journalist",
+      };
+
+      await db.insert(leadBuffer).values({
+        namespace: params.campaignId,
+        campaignId: params.campaignId,
+        email: validEmail ?? "",
+        externalId,
+        data,
+        status: "buffered",
+        pushRunId: params.pushRunId ?? null,
+        brandId: params.brandId,
+        orgId: params.orgId,
+        userId: params.userId ?? null,
+        workflowName: params.workflowName ?? null,
+        featureSlug: params.featureSlug ?? null,
+      });
+      totalFilled++;
+    }
+
+    // Save cursor after each outlet
+    if (totalFilled > 0) {
+      await saveCursor(params.orgId, cursorNamespace, { outletIndex: oi + 1, journalistIndex: 0 });
+      console.log(`[fillBufferFromJournalists] Buffered ${totalFilled} journalists from outlet ${outlet.name}`);
+      return { filled: totalFilled };
+    }
+  }
+
+  // All outlets exhausted
+  await saveCursor(params.orgId, cursorNamespace, { outletIndex: outlets.length, journalistIndex: 0 });
+  return { filled: totalFilled };
+}
+
 export async function pullNext(params: {
   orgId: string;
   campaignId: string;
@@ -217,6 +355,7 @@ export async function pullNext(params: {
   userId?: string | null;
   workflowName?: string;
   featureSlug?: string;
+  sourceType?: "apollo" | "journalist";
 }): Promise<{
   found: boolean;
   lead?: {
@@ -271,9 +410,23 @@ export async function pullNext(params: {
     } : null;
 
     if (!row) {
-      // Buffer empty - try to fill from search if searchParams provided
-      if (params.searchParams) {
-        const { filled } = await fillBufferFromSearch({
+      // Buffer empty — fill from the appropriate source
+      const st = params.sourceType ?? "apollo";
+      let filled = 0;
+
+      if (st === "journalist") {
+        const result = await fillBufferFromJournalists({
+          orgId: params.orgId,
+          campaignId: params.campaignId,
+          brandId: params.brandId,
+          pushRunId: params.runId,
+          userId: params.userId,
+          workflowName: params.workflowName,
+          featureSlug: params.featureSlug,
+        });
+        filled = result.filled;
+      } else if (params.searchParams) {
+        const result = await fillBufferFromSearch({
           orgId: params.orgId,
           campaignId: params.campaignId,
           brandId: params.brandId,
@@ -283,19 +436,73 @@ export async function pullNext(params: {
           workflowName: params.workflowName,
           featureSlug: params.featureSlug,
         });
+        filled = result.filled;
+      }
 
-        if (filled > 0) {
-          continue; // Retry pulling from buffer
-        }
+      if (filled > 0) {
+        continue; // Retry pulling from buffer
       }
 
       return { found: false };
     }
 
-    // Enrich if no email (search results don't include emails)
+    // Enrich if no email
     let email = row.email;
     let enrichedData = row.data;
-    if (!email && row.externalId) {
+    const rowData = row.data as Record<string, unknown> | null;
+    const isJournalistLead = rowData?.sourceType === "journalist";
+
+    if (!email && isJournalistLead && rowData?.firstName && rowData?.lastName && rowData?.organizationDomain) {
+      // Journalist without email — try Apollo match by name + domain
+      const matchResult = await apolloMatch(
+        {
+          firstName: rowData.firstName as string,
+          lastName: rowData.lastName as string,
+          organizationDomain: rowData.organizationDomain as string,
+        },
+        {
+          runId: params.runId,
+          orgId: params.orgId,
+          userId: params.userId,
+          brandId: params.brandId,
+          campaignId: params.campaignId,
+          workflowName: params.workflowName,
+          featureSlug: params.featureSlug,
+        }
+      );
+
+      if (!matchResult?.person?.email) {
+        await db
+          .update(leadBuffer)
+          .set({ status: "skipped" })
+          .where(eq(leadBuffer.id, row.id));
+        continue;
+      }
+
+      email = matchResult.person.email;
+      enrichedData = { ...(rowData ?? {}), ...matchResult.person };
+
+      // Cache the enrichment result
+      await db.insert(enrichments).values({
+        email,
+        apolloPersonId: matchResult.person.id ?? null,
+        firstName: matchResult.person.firstName ?? null,
+        lastName: matchResult.person.lastName ?? null,
+        title: matchResult.person.title ?? null,
+        linkedinUrl: matchResult.person.linkedinUrl ?? null,
+        organizationName: matchResult.person.organizationName ?? null,
+        organizationDomain: matchResult.person.organizationDomain ?? null,
+        organizationIndustry: matchResult.person.organizationIndustry ?? null,
+        organizationSize: matchResult.person.organizationSize ?? null,
+        responseRaw: matchResult.person,
+      }).onConflictDoNothing();
+
+      // Update buffer row with email
+      await db
+        .update(leadBuffer)
+        .set({ email, data: enrichedData })
+        .where(eq(leadBuffer.id, row.id));
+    } else if (!email && row.externalId) {
       // Check enrichment cache first to avoid duplicate Apollo API calls
       const cached = await db.query.enrichments.findFirst({
         where: eq(enrichments.apolloPersonId, row.externalId),

--- a/src/lib/journalist-client.ts
+++ b/src/lib/journalist-client.ts
@@ -1,0 +1,62 @@
+const JOURNALISTS_SERVICE_URL = process.env.JOURNALISTS_SERVICE_URL || "http://localhost:3011";
+const JOURNALISTS_SERVICE_API_KEY = process.env.JOURNALISTS_SERVICE_API_KEY || "";
+
+export interface JournalistEmail {
+  email: string;
+  isValid: boolean;
+  confidence: number;
+}
+
+export interface JournalistWithEmails {
+  id: string;
+  journalistName: string;
+  firstName: string | null;
+  lastName: string | null;
+  entityType: "individual" | "organization";
+  emails: JournalistEmail[];
+}
+
+export async function fetchJournalistsByOutlet(
+  outletId: string,
+  options?: {
+    campaignId?: string;
+    orgId?: string | null;
+    userId?: string;
+    runId?: string;
+    brandId?: string;
+    workflowName?: string;
+    featureSlug?: string;
+  }
+): Promise<JournalistWithEmails[] | null> {
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-API-Key": JOURNALISTS_SERVICE_API_KEY,
+    };
+    if (options?.orgId) headers["x-org-id"] = options.orgId;
+    if (options?.userId) headers["x-user-id"] = options.userId;
+    if (options?.runId) headers["x-run-id"] = options.runId;
+    if (options?.campaignId) headers["x-campaign-id"] = options.campaignId;
+    if (options?.brandId) headers["x-brand-id"] = options.brandId;
+    if (options?.workflowName) headers["x-workflow-name"] = options.workflowName;
+    if (options?.featureSlug) headers["x-feature-slug"] = options.featureSlug;
+
+    const url = new URL(
+      `${JOURNALISTS_SERVICE_URL}/internal/journalists/by-outlet-with-emails/${outletId}`
+    );
+    if (options?.campaignId) url.searchParams.set("campaignId", options.campaignId);
+
+    const response = await fetch(url.toString(), { headers });
+
+    if (!response.ok) {
+      console.warn(`[journalist-client] Failed to fetch journalists for outlet ${outletId}: ${response.status}`);
+      return null;
+    }
+
+    const data = (await response.json()) as { journalists: JournalistWithEmails[] };
+    return data.journalists;
+  } catch (error) {
+    console.error("[journalist-client] Error fetching journalists:", error);
+    return null;
+  }
+}

--- a/src/lib/outlet-client.ts
+++ b/src/lib/outlet-client.ts
@@ -1,0 +1,44 @@
+const OUTLETS_SERVICE_URL = process.env.OUTLETS_SERVICE_URL || "http://localhost:3010";
+const OUTLETS_SERVICE_API_KEY = process.env.OUTLETS_SERVICE_API_KEY || "";
+
+export interface OutletDetails {
+  id: string;
+  name: string;
+  outletUrl: string;
+}
+
+export async function fetchOutletsByCampaign(
+  campaignId: string,
+  orgId?: string | null,
+  context?: { userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string; featureSlug?: string }
+): Promise<OutletDetails[] | null> {
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-API-Key": OUTLETS_SERVICE_API_KEY,
+    };
+    if (orgId) headers["x-org-id"] = orgId;
+    if (context?.userId) headers["x-user-id"] = context.userId;
+    if (context?.runId) headers["x-run-id"] = context.runId;
+    if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
+    if (context?.brandId) headers["x-brand-id"] = context.brandId;
+    if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
+    if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
+
+    const response = await fetch(
+      `${OUTLETS_SERVICE_URL}/internal/outlets/by-campaign/${campaignId}`,
+      { headers }
+    );
+
+    if (!response.ok) {
+      console.warn(`[outlet-client] Failed to fetch outlets for campaign ${campaignId}: ${response.status}`);
+      return null;
+    }
+
+    const data = (await response.json()) as { outlets: OutletDetails[] };
+    return data.outlets;
+  } catch (error) {
+    console.error("[outlet-client] Error fetching outlets:", error);
+    return null;
+  }
+}

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -32,7 +32,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
   }
 
   try {
-    const { campaignId, brandId, searchParams, userId, idempotencyKey } = parsed.data;
+    const { campaignId, brandId, searchParams, userId, idempotencyKey, sourceType } = parsed.data;
 
     // Body workflowName takes precedence; fall back to header injected by workflow-service
     const workflowName = parsed.data.workflowName ?? req.workflowName;
@@ -71,6 +71,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       userId: userId ?? req.userId ?? null,
       workflowName,
       featureSlug: req.featureSlug,
+      sourceType,
     });
 
     // Cache the response for idempotency + probabilistic TTL cleanup (~1% of requests)

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -187,6 +187,7 @@ export const BufferNextRequestSchema = z
   .object({
     campaignId: z.string().min(1),
     brandId: z.string().min(1),
+    sourceType: z.enum(["apollo", "journalist"]).default("apollo").optional(),
     searchParams: z.record(z.string(), z.unknown()).nullish(),
     userId: z.string().optional(),
     workflowName: z.string().optional(),

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -15,6 +15,9 @@ vi.mock("../../src/db/index.js", () => ({
       enrichments: {
         findFirst: vi.fn(),
       },
+      cursors: {
+        findFirst: vi.fn(),
+      },
     },
     insert: vi.fn(),
     update: vi.fn(),
@@ -27,6 +30,17 @@ vi.mock("../../src/lib/apollo-client.js", () => ({
   apolloSearchNext: vi.fn(),
   apolloSearchParams: vi.fn(),
   apolloEnrich: vi.fn(),
+  apolloMatch: vi.fn(),
+}));
+
+// Mock outlet-client
+vi.mock("../../src/lib/outlet-client.js", () => ({
+  fetchOutletsByCampaign: vi.fn().mockResolvedValue(null),
+}));
+
+// Mock journalist-client
+vi.mock("../../src/lib/journalist-client.js", () => ({
+  fetchJournalistsByOutlet: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock campaign-client
@@ -54,9 +68,11 @@ vi.mock("../../src/lib/leads-registry.js", () => ({
 
 import { db } from "../../src/db/index.js";
 import { pullNext } from "../../src/lib/buffer.js";
-import { apolloSearchNext, apolloSearchParams, apolloEnrich } from "../../src/lib/apollo-client.js";
+import { apolloSearchNext, apolloSearchParams, apolloEnrich, apolloMatch } from "../../src/lib/apollo-client.js";
 import { checkDeliveryStatus } from "../../src/lib/email-gateway-client.js";
 import { resolveOrCreateLead } from "../../src/lib/leads-registry.js";
+import { fetchOutletsByCampaign } from "../../src/lib/outlet-client.js";
+import { fetchJournalistsByOutlet } from "../../src/lib/journalist-client.js";
 
 /** Helper: convert camelCase buffer row to snake_case raw SQL row (as returned by pgSql) */
 function toClaimedRow(row: {
@@ -782,6 +798,202 @@ describe("buffer", () => {
       // Should still serve the lead (fallback: not delivered)
       expect(result.found).toBe(true);
       expect(result.lead?.email).toBe("alice@acme.com");
+    });
+
+    it("fills buffer from journalists when sourceType=journalist and buffer empty", async () => {
+      // First pullNext: buffer empty → fills from journalists
+      // Second pullNext: serves the buffered journalist lead
+      const journalistRow = toClaimedRow({
+        id: "buf-j1",
+        namespace: "campaign-1",
+        campaignId: "campaign-1",
+        email: "jane@techcrunch.com",
+        externalId: "journalist:j-uuid-1",
+        data: {
+          firstName: "Jane",
+          lastName: "Reporter",
+          organizationDomain: "techcrunch.com",
+          organizationName: "TechCrunch",
+          sourceType: "journalist",
+        },
+        brandId: "brand-1",
+        orgId: "org-1",
+        userId: null,
+      });
+
+      pgSqlMock
+        .mockResolvedValueOnce([])             // pullNext: buffer empty
+        .mockResolvedValueOnce([journalistRow]); // pullNext retry: claimed journalist lead
+
+      // Cursor: no existing cursor
+      vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
+
+      // isInBuffer → not in buffer
+      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
+
+      // Outlet service returns outlets
+      vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([
+        { id: "outlet-1", name: "TechCrunch", outletUrl: "https://techcrunch.com" },
+      ]);
+
+      // Journalist service returns journalist with email
+      vi.mocked(fetchJournalistsByOutlet).mockResolvedValueOnce([
+        {
+          id: "j-uuid-1",
+          journalistName: "Jane Reporter",
+          firstName: "Jane",
+          lastName: "Reporter",
+          entityType: "individual" as const,
+          emails: [{ email: "jane@techcrunch.com", isValid: true, confidence: 0.95 }],
+        },
+      ]);
+
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
+
+      const returningMock = vi.fn().mockResolvedValue([{ id: "served-1" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
+        sourceType: "journalist",
+      });
+
+      expect(result.found).toBe(true);
+      expect(result.lead?.email).toBe("jane@techcrunch.com");
+      expect(vi.mocked(fetchOutletsByCampaign)).toHaveBeenCalledWith(
+        "campaign-1", "org-1", expect.objectContaining({ campaignId: "campaign-1" })
+      );
+      expect(vi.mocked(fetchJournalistsByOutlet)).toHaveBeenCalledWith(
+        "outlet-1", expect.objectContaining({ campaignId: "campaign-1" })
+      );
+    });
+
+    it("uses apolloMatch for journalist leads without email", async () => {
+      pgSqlMock.mockResolvedValue([toClaimedRow({
+        id: "buf-j-noemail",
+        namespace: "campaign-1",
+        campaignId: "campaign-1",
+        email: "",
+        externalId: "journalist:j-uuid-2",
+        data: {
+          firstName: "John",
+          lastName: "Writer",
+          organizationDomain: "theverge.com",
+          organizationName: "The Verge",
+          sourceType: "journalist",
+        },
+        brandId: "brand-1",
+        orgId: "org-1",
+        userId: null,
+      })]);
+
+      vi.mocked(apolloMatch).mockResolvedValueOnce({
+        enrichmentId: "enr-1",
+        person: {
+          id: "apollo-matched-1",
+          email: "john.writer@theverge.com",
+          firstName: "John",
+          lastName: "Writer",
+          organizationName: "The Verge",
+          organizationDomain: "theverge.com",
+        },
+        cached: false,
+      });
+
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
+
+      const returningMock = vi.fn().mockResolvedValue([{ id: "served-1" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
+      });
+
+      expect(result.found).toBe(true);
+      expect(result.lead?.email).toBe("john.writer@theverge.com");
+      expect(vi.mocked(apolloMatch)).toHaveBeenCalledWith(
+        { firstName: "John", lastName: "Writer", organizationDomain: "theverge.com" },
+        expect.objectContaining({ orgId: "org-1" })
+      );
+      // Should NOT call apolloEnrich (journalist path uses apolloMatch)
+      expect(vi.mocked(apolloEnrich)).not.toHaveBeenCalled();
+    });
+
+    it("skips journalist lead when apolloMatch returns no email", async () => {
+      pgSqlMock
+        .mockResolvedValueOnce([toClaimedRow({
+          id: "buf-j-fail",
+          namespace: "campaign-1",
+          campaignId: "campaign-1",
+          email: "",
+          externalId: "journalist:j-uuid-3",
+          data: {
+            firstName: "Ghost",
+            lastName: "Journalist",
+            organizationDomain: "unknown.com",
+            sourceType: "journalist",
+          },
+          brandId: "brand-1",
+          orgId: "org-1",
+          userId: null,
+        })])
+        .mockResolvedValueOnce([]); // no more rows
+
+      vi.mocked(apolloMatch).mockResolvedValueOnce({
+        enrichmentId: null,
+        person: null,
+        cached: false,
+      });
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
+      });
+
+      expect(result.found).toBe(false);
+      expect(vi.mocked(apolloMatch)).toHaveBeenCalled();
+    });
+
+    it("returns found: false when no outlets exist for journalist sourceType", async () => {
+      pgSqlMock.mockResolvedValue([]);
+
+      // Cursor: no existing cursor
+      vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
+
+      vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([]);
+
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
+        sourceType: "journalist",
+      });
+
+      expect(result.found).toBe(false);
     });
 
     it("skips lead when markServed returns inserted: false (race condition dedup)", async () => {

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -206,6 +206,96 @@ describe("service client headers", () => {
     });
   });
 
+  describe("apollo-client apolloMatch", () => {
+    it("sends correct headers and body for apolloMatch", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ enrichmentId: "e1", person: { id: "p1", email: "j@test.com" }, cached: false }));
+
+      const { apolloMatch } = await import("../../src/lib/apollo-client.js");
+      await apolloMatch(
+        { firstName: "Jane", lastName: "Doe", organizationDomain: "test.com" },
+        { orgId: "org-1", userId: "user-1", runId: "run-1", brandId: "brand-1", campaignId: "camp-1", workflowName: "wf-1", featureSlug: "feat-1" }
+      );
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, opts] = fetchSpy.mock.calls[0];
+      expect(url).toContain("/match");
+      expect(opts.headers["x-org-id"]).toBe("org-1");
+      expect(opts.headers["x-user-id"]).toBe("user-1");
+      expect(opts.headers["x-run-id"]).toBe("run-1");
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
+      expect(opts.headers["x-campaign-id"]).toBe("camp-1");
+      expect(opts.headers["x-workflow-name"]).toBe("wf-1");
+      expect(opts.headers["x-feature-slug"]).toBe("feat-1");
+      const body = JSON.parse(opts.body);
+      expect(body.firstName).toBe("Jane");
+      expect(body.lastName).toBe("Doe");
+      expect(body.organizationDomain).toBe("test.com");
+    });
+  });
+
+  describe("outlet-client", () => {
+    it("sends correct URL and headers for fetchOutletsByCampaign", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ outlets: [{ id: "o1", name: "TechCrunch", outletUrl: "https://techcrunch.com" }] }));
+
+      const { fetchOutletsByCampaign } = await import("../../src/lib/outlet-client.js");
+      await fetchOutletsByCampaign("campaign-123", "org-uuid-1", {
+        userId: "user-1", runId: "run-1", campaignId: "camp-1", brandId: "brand-1", workflowName: "wf-1", featureSlug: "feat-1",
+      });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, opts] = fetchSpy.mock.calls[0];
+      expect(url).toContain("/internal/outlets/by-campaign/campaign-123");
+      expect(opts.headers["x-org-id"]).toBe("org-uuid-1");
+      expect(opts.headers["x-user-id"]).toBe("user-1");
+      expect(opts.headers["x-run-id"]).toBe("run-1");
+      expect(opts.headers["x-campaign-id"]).toBe("camp-1");
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
+      expect(opts.headers["x-workflow-name"]).toBe("wf-1");
+      expect(opts.headers["x-feature-slug"]).toBe("feat-1");
+    });
+
+    it("returns null on error", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ error: "not found" }, 404));
+
+      const { fetchOutletsByCampaign } = await import("../../src/lib/outlet-client.js");
+      const result = await fetchOutletsByCampaign("bad-campaign", "org-1");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("journalist-client", () => {
+    it("sends correct URL with campaignId query param and headers", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ journalists: [{ id: "j1", journalistName: "Jane Doe" }] }));
+
+      const { fetchJournalistsByOutlet } = await import("../../src/lib/journalist-client.js");
+      await fetchJournalistsByOutlet("outlet-uuid-1", {
+        campaignId: "camp-1", orgId: "org-1", userId: "user-1", runId: "run-1", brandId: "brand-1", workflowName: "wf-1", featureSlug: "feat-1",
+      });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, opts] = fetchSpy.mock.calls[0];
+      expect(url).toContain("/internal/journalists/by-outlet-with-emails/outlet-uuid-1");
+      expect(url).toContain("campaignId=camp-1");
+      expect(opts.headers["x-org-id"]).toBe("org-1");
+      expect(opts.headers["x-user-id"]).toBe("user-1");
+      expect(opts.headers["x-run-id"]).toBe("run-1");
+      expect(opts.headers["x-campaign-id"]).toBe("camp-1");
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
+      expect(opts.headers["x-workflow-name"]).toBe("wf-1");
+      expect(opts.headers["x-feature-slug"]).toBe("feat-1");
+    });
+
+    it("returns null on error", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ error: "not found" }, 404));
+
+      const { fetchJournalistsByOutlet } = await import("../../src/lib/journalist-client.js");
+      const result = await fetchJournalistsByOutlet("bad-outlet");
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe("runs-client", () => {
     it("sends x-org-id, x-user-id, x-run-id headers for updateRun", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ id: "run-1", status: "completed" }));


### PR DESCRIPTION
## Summary
- Adds `sourceType: "journalist"` option to `POST /buffer/next` for journalist email outreach
- New `fillBufferFromJournalists()`: fetches prioritized outlets from outlets-service, then journalists from journalists-service, buffers them with cursor tracking
- Journalists with valid emails are buffered directly; those without are enriched via Apollo `POST /match` (firstName + lastName + organizationDomain)
- New service clients: `outlet-client.ts`, `journalist-client.ts`
- New `apolloMatch()` function in apollo-client for name+domain person matching
- Fully backwards compatible: existing callers default to `sourceType: "apollo"`

## Test plan
- [x] Unit tests for journalist buffer fill (sourceType=journalist)
- [x] Unit tests for apolloMatch enrichment path
- [x] Unit tests for skip when apolloMatch returns no email
- [x] Unit tests for empty outlets graceful handling
- [x] Service client header propagation tests for outlet-client, journalist-client, apolloMatch
- [x] All 102 existing tests still pass
- [x] Build and OpenAPI spec regeneration successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)