### PR TITLE
Use apolloMatch for journalist email discovery at buffer time

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -7,7 +7,7 @@ import { apolloSearchNext, apolloEnrich, apolloMatch, apolloSearchParams, type A
 import { fetchCampaign } from "./campaign-client.js";
 import { fetchBrand } from "./brand-client.js";
 import { fetchOutletsByCampaign, discoverOutlets } from "./outlet-client.js";
-import { fetchJournalistsByOutlet, discoverJournalistEmails } from "./journalist-client.js";
+import { fetchJournalistsByOutlet } from "./journalist-client.js";
 
 async function isInBuffer(orgId: string, campaignId: string, externalId: string): Promise<boolean> {
   const row = await db.query.leadBuffer.findFirst({
@@ -325,35 +325,7 @@ async function fillBufferFromJournalists(params: {
       continue;
     }
 
-    // Proactively discover emails for journalists on this outlet
     const organizationDomain = outlet.outletDomain || extractDomain(outlet.outletUrl);
-    const individualJournalists = journalists.filter(j => j.entityType !== "organization");
-    const emailResults = await discoverJournalistEmails(
-      {
-        outletId: outlet.id,
-        organizationDomain,
-        brandId: params.brandId,
-        campaignId: params.campaignId,
-        journalistIds: individualJournalists.map(j => j.id),
-      },
-      {
-        orgId: params.orgId,
-        userId: params.userId ?? undefined,
-        runId: params.pushRunId ?? undefined,
-        workflowName: params.workflowName,
-        featureSlug: params.featureSlug,
-      }
-    );
-
-    // Build a lookup map: journalistId → discovered email
-    const discoveredEmailMap = new Map<string, string>();
-    if (emailResults) {
-      for (const result of emailResults) {
-        if (result.email) {
-          discoveredEmailMap.set(result.journalistId, result.email);
-        }
-      }
-    }
 
     const startJ = oi === cursorState.outletIndex ? cursorState.journalistIndex : 0;
 
@@ -367,12 +339,53 @@ async function fillBufferFromJournalists(params: {
 
       if (await isInBuffer(params.orgId, params.campaignId, externalId)) continue;
 
-      // Use email from: 1) resolve response, 2) discover-emails, 3) empty (fallback to apolloMatch in pullNext)
-      const resolveEmail = journalist.emails
+      // Try email from resolve response first
+      let validEmail = journalist.emails
         ?.filter(e => e.isValid)
         ?.sort((a, b) => b.confidence - a.confidence)
         ?.[0]?.email ?? null;
-      const validEmail = resolveEmail ?? discoveredEmailMap.get(journalist.id) ?? null;
+
+      let enrichedData: Record<string, unknown> | null = null;
+
+      // No email from resolve — proactively match via Apollo Service
+      if (!validEmail && journalist.firstName && journalist.lastName && organizationDomain) {
+        const matchResult = await apolloMatch(
+          {
+            firstName: journalist.firstName,
+            lastName: journalist.lastName,
+            organizationDomain,
+          },
+          {
+            runId: params.pushRunId,
+            orgId: params.orgId,
+            userId: params.userId,
+            brandId: params.brandId,
+            campaignId: params.campaignId,
+            workflowName: params.workflowName,
+            featureSlug: params.featureSlug,
+          }
+        );
+
+        if (matchResult?.person?.email) {
+          validEmail = matchResult.person.email;
+          enrichedData = matchResult.person;
+
+          // Cache enrichment for later lookups
+          await db.insert(enrichments).values({
+            email: validEmail,
+            apolloPersonId: matchResult.person.id ?? null,
+            firstName: matchResult.person.firstName ?? null,
+            lastName: matchResult.person.lastName ?? null,
+            title: matchResult.person.title ?? null,
+            linkedinUrl: matchResult.person.linkedinUrl ?? null,
+            organizationName: matchResult.person.organizationName ?? null,
+            organizationDomain: matchResult.person.organizationDomain ?? null,
+            organizationIndustry: matchResult.person.organizationIndustry ?? null,
+            organizationSize: matchResult.person.organizationSize ?? null,
+            responseRaw: matchResult.person,
+          }).onConflictDoNothing();
+        }
+      }
 
       const data: Record<string, unknown> = {
         firstName: journalist.firstName,
@@ -384,6 +397,7 @@ async function fillBufferFromJournalists(params: {
         outletId: outlet.id,
         journalistId: journalist.id,
         sourceType: "journalist",
+        ...(enrichedData ?? {}),
       };
 
       await db.insert(leadBuffer).values({

--- a/src/lib/journalist-client.ts
+++ b/src/lib/journalist-client.ts
@@ -19,68 +19,6 @@ export interface JournalistWithEmails {
   emails: JournalistEmail[];
 }
 
-export interface DiscoverEmailsResult {
-  journalistId: string;
-  email: string | null;
-  emailStatus: string | null;
-  cached: boolean;
-  enrichmentId: string;
-}
-
-export async function discoverJournalistEmails(params: {
-  outletId: string;
-  organizationDomain: string;
-  brandId: string;
-  campaignId: string;
-  journalistIds?: string[];
-}, context?: {
-  orgId?: string | null;
-  userId?: string;
-  runId?: string;
-  workflowName?: string;
-  featureSlug?: string;
-}): Promise<DiscoverEmailsResult[] | null> {
-  try {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      "X-API-Key": JOURNALISTS_SERVICE_API_KEY,
-    };
-    if (context?.orgId) headers["x-org-id"] = context.orgId;
-    if (context?.userId) headers["x-user-id"] = context.userId;
-    if (context?.runId) headers["x-run-id"] = context.runId;
-    if (params.campaignId) headers["x-campaign-id"] = params.campaignId;
-    if (params.brandId) headers["x-brand-id"] = params.brandId;
-    if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
-    if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
-
-    const body: Record<string, unknown> = {
-      outletId: params.outletId,
-      organizationDomain: params.organizationDomain,
-      brandId: params.brandId,
-      campaignId: params.campaignId,
-    };
-    if (params.journalistIds) body.journalistIds = params.journalistIds;
-
-    const response = await fetch(`${JOURNALISTS_SERVICE_URL}/journalists/discover-emails`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      console.warn(`[journalist-client] Failed to discover emails for outlet ${params.outletId}: ${response.status}`);
-      return null;
-    }
-
-    const data = (await response.json()) as { discovered: number; total: number; skipped: number; results: DiscoverEmailsResult[] };
-    console.log(`[journalist-client] Discovered ${data.discovered}/${data.total} emails for outlet ${params.outletId} (skipped=${data.skipped})`);
-    return data.results;
-  } catch (error) {
-    console.error("[journalist-client] Error discovering emails:", error);
-    return null;
-  }
-}
-
 export async function fetchJournalistsByOutlet(
   outletId: string,
   options?: {

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -42,7 +42,6 @@ vi.mock("../../src/lib/outlet-client.js", () => ({
 // Mock journalist-client
 vi.mock("../../src/lib/journalist-client.js", () => ({
   fetchJournalistsByOutlet: vi.fn().mockResolvedValue(null),
-  discoverJournalistEmails: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock campaign-client
@@ -76,7 +75,7 @@ import { resolveOrCreateLead } from "../../src/lib/leads-registry.js";
 import { fetchOutletsByCampaign, discoverOutlets } from "../../src/lib/outlet-client.js";
 import { fetchCampaign } from "../../src/lib/campaign-client.js";
 import { fetchBrand } from "../../src/lib/brand-client.js";
-import { fetchJournalistsByOutlet, discoverJournalistEmails } from "../../src/lib/journalist-client.js";
+import { fetchJournalistsByOutlet } from "../../src/lib/journalist-client.js";
 
 /** Helper: convert camelCase buffer row to snake_case raw SQL row (as returned by pgSql) */
 function toClaimedRow(row: {
@@ -1146,7 +1145,7 @@ describe("buffer", () => {
       expect(result.lead?.email).toBe("discovered@outlet.com");
     });
 
-    it("uses discover-emails when resolve returns journalists without emails", async () => {
+    it("uses apolloMatch proactively when resolve returns journalists without emails", async () => {
       const journalistRow = toClaimedRow({
         id: "buf-j-noemail",
         namespace: "campaign-1",
@@ -1192,10 +1191,17 @@ describe("buffer", () => {
         },
       ]);
 
-      // discover-emails finds the email
-      vi.mocked(discoverJournalistEmails).mockResolvedValueOnce([
-        { journalistId: "j-noemail", email: "found@techcrunch.com", emailStatus: "valid", cached: false, enrichmentId: "enr-1" },
-      ]);
+      // apolloMatch finds the email
+      vi.mocked(apolloMatch).mockResolvedValueOnce({
+        person: {
+          id: "apollo-bob",
+          email: "found@techcrunch.com",
+          firstName: "Bob",
+          lastName: "Writer",
+          organizationName: "TechCrunch",
+          organizationDomain: "techcrunch.com",
+        },
+      });
 
       vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
 
@@ -1216,14 +1222,10 @@ describe("buffer", () => {
         sourceType: "journalist",
       });
 
-      expect(vi.mocked(discoverJournalistEmails)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          outletId: "outlet-1",
-          organizationDomain: "techcrunch.com",
-          brandId: "brand-1",
-          campaignId: "campaign-1",
-        }),
-        expect.any(Object),
+      // apolloMatch should have been called during fillBufferFromJournalists
+      expect(vi.mocked(apolloMatch)).toHaveBeenCalledWith(
+        { firstName: "Bob", lastName: "Writer", organizationDomain: "techcrunch.com" },
+        expect.objectContaining({ campaignId: "campaign-1", brandId: "brand-1" }),
       );
       expect(result.found).toBe(true);
       expect(result.lead?.email).toBe("found@techcrunch.com");


### PR DESCRIPTION
## Summary
- Removes dead `discoverJournalistEmails` call (endpoint deleted from journalist-service in PR #14)
- Replaces it with proactive `apolloMatch` calls in `fillBufferFromJournalists`: for each journalist without email, calls Apollo Service directly via `apolloMatch(firstName, lastName, organizationDomain)`
- Caches enrichment results to avoid duplicate Apollo calls in `pullNext`
- Email discovery now happens at buffer time (proactive) instead of pull time (reactive)

## Test plan
- [x] Unit test: apolloMatch called proactively when resolve returns journalist without email
- [x] All 104 unit tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)