### PR TITLE
Add brandContext fallback for outlet discovery

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -460,6 +460,13 @@
               "nullable": true
             }
           },
+          "brandContext": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "nullable": true
+            }
+          },
           "userId": {
             "type": "string"
           },

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -236,6 +236,7 @@ async function fillBufferFromJournalists(params: {
   orgId: string;
   campaignId: string;
   brandId: string;
+  brandContext?: Record<string, unknown>;
   pushRunId?: string | null;
   userId?: string | null;
   workflowName?: string;
@@ -272,8 +273,16 @@ async function fillBufferFromJournalists(params: {
       fetchBrand(params.brandId, params.orgId, serviceContext),
     ]);
 
-    if (!brand?.name || !brand?.elevatorPitch || !brand?.categories) {
-      console.warn(`[fillBufferFromJournalists] Cannot discover outlets — missing brand data (name/description/categories)`);
+    // Build discovery params from brandContext (DAG-provided) with brand-service as fallback
+    const ctx = params.brandContext ?? {};
+    const brandName = (ctx.brandName as string) ?? (ctx.companyName as string) ?? brand?.name ?? null;
+    const brandDescription = (ctx.companyContext as string) ?? (ctx.brandDescription as string) ?? brand?.elevatorPitch ?? brand?.bio ?? null;
+    const industry = (ctx.industry as string) ?? (ctx.categories as string) ?? brand?.categories ?? null;
+    const targetGeo = (ctx.targetGeo as string) ?? brand?.location ?? undefined;
+    const targetAudience = (ctx.targetAudience as string) ?? campaign?.targetAudience ?? undefined;
+
+    if (!brandName || !brandDescription || !industry) {
+      console.warn(`[fillBufferFromJournalists] Cannot discover outlets — insufficient context (need brandName, brandDescription, industry). brandContext=${JSON.stringify(ctx)}, brand=${JSON.stringify(brand ? { name: brand.name, elevatorPitch: brand.elevatorPitch, categories: brand.categories } : null)}`);
       return { filled: 0 };
     }
 
@@ -281,11 +290,11 @@ async function fillBufferFromJournalists(params: {
       {
         campaignId: params.campaignId,
         brandId: params.brandId,
-        brandName: brand.name,
-        brandDescription: brand.elevatorPitch,
-        industry: brand.categories,
-        targetGeo: brand.location ?? undefined,
-        targetAudience: campaign?.targetAudience ?? undefined,
+        brandName,
+        brandDescription,
+        industry,
+        targetGeo,
+        targetAudience,
         workflowName: params.workflowName,
       },
       {
@@ -436,6 +445,7 @@ export async function pullNext(params: {
   brandId: string;
   runId?: string | null;
   searchParams?: ApolloSearchParams;
+  brandContext?: Record<string, unknown>;
   userId?: string | null;
   workflowName?: string;
   featureSlug?: string;
@@ -503,6 +513,7 @@ export async function pullNext(params: {
           orgId: params.orgId,
           campaignId: params.campaignId,
           brandId: params.brandId,
+          brandContext: params.brandContext,
           pushRunId: params.runId,
           userId: params.userId,
           workflowName: params.workflowName,

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -32,7 +32,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
   }
 
   try {
-    const { campaignId, brandId, searchParams, userId, idempotencyKey, sourceType } = parsed.data;
+    const { campaignId, brandId, searchParams, brandContext, userId, idempotencyKey, sourceType } = parsed.data;
 
     // Body workflowName takes precedence; fall back to header injected by workflow-service
     const workflowName = parsed.data.workflowName ?? req.workflowName;
@@ -68,6 +68,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       brandId,
       runId: serveRunId,
       searchParams: searchParams ?? undefined,
+      brandContext: brandContext ?? undefined,
       userId: userId ?? req.userId ?? null,
       workflowName,
       featureSlug: req.featureSlug,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -189,6 +189,7 @@ export const BufferNextRequestSchema = z
     brandId: z.string().min(1),
     sourceType: z.enum(["apollo", "journalist"]).default("apollo").optional(),
     searchParams: z.record(z.string(), z.unknown()).nullish(),
+    brandContext: z.record(z.string(), z.unknown()).nullish(),
     userId: z.string().optional(),
     workflowName: z.string().optional(),
     idempotencyKey: z.string().min(1).optional(),

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -1145,6 +1145,158 @@ describe("buffer", () => {
       expect(result.lead?.email).toBe("discovered@outlet.com");
     });
 
+    it("uses brandContext for outlet discovery when brand-service returns incomplete data", async () => {
+      const journalistRow = toClaimedRow({
+        id: "buf-j-ctx",
+        namespace: "campaign-1",
+        campaignId: "campaign-1",
+        email: "ctx@outlet.com",
+        externalId: "journalist:j-ctx",
+        data: {
+          firstName: "Alice",
+          lastName: "Ctx",
+          organizationName: "Context Outlet",
+          sourceType: "journalist",
+        },
+        brandId: "brand-1",
+        orgId: "org-1",
+        userId: null,
+      });
+
+      pgSqlMock
+        .mockResolvedValueOnce([])              // buffer empty
+        .mockResolvedValueOnce([journalistRow]); // retry: claimed
+
+      vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
+
+      vi.mocked(fetchOutletsByCampaign)
+        .mockResolvedValueOnce([])   // no outlets → triggers discovery
+        .mockResolvedValueOnce([{
+          id: "outlet-ctx",
+          outletName: "Context Outlet",
+          outletUrl: "https://context-outlet.com",
+          outletDomain: "context-outlet.com",
+          relevanceScore: 0.9,
+          outletStatus: "active",
+          campaignId: "campaign-1",
+        }]);
+
+      // Brand-service returns incomplete data (no elevatorPitch, no categories)
+      vi.mocked(fetchBrand).mockResolvedValueOnce({
+        id: "brand-1",
+        name: "Distribute",
+        domain: "distribute.so",
+        elevatorPitch: null,
+        bio: null,
+        mission: null,
+        location: null,
+        categories: null,
+      });
+      vi.mocked(fetchCampaign).mockResolvedValueOnce({
+        id: "campaign-1",
+        name: "Test Campaign",
+        targetAudience: null,
+        targetOutcome: null,
+        valueForTarget: null,
+      });
+
+      vi.mocked(discoverOutlets).mockResolvedValueOnce([{
+        id: "outlet-ctx",
+        outletName: "Context Outlet",
+        outletUrl: "https://context-outlet.com",
+        outletDomain: "context-outlet.com",
+        relevanceScore: 0.9,
+        outletStatus: "active",
+        campaignId: "campaign-1",
+      }]);
+
+      vi.mocked(fetchJournalistsByOutlet).mockResolvedValueOnce([{
+        id: "j-ctx",
+        journalistName: "Alice Ctx",
+        firstName: "Alice",
+        lastName: "Ctx",
+        entityType: "individual",
+        relevanceScore: 0.8,
+        whyRelevant: "Covers AI",
+        whyNotRelevant: "",
+        emails: [{ email: "ctx@outlet.com", isValid: true, confidence: 0.95 }],
+      }]);
+
+      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
+
+      const returningMock = vi.fn().mockResolvedValue([{ id: "served-ctx" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({
+        onConflictDoNothing: onConflictMock,
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
+
+      // brandContext provides the missing data
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
+        sourceType: "journalist",
+        brandContext: {
+          companyContext: "AI-powered PR distribution platform",
+          industry: "Technology",
+          targetGeo: "US",
+        },
+      });
+
+      // Should use brandContext fields for discovery (not fail due to missing brand-service data)
+      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
+      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          brandName: "Distribute",                              // from brand-service (name was available)
+          brandDescription: "AI-powered PR distribution platform", // from brandContext.companyContext
+          industry: "Technology",                                // from brandContext.industry
+          targetGeo: "US",                                       // from brandContext.targetGeo
+        }),
+        expect.any(Object),
+      );
+      expect(result.found).toBe(true);
+      expect(result.lead?.email).toBe("ctx@outlet.com");
+    });
+
+    it("fails gracefully when neither brandContext nor brand-service provide sufficient data", async () => {
+      pgSqlMock.mockResolvedValue([]);
+
+      vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
+      vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([]);
+
+      // Brand-service returns minimal data
+      vi.mocked(fetchBrand).mockResolvedValueOnce({
+        id: "brand-1",
+        name: "Distribute",
+        domain: "distribute.so",
+        elevatorPitch: null,
+        bio: null,
+        mission: null,
+        location: null,
+        categories: null,
+      });
+      vi.mocked(fetchCampaign).mockResolvedValueOnce(null);
+
+      // No brandContext provided either
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
+        sourceType: "journalist",
+      });
+
+      expect(result.found).toBe(false);
+      expect(vi.mocked(discoverOutlets)).not.toHaveBeenCalled();
+    });
+
     it("uses apolloMatch proactively when resolve returns journalists without emails", async () => {
       const journalistRow = toClaimedRow({
         id: "buf-j-noemail",

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -73,6 +73,30 @@ describe("schema validation", () => {
       }
     });
 
+    it("accepts optional brandContext", () => {
+      const result = BufferNextRequestSchema.safeParse({
+        campaignId: "c1",
+        brandId: "b1",
+        brandContext: { companyContext: "AI startup", industry: "Technology" },
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.brandContext).toEqual({ companyContext: "AI startup", industry: "Technology" });
+      }
+    });
+
+    it("accepts null brandContext", () => {
+      const result = BufferNextRequestSchema.safeParse({
+        campaignId: "c1",
+        brandId: "b1",
+        brandContext: null,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.brandContext).toBeNull();
+      }
+    });
+
     it("accepts request without workflowName", () => {
       const result = BufferNextRequestSchema.safeParse({
         campaignId: "c1",


### PR DESCRIPTION
## Summary
- Adds optional `brandContext` field to `POST /buffer/next` request schema — a generic `Record<string, unknown>` the DAG can populate from `featureInputs`
- Replaces hardcoded `elevatorPitch`/`categories` field checks with generic context resolution: `brandContext` takes priority, brand-service data is fallback
- When neither source provides sufficient data (brandName + brandDescription + industry), logs a detailed warning and returns `filled: 0`

## Test plan
- [x] New test: brandContext fallback works when brand-service returns incomplete data
- [x] New test: fails gracefully when neither brandContext nor brand-service have data
- [x] Existing tests still pass (brand-service data still works as primary source)
- [x] Schema tests for new `brandContext` field (accepts object, null, undefined)
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)