### PR TITLE
Auto-discover outlets for journalist campaigns

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -6,7 +6,7 @@ import { resolveOrCreateLead, findLeadByApolloPersonId } from "./leads-registry.
 import { apolloSearchNext, apolloEnrich, apolloMatch, apolloSearchParams, type ApolloSearchParams } from "./apollo-client.js";
 import { fetchCampaign } from "./campaign-client.js";
 import { fetchBrand } from "./brand-client.js";
-import { fetchOutletsByCampaign } from "./outlet-client.js";
+import { fetchOutletsByCampaign, discoverOutlets } from "./outlet-client.js";
 import { fetchJournalistsByOutlet } from "./journalist-client.js";
 
 async function isInBuffer(orgId: string, campaignId: string, externalId: string): Promise<boolean> {
@@ -262,10 +262,51 @@ async function fillBufferFromJournalists(params: {
     ?? { outletIndex: 0, journalistIndex: 0 };
 
   // Fetch outlets for this campaign
-  const outlets = await fetchOutletsByCampaign(params.campaignId, params.orgId, serviceContext);
+  let outlets = await fetchOutletsByCampaign(params.campaignId, params.orgId, serviceContext);
   if (!outlets || outlets.length === 0) {
-    console.log(`[fillBufferFromJournalists] No outlets for campaign=${params.campaignId}`);
-    return { filled: 0 };
+    // No outlets yet — discover them via outlets-service
+    console.log(`[fillBufferFromJournalists] No outlets for campaign=${params.campaignId}, discovering...`);
+
+    const [campaign, brand] = await Promise.all([
+      fetchCampaign(params.campaignId, params.orgId, serviceContext),
+      fetchBrand(params.brandId, params.orgId, serviceContext),
+    ]);
+
+    if (!brand?.name || !brand?.elevatorPitch || !brand?.categories) {
+      console.warn(`[fillBufferFromJournalists] Cannot discover outlets — missing brand data (name/description/categories)`);
+      return { filled: 0 };
+    }
+
+    const discovered = await discoverOutlets(
+      {
+        campaignId: params.campaignId,
+        brandId: params.brandId,
+        brandName: brand.name,
+        brandDescription: brand.elevatorPitch,
+        industry: brand.categories,
+        targetGeo: brand.location ?? undefined,
+        targetAudience: campaign?.targetAudience ?? undefined,
+        workflowName: params.workflowName,
+      },
+      {
+        orgId: params.orgId,
+        userId: params.userId ?? undefined,
+        runId: params.pushRunId ?? undefined,
+        featureSlug: params.featureSlug,
+      }
+    );
+
+    if (!discovered || discovered.length === 0) {
+      console.log(`[fillBufferFromJournalists] Outlet discovery returned 0 results for campaign=${params.campaignId}`);
+      return { filled: 0 };
+    }
+
+    // Re-fetch outlets now that discovery has saved them
+    outlets = await fetchOutletsByCampaign(params.campaignId, params.orgId, serviceContext);
+    if (!outlets || outlets.length === 0) {
+      console.warn(`[fillBufferFromJournalists] Outlets still empty after discovery for campaign=${params.campaignId}`);
+      return { filled: 0 };
+    }
   }
 
   let totalFilled = 0;

--- a/src/lib/outlet-client.ts
+++ b/src/lib/outlet-client.ts
@@ -11,6 +11,69 @@ export interface OutletDetails {
   campaignId: string;
 }
 
+export async function discoverOutlets(params: {
+  campaignId: string;
+  brandId: string;
+  brandName: string;
+  brandDescription: string;
+  industry: string;
+  targetGeo?: string;
+  targetAudience?: string;
+  workflowName?: string;
+}, context?: {
+  orgId?: string | null;
+  userId?: string;
+  runId?: string;
+  featureSlug?: string;
+}): Promise<OutletDetails[] | null> {
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-API-Key": OUTLETS_SERVICE_API_KEY,
+    };
+    if (context?.orgId) headers["x-org-id"] = context.orgId;
+    if (context?.userId) headers["x-user-id"] = context.userId;
+    if (context?.runId) headers["x-run-id"] = context.runId;
+    if (params.campaignId) headers["x-campaign-id"] = params.campaignId;
+    if (params.brandId) headers["x-brand-id"] = params.brandId;
+    if (params.workflowName) headers["x-workflow-name"] = params.workflowName;
+    if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
+
+    const response = await fetch(`${OUTLETS_SERVICE_URL}/outlets/discover`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        campaignId: params.campaignId,
+        brandId: params.brandId,
+        brandName: params.brandName,
+        brandDescription: params.brandDescription,
+        industry: params.industry,
+        targetGeo: params.targetGeo,
+        targetAudience: params.targetAudience,
+        workflowName: params.workflowName,
+      }),
+    });
+
+    if (response.status === 200) {
+      // 200 = no outlets found
+      console.log(`[outlet-client] Discover returned 0 outlets for campaign ${params.campaignId}`);
+      return [];
+    }
+
+    if (!response.ok) {
+      console.warn(`[outlet-client] Failed to discover outlets for campaign ${params.campaignId}: ${response.status}`);
+      return null;
+    }
+
+    const data = (await response.json()) as { discoveredCount: number; outlets: OutletDetails[] };
+    console.log(`[outlet-client] Discovered ${data.discoveredCount} outlets for campaign ${params.campaignId}`);
+    return data.outlets;
+  } catch (error) {
+    console.error("[outlet-client] Error discovering outlets:", error);
+    return null;
+  }
+}
+
 export async function fetchOutletsByCampaign(
   campaignId: string,
   orgId?: string | null,

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -36,6 +36,7 @@ vi.mock("../../src/lib/apollo-client.js", () => ({
 // Mock outlet-client
 vi.mock("../../src/lib/outlet-client.js", () => ({
   fetchOutletsByCampaign: vi.fn().mockResolvedValue(null),
+  discoverOutlets: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock journalist-client
@@ -71,7 +72,9 @@ import { pullNext } from "../../src/lib/buffer.js";
 import { apolloSearchNext, apolloSearchParams, apolloEnrich, apolloMatch } from "../../src/lib/apollo-client.js";
 import { checkDeliveryStatus } from "../../src/lib/email-gateway-client.js";
 import { resolveOrCreateLead } from "../../src/lib/leads-registry.js";
-import { fetchOutletsByCampaign } from "../../src/lib/outlet-client.js";
+import { fetchOutletsByCampaign, discoverOutlets } from "../../src/lib/outlet-client.js";
+import { fetchCampaign } from "../../src/lib/campaign-client.js";
+import { fetchBrand } from "../../src/lib/brand-client.js";
 import { fetchJournalistsByOutlet } from "../../src/lib/journalist-client.js";
 
 /** Helper: convert camelCase buffer row to snake_case raw SQL row (as returned by pgSql) */
@@ -978,13 +981,35 @@ describe("buffer", () => {
       expect(vi.mocked(apolloMatch)).toHaveBeenCalled();
     });
 
-    it("returns found: false when no outlets exist for journalist sourceType", async () => {
+    it("returns found: false when no outlets exist and discovery finds none", async () => {
       pgSqlMock.mockResolvedValue([]);
 
       // Cursor: no existing cursor
       vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
 
       vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([]);
+
+      // Brand data available for discovery
+      vi.mocked(fetchBrand).mockResolvedValueOnce({
+        id: "brand-1",
+        name: "TestBrand",
+        domain: "testbrand.com",
+        elevatorPitch: "A test brand",
+        bio: null,
+        mission: null,
+        location: null,
+        categories: "Technology",
+      });
+      vi.mocked(fetchCampaign).mockResolvedValueOnce({
+        id: "campaign-1",
+        name: "Test Campaign",
+        targetAudience: "Tech journalists",
+        targetOutcome: null,
+        valueForTarget: null,
+      });
+
+      // Discovery returns empty
+      vi.mocked(discoverOutlets).mockResolvedValueOnce([]);
 
       const result = await pullNext({
         orgId: "org-1",
@@ -994,6 +1019,130 @@ describe("buffer", () => {
       });
 
       expect(result.found).toBe(false);
+      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
+    });
+
+    it("discovers outlets and fills buffer when no outlets exist initially", async () => {
+      const journalistRow = toClaimedRow({
+        id: "buf-j-discover",
+        namespace: "campaign-1",
+        campaignId: "campaign-1",
+        email: "discovered@outlet.com",
+        externalId: "journalist:j-discovered",
+        data: {
+          firstName: "Jane",
+          lastName: "Reporter",
+          organizationName: "Discovered Outlet",
+          sourceType: "journalist",
+        },
+        brandId: "brand-1",
+        orgId: "org-1",
+        userId: null,
+      });
+
+      pgSqlMock
+        .mockResolvedValueOnce([])              // pullNext: buffer empty
+        .mockResolvedValueOnce([journalistRow]); // pullNext retry: claimed journalist lead
+
+      // Cursor: no existing cursor
+      vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
+
+      // First fetch: no outlets → triggers discovery
+      // Second fetch (after discovery): outlets found
+      vi.mocked(fetchOutletsByCampaign)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{
+          id: "outlet-discovered",
+          outletName: "Discovered Outlet",
+          outletUrl: "https://discovered-outlet.com",
+          outletDomain: "discovered-outlet.com",
+          relevanceScore: 0.9,
+          outletStatus: "active",
+          campaignId: "campaign-1",
+        }]);
+
+      // Brand + campaign for discovery
+      vi.mocked(fetchBrand).mockResolvedValueOnce({
+        id: "brand-1",
+        name: "TestBrand",
+        domain: "testbrand.com",
+        elevatorPitch: "A test brand",
+        bio: null,
+        mission: null,
+        location: null,
+        categories: "Technology",
+      });
+      vi.mocked(fetchCampaign).mockResolvedValueOnce({
+        id: "campaign-1",
+        name: "Test Campaign",
+        targetAudience: "Tech journalists",
+        targetOutcome: null,
+        valueForTarget: null,
+      });
+
+      // Discovery succeeds
+      vi.mocked(discoverOutlets).mockResolvedValueOnce([{
+        id: "outlet-discovered",
+        outletName: "Discovered Outlet",
+        outletUrl: "https://discovered-outlet.com",
+        outletDomain: "discovered-outlet.com",
+        relevanceScore: 0.9,
+        outletStatus: "active",
+        campaignId: "campaign-1",
+      }]);
+
+      // Journalist service returns journalist with email
+      vi.mocked(fetchJournalistsByOutlet).mockResolvedValueOnce([{
+        id: "j-discovered",
+        journalistName: "Jane Reporter",
+        firstName: "Jane",
+        lastName: "Reporter",
+        entityType: "individual",
+        relevanceScore: 0.8,
+        whyRelevant: "Covers tech",
+        whyNotRelevant: "",
+        emails: [{ email: "discovered@outlet.com", isValid: true, confidence: 0.95 }],
+      }]);
+
+      // isInBuffer → not in buffer
+      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
+
+      // db.insert for buffer + served_leads
+      const returningMock = vi.fn().mockResolvedValue([{ id: "served-1" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({
+        onConflictDoNothing: onConflictMock,
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      // db.update for cursor + buffer status
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
+
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
+        sourceType: "journalist",
+      });
+
+      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
+      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          campaignId: "campaign-1",
+          brandId: "brand-1",
+          brandName: "TestBrand",
+          brandDescription: "A test brand",
+          industry: "Technology",
+        }),
+        expect.any(Object),
+      );
+      expect(result.found).toBe(true);
+      expect(result.lead?.email).toBe("discovered@outlet.com");
     });
 
     it("skips lead when markServed returns inserted: false (race condition dedup)", async () => {


### PR DESCRIPTION
## Summary
- When `fillBufferFromJournalists` finds no outlets for a campaign, it now calls `POST /outlets/discover` on outlets-service to discover relevant outlets using brand/campaign context (name, description, industry, target audience)
- After discovery, re-fetches outlets and proceeds with the normal journalist buffering flow
- Fixes journalist-sourced campaigns (e.g. `95ef1e3d`) failing with `to=NULL` because no outlets had been discovered yet

## Test plan
- [x] Unit test: returns `found: false` when discovery finds no outlets
- [x] Unit test: discovers outlets, fills buffer, and serves journalist lead when no outlets exist initially
- [x] All 103 existing unit tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)