### PR TITLE
Switch journalist-client to POST /journalists/resolve

### DIFF
--- a/src/lib/journalist-client.ts
+++ b/src/lib/journalist-client.ts
@@ -13,6 +13,9 @@ export interface JournalistWithEmails {
   firstName: string | null;
   lastName: string | null;
   entityType: "individual" | "organization";
+  relevanceScore: number;
+  whyRelevant: string;
+  whyNotRelevant: string;
   emails: JournalistEmail[];
 }
 
@@ -41,22 +44,24 @@ export async function fetchJournalistsByOutlet(
     if (options?.workflowName) headers["x-workflow-name"] = options.workflowName;
     if (options?.featureSlug) headers["x-feature-slug"] = options.featureSlug;
 
-    const url = new URL(
-      `${JOURNALISTS_SERVICE_URL}/internal/journalists/by-outlet-with-emails/${outletId}`
-    );
-    if (options?.campaignId) url.searchParams.set("campaignId", options.campaignId);
-
-    const response = await fetch(url.toString(), { headers });
+    const response = await fetch(`${JOURNALISTS_SERVICE_URL}/journalists/resolve`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ outletId }),
+    });
 
     if (!response.ok) {
-      console.warn(`[journalist-client] Failed to fetch journalists for outlet ${outletId}: ${response.status}`);
+      console.warn(`[journalist-client] Failed to resolve journalists for outlet ${outletId}: ${response.status}`);
       return null;
     }
 
-    const data = (await response.json()) as { journalists: JournalistWithEmails[] };
+    const data = (await response.json()) as { journalists: JournalistWithEmails[]; cached: boolean };
+    if (data.cached) {
+      console.log(`[journalist-client] Resolved journalists for outlet ${outletId} (cached)`);
+    }
     return data.journalists;
   } catch (error) {
-    console.error("[journalist-client] Error fetching journalists:", error);
+    console.error("[journalist-client] Error resolving journalists:", error);
     return null;
   }
 }

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -265,8 +265,8 @@ describe("service client headers", () => {
   });
 
   describe("journalist-client", () => {
-    it("sends correct URL with campaignId query param and headers", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ journalists: [{ id: "j1", journalistName: "Jane Doe" }] }));
+    it("sends POST to /journalists/resolve with outletId in body and headers", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ journalists: [{ id: "j1", journalistName: "Jane Doe" }], cached: false }));
 
       const { fetchJournalistsByOutlet } = await import("../../src/lib/journalist-client.js");
       await fetchJournalistsByOutlet("outlet-uuid-1", {
@@ -275,8 +275,10 @@ describe("service client headers", () => {
 
       expect(fetchSpy).toHaveBeenCalledOnce();
       const [url, opts] = fetchSpy.mock.calls[0];
-      expect(url).toContain("/internal/journalists/by-outlet-with-emails/outlet-uuid-1");
-      expect(url).toContain("campaignId=camp-1");
+      expect(url).toContain("/journalists/resolve");
+      expect(opts.method).toBe("POST");
+      const body = JSON.parse(opts.body);
+      expect(body.outletId).toBe("outlet-uuid-1");
       expect(opts.headers["x-org-id"]).toBe("org-1");
       expect(opts.headers["x-user-id"]).toBe("user-1");
       expect(opts.headers["x-run-id"]).toBe("run-1");


### PR DESCRIPTION
## Summary
- Switches from `GET /internal/journalists/by-outlet-with-emails/{outletId}` to `POST /journalists/resolve` with `outletId` in request body
- Adds `relevanceScore`, `whyRelevant`, `whyNotRelevant` to `JournalistWithEmails` interface
- `x-campaign-id` and `x-brand-id` headers are required by the new endpoint (already sent)
- First call triggers discovery+scoring (~10-30s), subsequent calls hit cache (7-day TTL)

## Test plan
- [x] All 102 unit tests pass
- [x] Service client header test updated to verify POST method + body

🤖 Generated with [Claude Code](https://claude.com/claude-code)