### PR TITLE
Enrich Apollo search context with extract-fields + brandContext

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -27,6 +27,7 @@ async function fillBufferFromSearch(params: {
   campaignId: string;
   brandId: string;
   searchParams: ApolloSearchParams;
+  brandContext?: Record<string, unknown>;
   pushRunId?: string | null;
   userId?: string | null;
   workflowName?: string;
@@ -41,25 +42,44 @@ async function fillBufferFromSearch(params: {
     featureSlug: params.featureSlug,
   };
 
-  // Fetch campaign + brand details in parallel for rich LLM context
-  const [campaign, brand] = await Promise.all([
+  // Fetch campaign, brand, and extracted fields in parallel for rich LLM context
+  const [campaign, brand, extracted] = await Promise.all([
     fetchCampaign(params.campaignId, params.orgId, serviceContext),
     fetchBrand(params.brandId, params.orgId, serviceContext),
+    resolveBrandContext(params.brandId, params.orgId, serviceContext),
   ]);
 
-  // Build rich context string from campaign, brand, and raw searchParams
+  // Build rich context string from all sources: extract-fields, brandContext (DAG), campaign, brand
   const contextParts: string[] = [];
+  const ctx = params.brandContext ?? {};
 
   if (campaign?.targetAudience) contextParts.push(`Target audience: ${campaign.targetAudience}`);
   if (campaign?.targetOutcome) contextParts.push(`Expected outcome: ${campaign.targetOutcome}`);
   if (campaign?.valueForTarget) contextParts.push(`Value for the audience: ${campaign.valueForTarget}`);
 
-  if (brand?.name) contextParts.push(`Brand: ${brand.name}`);
-  if (brand?.elevatorPitch) contextParts.push(`Brand pitch: ${brand.elevatorPitch}`);
-  if (brand?.bio) contextParts.push(`Brand bio: ${brand.bio}`);
+  // Brand name: extract-fields → brandContext → legacy
+  const brandName = extracted.brandName ?? (ctx.brandName as string) ?? (ctx.companyName as string) ?? brand?.name;
+  if (brandName) contextParts.push(`Brand: ${brandName}`);
+
+  // Brand description: extract-fields → brandContext → legacy
+  const brandDescription = extracted.brandDescription ?? (ctx.companyContext as string) ?? (ctx.brandDescription as string) ?? brand?.elevatorPitch;
+  if (brandDescription) contextParts.push(`Brand pitch: ${brandDescription}`);
+
+  // Additional brand context from brandContext (DAG featureInputs)
+  if (ctx.prAngle) contextParts.push(`PR angle: ${ctx.prAngle}`);
+  if (ctx.targetOutlets) contextParts.push(`Target outlets: ${typeof ctx.targetOutlets === "string" ? ctx.targetOutlets : JSON.stringify(ctx.targetOutlets)}`);
+
+  // Bio/mission: legacy brand columns (if extract-fields didn't cover them)
+  if (brand?.bio && !brandDescription) contextParts.push(`Brand bio: ${brand.bio}`);
   if (brand?.mission) contextParts.push(`Brand mission: ${brand.mission}`);
-  if (brand?.categories) contextParts.push(`Brand categories: ${brand.categories}`);
-  if (brand?.location) contextParts.push(`Brand location: ${brand.location}`);
+
+  // Industry/categories: extract-fields → brandContext → legacy
+  const industry = extracted.industry ?? (ctx.industry as string) ?? (ctx.categories as string) ?? brand?.categories;
+  if (industry) contextParts.push(`Brand categories: ${industry}`);
+
+  // Location: extract-fields → brandContext → legacy
+  const location = extracted.targetGeo ?? (ctx.targetGeo as string) ?? brand?.location;
+  if (location) contextParts.push(`Brand location: ${location}`);
 
   // Include raw searchParams as additional context
   const rawSearch = typeof params.searchParams === "string"
@@ -587,6 +607,7 @@ export async function pullNext(params: {
           campaignId: params.campaignId,
           brandId: params.brandId,
           searchParams: params.searchParams,
+          brandContext: params.brandContext,
           pushRunId: params.runId,
           userId: params.userId,
           workflowName: params.workflowName,

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -347,6 +347,73 @@ describe("buffer", () => {
       expect(vi.mocked(apolloSearchParams)).toHaveBeenCalledOnce();
     });
 
+    it("passes brandContext and extracted fields as LLM context for Apollo search", async () => {
+      const newLeadRow = toClaimedRow({
+        id: "buf-ctx-search",
+        namespace: "campaign-1",
+        campaignId: "campaign-1",
+        email: "ctx-lead@example.com",
+        externalId: "apollo-ctx",
+        data: { firstName: "Ctx" },
+        brandId: "brand-1",
+        orgId: "org-1",
+        userId: null,
+      });
+
+      pgSqlMock
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([newLeadRow]);
+
+      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
+
+      // extract-fields returns cached brand description
+      vi.mocked(fetchExtractedFields).mockResolvedValueOnce([
+        { key: "elevator_pitch", value: "AI-powered PR platform", cached: true, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
+        { key: "categories", value: "Technology, PR", cached: true, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
+      ]);
+
+      vi.mocked(apolloSearchParams).mockResolvedValue({
+        searchParams: { personTitles: ["Head of PR"] }, totalResults: 50, attempts: 1,
+      });
+
+      vi.mocked(apolloSearchNext).mockResolvedValue({
+        people: [{ id: "apollo-ctx", email: "ctx-lead@example.com", firstName: "Ctx" }],
+        done: true,
+        totalEntries: 1,
+      });
+
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
+
+      const returningMock = vi.fn().mockResolvedValue([{ id: "served-ctx" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
+        searchParams: { description: "PR contacts" },
+        brandContext: {
+          companyContext: "AI-powered PR distribution",
+          prAngle: "Launch of new journalist outreach feature",
+          targetOutlets: ["TechCrunch", "The Verge"],
+        },
+      });
+
+      expect(result.found).toBe(true);
+
+      // Verify the LLM context includes extracted fields and brandContext
+      const contextArg = vi.mocked(apolloSearchParams).mock.calls[0][0].context;
+      expect(contextArg).toContain("AI-powered PR platform");       // from extract-fields
+      expect(contextArg).toContain("Technology, PR");                // from extract-fields
+      expect(contextArg).toContain("PR angle:");                     // from brandContext.prAngle
+      expect(contextArg).toContain("Target outlets:");               // from brandContext.targetOutlets
+    });
+
     it("merges enrichment cache data into buffer when filling from search", async () => {
       // Scenario: Apollo search returns sparse person data (no lastName).
       // Enrichment cache has full data (with lastName). fillBufferFromSearch should


### PR DESCRIPTION
## Summary
- `fillBufferFromSearch` now calls `resolveBrandContext()` (same as journalist path) to get AI-extracted brand data for the LLM context
- `brandContext` (DAG featureInputs) is now passed to both search and journalist paths
- Additional featureInputs fields (`prAngle`, `targetOutlets`) are included in the LLM context for better Apollo search param generation
- Resolution order for all brand data: extract-fields cache → AI extraction → brandContext (DAG) → legacy brand columns

## Test plan
- [x] New test: verifies extracted fields + brandContext appear in the apolloSearchParams LLM context
- [x] All existing search tests still pass (default mocks return null, graceful degradation)
- [x] 112 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)