### PR TITLE
Align outlet-client with actual API fields

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -302,14 +302,14 @@ async function fillBufferFromJournalists(params: {
         ?.sort((a, b) => b.confidence - a.confidence)
         ?.[0]?.email ?? null;
 
-      const organizationDomain = extractDomain(outlet.outletUrl);
+      const organizationDomain = outlet.outletDomain || extractDomain(outlet.outletUrl);
 
       const data: Record<string, unknown> = {
         firstName: journalist.firstName,
         lastName: journalist.lastName,
         journalistName: journalist.journalistName,
         organizationDomain,
-        organizationName: outlet.name,
+        organizationName: outlet.outletName,
         outletUrl: outlet.outletUrl,
         outletId: outlet.id,
         journalistId: journalist.id,
@@ -336,7 +336,7 @@ async function fillBufferFromJournalists(params: {
     // Save cursor after each outlet
     if (totalFilled > 0) {
       await saveCursor(params.orgId, cursorNamespace, { outletIndex: oi + 1, journalistIndex: 0 });
-      console.log(`[fillBufferFromJournalists] Buffered ${totalFilled} journalists from outlet ${outlet.name}`);
+      console.log(`[fillBufferFromJournalists] Buffered ${totalFilled} journalists from outlet ${outlet.outletName}`);
       return { filled: totalFilled };
     }
   }

--- a/src/lib/outlet-client.ts
+++ b/src/lib/outlet-client.ts
@@ -3,8 +3,12 @@ const OUTLETS_SERVICE_API_KEY = process.env.OUTLETS_SERVICE_API_KEY || "";
 
 export interface OutletDetails {
   id: string;
-  name: string;
+  outletName: string;
   outletUrl: string;
+  outletDomain: string;
+  relevanceScore: number;
+  outletStatus: string;
+  campaignId: string;
 }
 
 export async function fetchOutletsByCampaign(

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -833,7 +833,7 @@ describe("buffer", () => {
 
       // Outlet service returns outlets
       vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([
-        { id: "outlet-1", name: "TechCrunch", outletUrl: "https://techcrunch.com" },
+        { id: "outlet-1", outletName: "TechCrunch", outletUrl: "https://techcrunch.com", outletDomain: "techcrunch.com", relevanceScore: 85, outletStatus: "open", campaignId: "campaign-1" },
       ]);
 
       // Journalist service returns journalist with email

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -235,7 +235,7 @@ describe("service client headers", () => {
 
   describe("outlet-client", () => {
     it("sends correct URL and headers for fetchOutletsByCampaign", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ outlets: [{ id: "o1", name: "TechCrunch", outletUrl: "https://techcrunch.com" }] }));
+      fetchSpy.mockReturnValue(jsonResponse({ outlets: [{ id: "o1", outletName: "TechCrunch", outletUrl: "https://techcrunch.com", outletDomain: "techcrunch.com" }] }));
 
       const { fetchOutletsByCampaign } = await import("../../src/lib/outlet-client.js");
       await fetchOutletsByCampaign("campaign-123", "org-uuid-1", {


### PR DESCRIPTION
## Summary
- Updates `OutletDetails` interface to match the actual outlets-service response: `outletName` (not `name`), `outletDomain`, `relevanceScore`, `outletStatus`
- Uses `outletDomain` directly instead of extracting domain from URL
- Updates tests accordingly

## Test plan
- [x] All 102 unit tests pass
- [x] Build + OpenAPI regen successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)