### PR TITLE
Make industry optional for outlet discovery

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -337,12 +337,13 @@ async function fillBufferFromJournalists(params: {
 
     const brandName = extracted.brandName ?? (ctx.brandName as string) ?? (ctx.companyName as string) ?? brand?.name ?? null;
     const brandDescription = extracted.brandDescription ?? (ctx.companyContext as string) ?? (ctx.brandDescription as string) ?? brand?.elevatorPitch ?? brand?.bio ?? null;
-    const industry = extracted.industry ?? (ctx.industry as string) ?? (ctx.categories as string) ?? brand?.categories ?? null;
+    const industry = extracted.industry ?? (ctx.industry as string) ?? (ctx.categories as string) ?? brand?.categories ?? undefined;
     const targetGeo = extracted.targetGeo ?? (ctx.targetGeo as string) ?? brand?.location ?? undefined;
     const targetAudience = (ctx.targetAudience as string) ?? campaign?.targetAudience ?? undefined;
 
-    if (!brandName || !brandDescription || !industry) {
-      console.warn(`[fillBufferFromJournalists] Cannot discover outlets — insufficient context (need brandName, brandDescription, industry). extracted=${JSON.stringify(extracted)}, brandContext=${JSON.stringify(ctx)}, brand=${JSON.stringify(brand ? { name: brand.name, elevatorPitch: brand.elevatorPitch, categories: brand.categories } : null)}`);
+    if (!brandName || !brandDescription) {
+      console.warn(`[fillBufferFromJournalists] Cannot discover outlets — insufficient context (need brandName, brandDescription). extracted=${JSON.stringify(extracted)}, brandContext=${JSON.stringify(ctx)}, brand=${JSON.stringify(brand ? { name: brand.name, elevatorPitch: brand.elevatorPitch, categories: brand.categories } : null)}`);
+
       return { filled: 0 };
     }
 
@@ -352,7 +353,7 @@ async function fillBufferFromJournalists(params: {
         brandId: params.brandId,
         brandName,
         brandDescription,
-        industry,
+        industry: industry ?? undefined,
         targetGeo,
         targetAudience,
         workflowName: params.workflowName,

--- a/src/lib/outlet-client.ts
+++ b/src/lib/outlet-client.ts
@@ -16,7 +16,7 @@ export async function discoverOutlets(params: {
   brandId: string;
   brandName: string;
   brandDescription: string;
-  industry: string;
+  industry?: string;
   targetGeo?: string;
   targetAudience?: string;
   workflowName?: string;

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -1285,6 +1285,121 @@ describe("buffer", () => {
       expect(result.lead?.email).toBe("ctx@outlet.com");
     });
 
+    it("discovers outlets when brandContext has companyContext but no industry", async () => {
+      const journalistRow = toClaimedRow({
+        id: "buf-j-noind",
+        namespace: "campaign-1",
+        campaignId: "campaign-1",
+        email: "noind@outlet.com",
+        externalId: "journalist:j-noind",
+        data: {
+          firstName: "Sam",
+          lastName: "NoIndustry",
+          organizationName: "NoIndustry Outlet",
+          sourceType: "journalist",
+        },
+        brandId: "brand-1",
+        orgId: "org-1",
+        userId: null,
+      });
+
+      pgSqlMock
+        .mockResolvedValueOnce([])              // buffer empty
+        .mockResolvedValueOnce([journalistRow]); // retry: claimed
+
+      vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
+
+      vi.mocked(fetchOutletsByCampaign)
+        .mockResolvedValueOnce([])   // no outlets → triggers discovery
+        .mockResolvedValueOnce([{
+          id: "outlet-noind",
+          outletName: "NoIndustry Outlet",
+          outletUrl: "https://noindustry-outlet.com",
+          outletDomain: "noindustry-outlet.com",
+          relevanceScore: 0.9,
+          outletStatus: "active",
+          campaignId: "campaign-1",
+        }]);
+
+      // Brand-service returns no categories
+      vi.mocked(fetchBrand).mockResolvedValueOnce({
+        id: "brand-1",
+        name: "Distribute",
+        domain: "distribute.so",
+        elevatorPitch: null,
+        bio: null,
+        mission: null,
+        location: null,
+        categories: null,
+      });
+      vi.mocked(fetchCampaign).mockResolvedValueOnce(null);
+
+      vi.mocked(discoverOutlets).mockResolvedValueOnce([{
+        id: "outlet-noind",
+        outletName: "NoIndustry Outlet",
+        outletUrl: "https://noindustry-outlet.com",
+        outletDomain: "noindustry-outlet.com",
+        relevanceScore: 0.9,
+        outletStatus: "active",
+        campaignId: "campaign-1",
+      }]);
+
+      vi.mocked(fetchJournalistsByOutlet).mockResolvedValueOnce([{
+        id: "j-noind",
+        journalistName: "Sam NoIndustry",
+        firstName: "Sam",
+        lastName: "NoIndustry",
+        entityType: "individual",
+        relevanceScore: 0.8,
+        whyRelevant: "Covers SaaS",
+        whyNotRelevant: "",
+        emails: [{ email: "noind@outlet.com", isValid: true, confidence: 0.95 }],
+      }]);
+
+      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
+
+      const returningMock = vi.fn().mockResolvedValue([{ id: "served-noind" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({
+        onConflictDoNothing: onConflictMock,
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
+
+      // brandContext with companyContext but NO industry
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
+        sourceType: "journalist",
+        brandContext: {
+          companyContext: "AI-powered marketing automation platform for SaaS founders",
+          targetOutlets: "Top-tier tech blogs, SaaS publications",
+        },
+      });
+
+      // Should proceed with discovery even without industry
+      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
+      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          brandName: "Distribute",
+          brandDescription: "AI-powered marketing automation platform for SaaS founders",
+        }),
+        expect.any(Object),
+      );
+      // industry should be undefined, not blocking discovery
+      const callArgs = vi.mocked(discoverOutlets).mock.calls[0][0];
+      expect(callArgs.industry).toBeUndefined();
+      expect(result.found).toBe(true);
+      expect(result.lead?.email).toBe("noind@outlet.com");
+    });
+
     it("fails gracefully when neither brandContext nor brand-service provide sufficient data", async () => {
       pgSqlMock.mockResolvedValue([]);
 


### PR DESCRIPTION
## Summary
- Removes `industry` as a hard requirement for journalist outlet discovery — only `brandName` and `brandDescription` are now required
- When `brandContext` from the DAG has `companyContext` but no explicit `industry`/`categories`, and brand-service also returns null categories, discovery was silently blocked
- The AI-powered outlets discovery endpoint can infer industry from the brand description, so this gate was unnecessarily strict

## Test plan
- [x] Added unit test: "discovers outlets when brandContext has companyContext but no industry"
- [x] Existing tests still pass (111/111)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)