### PR TITLE
Use extract-fields API for journalist outlet discovery

### DIFF
--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -47,3 +47,78 @@ export async function fetchBrand(
     return null;
   }
 }
+
+export interface ExtractedField {
+  key: string;
+  value: string | string[] | Record<string, unknown> | null;
+  cached: boolean;
+  extractedAt: string;
+  expiresAt: string | null;
+  sourceUrls: string[] | null;
+}
+
+type ServiceContext = { userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string; featureSlug?: string };
+
+function buildHeaders(orgId?: string | null, context?: ServiceContext): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-API-Key": BRAND_SERVICE_API_KEY,
+  };
+  if (orgId) headers["x-org-id"] = orgId;
+  if (context?.userId) headers["x-user-id"] = context.userId;
+  if (context?.runId) headers["x-run-id"] = context.runId;
+  if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
+  if (context?.brandId) headers["x-brand-id"] = context.brandId;
+  if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
+  if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
+  return headers;
+}
+
+export async function extractBrandFields(
+  brandId: string,
+  fields: Array<{ key: string; description: string }>,
+  orgId?: string | null,
+  context?: ServiceContext,
+): Promise<ExtractedField[] | null> {
+  try {
+    const response = await fetch(`${BRAND_SERVICE_URL}/brands/${brandId}/extract-fields`, {
+      method: "POST",
+      headers: buildHeaders(orgId, context),
+      body: JSON.stringify({ fields }),
+    });
+
+    if (!response.ok) {
+      console.warn(`[brand-client] extract-fields failed for brand ${brandId}: ${response.status}`);
+      return null;
+    }
+
+    const data = (await response.json()) as { brandId: string; results: ExtractedField[] };
+    return data.results;
+  } catch (error) {
+    console.error("[brand-client] Error extracting brand fields:", error);
+    return null;
+  }
+}
+
+export async function fetchExtractedFields(
+  brandId: string,
+  orgId?: string | null,
+  context?: ServiceContext,
+): Promise<ExtractedField[] | null> {
+  try {
+    const response = await fetch(`${BRAND_SERVICE_URL}/brands/${brandId}/extracted-fields`, {
+      headers: buildHeaders(orgId, context),
+    });
+
+    if (!response.ok) {
+      console.warn(`[brand-client] fetch extracted-fields failed for brand ${brandId}: ${response.status}`);
+      return null;
+    }
+
+    const data = (await response.json()) as { brandId: string; fields: ExtractedField[] };
+    return data.fields;
+  } catch (error) {
+    console.error("[brand-client] Error fetching extracted fields:", error);
+    return null;
+  }
+}

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -5,7 +5,7 @@ import { checkContacted, markServed } from "./dedup.js";
 import { resolveOrCreateLead, findLeadByApolloPersonId } from "./leads-registry.js";
 import { apolloSearchNext, apolloEnrich, apolloMatch, apolloSearchParams, type ApolloSearchParams } from "./apollo-client.js";
 import { fetchCampaign } from "./campaign-client.js";
-import { fetchBrand } from "./brand-client.js";
+import { fetchBrand, fetchExtractedFields, extractBrandFields } from "./brand-client.js";
 import { fetchOutletsByCampaign, discoverOutlets } from "./outlet-client.js";
 import { fetchJournalistsByOutlet } from "./journalist-client.js";
 
@@ -232,6 +232,64 @@ async function saveCursor(orgId: string, namespace: string, state: unknown): Pro
   }
 }
 
+const DISCOVERY_FIELDS = [
+  { key: "elevator_pitch", description: "A one-sentence pitch describing what the brand does" },
+  { key: "categories", description: "Comma-separated industry categories the brand operates in" },
+  { key: "target_geo", description: "Primary geographic market the brand targets" },
+];
+
+interface BrandContext {
+  brandName: string | null;
+  brandDescription: string | null;
+  industry: string | null;
+  targetGeo: string | null;
+}
+
+async function resolveBrandContext(
+  brandId: string,
+  orgId: string,
+  serviceContext: { userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string; featureSlug?: string },
+): Promise<BrandContext> {
+  const empty: BrandContext = { brandName: null, brandDescription: null, industry: null, targetGeo: null };
+
+  // 1. Check cached extracted fields first (fast, no AI cost)
+  const cached = await fetchExtractedFields(brandId, orgId, serviceContext);
+  if (cached && cached.length > 0) {
+    const fieldMap = new Map(cached.map(f => [f.key, f.value]));
+    const pitch = fieldMap.get("elevator_pitch");
+    const cats = fieldMap.get("categories");
+    const geo = fieldMap.get("target_geo");
+
+    // If we have the key fields cached, return them directly
+    if (pitch && cats) {
+      console.log(`[resolveBrandContext] Using cached extracted fields for brand=${brandId}`);
+      return {
+        brandName: null, // will be filled from brand.name by caller
+        brandDescription: typeof pitch === "string" ? pitch : JSON.stringify(pitch),
+        industry: typeof cats === "string" ? cats : Array.isArray(cats) ? cats.join(", ") : JSON.stringify(cats),
+        targetGeo: geo ? (typeof geo === "string" ? geo : JSON.stringify(geo)) : null,
+      };
+    }
+  }
+
+  // 2. Extract fields via AI (slow, but results get cached for 30 days)
+  console.log(`[resolveBrandContext] Extracting fields via AI for brand=${brandId}`);
+  const results = await extractBrandFields(brandId, DISCOVERY_FIELDS, orgId, serviceContext);
+  if (!results) return empty;
+
+  const fieldMap = new Map(results.map(f => [f.key, f.value]));
+  const pitch = fieldMap.get("elevator_pitch");
+  const cats = fieldMap.get("categories");
+  const geo = fieldMap.get("target_geo");
+
+  return {
+    brandName: null,
+    brandDescription: pitch ? (typeof pitch === "string" ? pitch : JSON.stringify(pitch)) : null,
+    industry: cats ? (typeof cats === "string" ? cats : Array.isArray(cats) ? cats.join(", ") : JSON.stringify(cats)) : null,
+    targetGeo: geo ? (typeof geo === "string" ? geo : JSON.stringify(geo)) : null,
+  };
+}
+
 async function fillBufferFromJournalists(params: {
   orgId: string;
   campaignId: string;
@@ -273,16 +331,18 @@ async function fillBufferFromJournalists(params: {
       fetchBrand(params.brandId, params.orgId, serviceContext),
     ]);
 
-    // Build discovery params from brandContext (DAG-provided) with brand-service as fallback
+    // Resolve brand context: extract-fields (primary) → brandContext (DAG) → legacy brand columns (fallback)
+    const extracted = await resolveBrandContext(params.brandId, params.orgId, serviceContext);
     const ctx = params.brandContext ?? {};
-    const brandName = (ctx.brandName as string) ?? (ctx.companyName as string) ?? brand?.name ?? null;
-    const brandDescription = (ctx.companyContext as string) ?? (ctx.brandDescription as string) ?? brand?.elevatorPitch ?? brand?.bio ?? null;
-    const industry = (ctx.industry as string) ?? (ctx.categories as string) ?? brand?.categories ?? null;
-    const targetGeo = (ctx.targetGeo as string) ?? brand?.location ?? undefined;
+
+    const brandName = extracted.brandName ?? (ctx.brandName as string) ?? (ctx.companyName as string) ?? brand?.name ?? null;
+    const brandDescription = extracted.brandDescription ?? (ctx.companyContext as string) ?? (ctx.brandDescription as string) ?? brand?.elevatorPitch ?? brand?.bio ?? null;
+    const industry = extracted.industry ?? (ctx.industry as string) ?? (ctx.categories as string) ?? brand?.categories ?? null;
+    const targetGeo = extracted.targetGeo ?? (ctx.targetGeo as string) ?? brand?.location ?? undefined;
     const targetAudience = (ctx.targetAudience as string) ?? campaign?.targetAudience ?? undefined;
 
     if (!brandName || !brandDescription || !industry) {
-      console.warn(`[fillBufferFromJournalists] Cannot discover outlets — insufficient context (need brandName, brandDescription, industry). brandContext=${JSON.stringify(ctx)}, brand=${JSON.stringify(brand ? { name: brand.name, elevatorPitch: brand.elevatorPitch, categories: brand.categories } : null)}`);
+      console.warn(`[fillBufferFromJournalists] Cannot discover outlets — insufficient context (need brandName, brandDescription, industry). extracted=${JSON.stringify(extracted)}, brandContext=${JSON.stringify(ctx)}, brand=${JSON.stringify(brand ? { name: brand.name, elevatorPitch: brand.elevatorPitch, categories: brand.categories } : null)}`);
       return { filled: 0 };
     }
 

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -52,6 +52,8 @@ vi.mock("../../src/lib/campaign-client.js", () => ({
 // Mock brand-client
 vi.mock("../../src/lib/brand-client.js", () => ({
   fetchBrand: vi.fn().mockResolvedValue(null),
+  fetchExtractedFields: vi.fn().mockResolvedValue(null),
+  extractBrandFields: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock email-gateway-client
@@ -74,7 +76,7 @@ import { checkDeliveryStatus } from "../../src/lib/email-gateway-client.js";
 import { resolveOrCreateLead } from "../../src/lib/leads-registry.js";
 import { fetchOutletsByCampaign, discoverOutlets } from "../../src/lib/outlet-client.js";
 import { fetchCampaign } from "../../src/lib/campaign-client.js";
-import { fetchBrand } from "../../src/lib/brand-client.js";
+import { fetchBrand, fetchExtractedFields, extractBrandFields } from "../../src/lib/brand-client.js";
 import { fetchJournalistsByOutlet } from "../../src/lib/journalist-client.js";
 
 /** Helper: convert camelCase buffer row to snake_case raw SQL row (as returned by pgSql) */
@@ -989,16 +991,22 @@ describe("buffer", () => {
 
       vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([]);
 
-      // Brand data available for discovery
+      // extract-fields returns cached data
+      vi.mocked(fetchExtractedFields).mockResolvedValueOnce([
+        { key: "elevator_pitch", value: "A test brand", cached: true, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
+        { key: "categories", value: "Technology", cached: true, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
+      ]);
+
+      // Brand basic info (name) for discovery
       vi.mocked(fetchBrand).mockResolvedValueOnce({
         id: "brand-1",
         name: "TestBrand",
         domain: "testbrand.com",
-        elevatorPitch: "A test brand",
+        elevatorPitch: null,
         bio: null,
         mission: null,
         location: null,
-        categories: "Technology",
+        categories: null,
       });
       vi.mocked(fetchCampaign).mockResolvedValueOnce({
         id: "campaign-1",
@@ -1061,16 +1069,23 @@ describe("buffer", () => {
           campaignId: "campaign-1",
         }]);
 
+      // extract-fields: trigger AI extraction (no cache)
+      vi.mocked(fetchExtractedFields).mockResolvedValueOnce(null);
+      vi.mocked(extractBrandFields).mockResolvedValueOnce([
+        { key: "elevator_pitch", value: "A test brand", cached: false, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
+        { key: "categories", value: "Technology", cached: false, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
+      ]);
+
       // Brand + campaign for discovery
       vi.mocked(fetchBrand).mockResolvedValueOnce({
         id: "brand-1",
         name: "TestBrand",
         domain: "testbrand.com",
-        elevatorPitch: "A test brand",
+        elevatorPitch: null,
         bio: null,
         mission: null,
         location: null,
-        categories: "Technology",
+        categories: null,
       });
       vi.mocked(fetchCampaign).mockResolvedValueOnce({
         id: "campaign-1",
@@ -1168,6 +1183,10 @@ describe("buffer", () => {
         .mockResolvedValueOnce([journalistRow]); // retry: claimed
 
       vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
+
+      // extract-fields also fails (brand has no URL or scraping failed)
+      vi.mocked(fetchExtractedFields).mockResolvedValueOnce(null);
+      vi.mocked(extractBrandFields).mockResolvedValueOnce(null);
 
       vi.mocked(fetchOutletsByCampaign)
         .mockResolvedValueOnce([])   // no outlets → triggers discovery
@@ -1271,6 +1290,10 @@ describe("buffer", () => {
 
       vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
       vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([]);
+
+      // extract-fields also fails
+      vi.mocked(fetchExtractedFields).mockResolvedValueOnce(null);
+      vi.mocked(extractBrandFields).mockResolvedValueOnce(null);
 
       // Brand-service returns minimal data
       vi.mocked(fetchBrand).mockResolvedValueOnce({

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -206,6 +206,47 @@ describe("service client headers", () => {
     });
   });
 
+  describe("brand-client extractBrandFields", () => {
+    it("sends correct headers and body for extractBrandFields", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ brandId: "brand-123", results: [] }));
+
+      const { extractBrandFields } = await import("../../src/lib/brand-client.js");
+      await extractBrandFields(
+        "brand-123",
+        [{ key: "elevator_pitch", description: "One-sentence pitch" }],
+        "org-1",
+        { userId: "user-1", runId: "run-1", campaignId: "camp-1", brandId: "brand-1", workflowName: "wf-1", featureSlug: "feat-1" },
+      );
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, opts] = fetchSpy.mock.calls[0];
+      expect(url).toContain("/brands/brand-123/extract-fields");
+      expect(opts.method).toBe("POST");
+      expect(opts.headers["x-org-id"]).toBe("org-1");
+      expect(opts.headers["x-user-id"]).toBe("user-1");
+      expect(opts.headers["x-run-id"]).toBe("run-1");
+      const body = JSON.parse(opts.body);
+      expect(body.fields).toHaveLength(1);
+      expect(body.fields[0].key).toBe("elevator_pitch");
+    });
+  });
+
+  describe("brand-client fetchExtractedFields", () => {
+    it("sends correct headers for fetchExtractedFields", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ brandId: "brand-123", fields: [] }));
+
+      const { fetchExtractedFields } = await import("../../src/lib/brand-client.js");
+      await fetchExtractedFields("brand-123", "org-1", { userId: "user-1", runId: "run-1" });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, opts] = fetchSpy.mock.calls[0];
+      expect(url).toContain("/brands/brand-123/extracted-fields");
+      expect(opts.headers["x-org-id"]).toBe("org-1");
+      expect(opts.headers["x-user-id"]).toBe("user-1");
+      expect(opts.headers["x-run-id"]).toBe("run-1");
+    });
+  });
+
   describe("apollo-client apolloMatch", () => {
     it("sends correct headers and body for apolloMatch", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ enrichmentId: "e1", person: { id: "p1", email: "j@test.com" }, cached: false }));


### PR DESCRIPTION
## Summary
- Adds `extractBrandFields()` and `fetchExtractedFields()` to brand-client — calls `POST /brands/:brandId/extract-fields` and `GET /brands/:brandId/extracted-fields`
- `fillBufferFromJournalists` now resolves brand context via `resolveBrandContext()` with this priority:
  1. Cached extracted fields (GET /extracted-fields — fast, no AI cost)
  2. AI extraction (POST /extract-fields — slow first time, cached 30 days)
  3. brandContext from DAG (PR #112)
  4. Legacy brand columns (fallback)
- No longer relies on `elevatorPitch`/`bio`/`categories` columns on the brands row, which are legacy and never populated for new brands

## Test plan
- [x] Existing discovery tests updated to use extract-fields mocks
- [x] brandContext fallback test still passes (extract-fields returns null → falls back to DAG context)
- [x] Graceful failure test: neither extract-fields nor brandContext provide data
- [x] Service-client header tests for new `extractBrandFields` and `fetchExtractedFields`
- [x] 110 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)