### PR TITLE
Proactively discover journalist emails before buffering

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -7,7 +7,7 @@ import { apolloSearchNext, apolloEnrich, apolloMatch, apolloSearchParams, type A
 import { fetchCampaign } from "./campaign-client.js";
 import { fetchBrand } from "./brand-client.js";
 import { fetchOutletsByCampaign, discoverOutlets } from "./outlet-client.js";
-import { fetchJournalistsByOutlet } from "./journalist-client.js";
+import { fetchJournalistsByOutlet, discoverJournalistEmails } from "./journalist-client.js";
 
 async function isInBuffer(orgId: string, campaignId: string, externalId: string): Promise<boolean> {
   const row = await db.query.leadBuffer.findFirst({
@@ -325,6 +325,36 @@ async function fillBufferFromJournalists(params: {
       continue;
     }
 
+    // Proactively discover emails for journalists on this outlet
+    const organizationDomain = outlet.outletDomain || extractDomain(outlet.outletUrl);
+    const individualJournalists = journalists.filter(j => j.entityType !== "organization");
+    const emailResults = await discoverJournalistEmails(
+      {
+        outletId: outlet.id,
+        organizationDomain,
+        brandId: params.brandId,
+        campaignId: params.campaignId,
+        journalistIds: individualJournalists.map(j => j.id),
+      },
+      {
+        orgId: params.orgId,
+        userId: params.userId ?? undefined,
+        runId: params.pushRunId ?? undefined,
+        workflowName: params.workflowName,
+        featureSlug: params.featureSlug,
+      }
+    );
+
+    // Build a lookup map: journalistId → discovered email
+    const discoveredEmailMap = new Map<string, string>();
+    if (emailResults) {
+      for (const result of emailResults) {
+        if (result.email) {
+          discoveredEmailMap.set(result.journalistId, result.email);
+        }
+      }
+    }
+
     const startJ = oi === cursorState.outletIndex ? cursorState.journalistIndex : 0;
 
     for (let ji = startJ; ji < journalists.length; ji++) {
@@ -337,13 +367,12 @@ async function fillBufferFromJournalists(params: {
 
       if (await isInBuffer(params.orgId, params.campaignId, externalId)) continue;
 
-      // Pick the best valid email if available
-      const validEmail = journalist.emails
+      // Use email from: 1) resolve response, 2) discover-emails, 3) empty (fallback to apolloMatch in pullNext)
+      const resolveEmail = journalist.emails
         ?.filter(e => e.isValid)
         ?.sort((a, b) => b.confidence - a.confidence)
         ?.[0]?.email ?? null;
-
-      const organizationDomain = outlet.outletDomain || extractDomain(outlet.outletUrl);
+      const validEmail = resolveEmail ?? discoveredEmailMap.get(journalist.id) ?? null;
 
       const data: Record<string, unknown> = {
         firstName: journalist.firstName,

--- a/src/lib/journalist-client.ts
+++ b/src/lib/journalist-client.ts
@@ -19,6 +19,68 @@ export interface JournalistWithEmails {
   emails: JournalistEmail[];
 }
 
+export interface DiscoverEmailsResult {
+  journalistId: string;
+  email: string | null;
+  emailStatus: string | null;
+  cached: boolean;
+  enrichmentId: string;
+}
+
+export async function discoverJournalistEmails(params: {
+  outletId: string;
+  organizationDomain: string;
+  brandId: string;
+  campaignId: string;
+  journalistIds?: string[];
+}, context?: {
+  orgId?: string | null;
+  userId?: string;
+  runId?: string;
+  workflowName?: string;
+  featureSlug?: string;
+}): Promise<DiscoverEmailsResult[] | null> {
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-API-Key": JOURNALISTS_SERVICE_API_KEY,
+    };
+    if (context?.orgId) headers["x-org-id"] = context.orgId;
+    if (context?.userId) headers["x-user-id"] = context.userId;
+    if (context?.runId) headers["x-run-id"] = context.runId;
+    if (params.campaignId) headers["x-campaign-id"] = params.campaignId;
+    if (params.brandId) headers["x-brand-id"] = params.brandId;
+    if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
+    if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
+
+    const body: Record<string, unknown> = {
+      outletId: params.outletId,
+      organizationDomain: params.organizationDomain,
+      brandId: params.brandId,
+      campaignId: params.campaignId,
+    };
+    if (params.journalistIds) body.journalistIds = params.journalistIds;
+
+    const response = await fetch(`${JOURNALISTS_SERVICE_URL}/journalists/discover-emails`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      console.warn(`[journalist-client] Failed to discover emails for outlet ${params.outletId}: ${response.status}`);
+      return null;
+    }
+
+    const data = (await response.json()) as { discovered: number; total: number; skipped: number; results: DiscoverEmailsResult[] };
+    console.log(`[journalist-client] Discovered ${data.discovered}/${data.total} emails for outlet ${params.outletId} (skipped=${data.skipped})`);
+    return data.results;
+  } catch (error) {
+    console.error("[journalist-client] Error discovering emails:", error);
+    return null;
+  }
+}
+
 export async function fetchJournalistsByOutlet(
   outletId: string,
   options?: {

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -42,6 +42,7 @@ vi.mock("../../src/lib/outlet-client.js", () => ({
 // Mock journalist-client
 vi.mock("../../src/lib/journalist-client.js", () => ({
   fetchJournalistsByOutlet: vi.fn().mockResolvedValue(null),
+  discoverJournalistEmails: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock campaign-client
@@ -75,7 +76,7 @@ import { resolveOrCreateLead } from "../../src/lib/leads-registry.js";
 import { fetchOutletsByCampaign, discoverOutlets } from "../../src/lib/outlet-client.js";
 import { fetchCampaign } from "../../src/lib/campaign-client.js";
 import { fetchBrand } from "../../src/lib/brand-client.js";
-import { fetchJournalistsByOutlet } from "../../src/lib/journalist-client.js";
+import { fetchJournalistsByOutlet, discoverJournalistEmails } from "../../src/lib/journalist-client.js";
 
 /** Helper: convert camelCase buffer row to snake_case raw SQL row (as returned by pgSql) */
 function toClaimedRow(row: {
@@ -1143,6 +1144,89 @@ describe("buffer", () => {
       );
       expect(result.found).toBe(true);
       expect(result.lead?.email).toBe("discovered@outlet.com");
+    });
+
+    it("uses discover-emails when resolve returns journalists without emails", async () => {
+      const journalistRow = toClaimedRow({
+        id: "buf-j-noemail",
+        namespace: "campaign-1",
+        campaignId: "campaign-1",
+        email: "found@techcrunch.com",
+        externalId: "journalist:j-noemail",
+        data: {
+          firstName: "Bob",
+          lastName: "Writer",
+          organizationDomain: "techcrunch.com",
+          organizationName: "TechCrunch",
+          sourceType: "journalist",
+        },
+        brandId: "brand-1",
+        orgId: "org-1",
+        userId: null,
+      });
+
+      pgSqlMock
+        .mockResolvedValueOnce([])              // pullNext: buffer empty
+        .mockResolvedValueOnce([journalistRow]); // pullNext retry: claimed lead
+
+      vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
+      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
+
+      // Outlets exist
+      vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([
+        { id: "outlet-1", outletName: "TechCrunch", outletUrl: "https://techcrunch.com", outletDomain: "techcrunch.com", relevanceScore: 85, outletStatus: "open", campaignId: "campaign-1" },
+      ]);
+
+      // Resolve returns journalist WITHOUT emails
+      vi.mocked(fetchJournalistsByOutlet).mockResolvedValueOnce([
+        {
+          id: "j-noemail",
+          journalistName: "Bob Writer",
+          firstName: "Bob",
+          lastName: "Writer",
+          entityType: "individual" as const,
+          relevanceScore: 0.8,
+          whyRelevant: "Covers tech",
+          whyNotRelevant: "",
+          emails: [],
+        },
+      ]);
+
+      // discover-emails finds the email
+      vi.mocked(discoverJournalistEmails).mockResolvedValueOnce([
+        { journalistId: "j-noemail", email: "found@techcrunch.com", emailStatus: "valid", cached: false, enrichmentId: "enr-1" },
+      ]);
+
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
+
+      const returningMock = vi.fn().mockResolvedValue([{ id: "served-1" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
+        sourceType: "journalist",
+      });
+
+      expect(vi.mocked(discoverJournalistEmails)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outletId: "outlet-1",
+          organizationDomain: "techcrunch.com",
+          brandId: "brand-1",
+          campaignId: "campaign-1",
+        }),
+        expect.any(Object),
+      );
+      expect(result.found).toBe(true);
+      expect(result.lead?.email).toBe("found@techcrunch.com");
     });
 
     it("skips lead when markServed returns inserted: false (race condition dedup)", async () => {


### PR DESCRIPTION
## Summary
- After resolving journalists via `POST /journalists/resolve`, now calls `POST /journalists/discover-emails` to batch-discover email addresses for all individual journalists on the outlet
- Emails from discover-emails are used as fallback when resolve doesn't return them (which is the common case per the API spec)
- Combined with PR #109 (auto-discover outlets), this completes the proactive journalist lead pipeline: discover outlets → resolve journalists → discover emails → buffer with full data

## Test plan
- [x] Unit test: discover-emails called and email used when resolve returns journalist without emails
- [x] All 104 unit tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)