### PR TITLE
Pass brandContext through to outlets-service

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -5,7 +5,7 @@ import { checkContacted, markServed } from "./dedup.js";
 import { resolveOrCreateLead, findLeadByApolloPersonId } from "./leads-registry.js";
 import { apolloSearchNext, apolloEnrich, apolloMatch, apolloSearchParams, type ApolloSearchParams } from "./apollo-client.js";
 import { fetchCampaign } from "./campaign-client.js";
-import { fetchBrand, fetchExtractedFields, extractBrandFields } from "./brand-client.js";
+import { fetchBrand } from "./brand-client.js";
 import { fetchOutletsByCampaign, discoverOutlets } from "./outlet-client.js";
 import { fetchJournalistsByOutlet } from "./journalist-client.js";
 
@@ -232,64 +232,6 @@ async function saveCursor(orgId: string, namespace: string, state: unknown): Pro
   }
 }
 
-const DISCOVERY_FIELDS = [
-  { key: "elevator_pitch", description: "A one-sentence pitch describing what the brand does" },
-  { key: "categories", description: "Comma-separated industry categories the brand operates in" },
-  { key: "target_geo", description: "Primary geographic market the brand targets" },
-];
-
-interface BrandContext {
-  brandName: string | null;
-  brandDescription: string | null;
-  industry: string | null;
-  targetGeo: string | null;
-}
-
-async function resolveBrandContext(
-  brandId: string,
-  orgId: string,
-  serviceContext: { userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string; featureSlug?: string },
-): Promise<BrandContext> {
-  const empty: BrandContext = { brandName: null, brandDescription: null, industry: null, targetGeo: null };
-
-  // 1. Check cached extracted fields first (fast, no AI cost)
-  const cached = await fetchExtractedFields(brandId, orgId, serviceContext);
-  if (cached && cached.length > 0) {
-    const fieldMap = new Map(cached.map(f => [f.key, f.value]));
-    const pitch = fieldMap.get("elevator_pitch");
-    const cats = fieldMap.get("categories");
-    const geo = fieldMap.get("target_geo");
-
-    // If we have the key fields cached, return them directly
-    if (pitch && cats) {
-      console.log(`[resolveBrandContext] Using cached extracted fields for brand=${brandId}`);
-      return {
-        brandName: null, // will be filled from brand.name by caller
-        brandDescription: typeof pitch === "string" ? pitch : JSON.stringify(pitch),
-        industry: typeof cats === "string" ? cats : Array.isArray(cats) ? cats.join(", ") : JSON.stringify(cats),
-        targetGeo: geo ? (typeof geo === "string" ? geo : JSON.stringify(geo)) : null,
-      };
-    }
-  }
-
-  // 2. Extract fields via AI (slow, but results get cached for 30 days)
-  console.log(`[resolveBrandContext] Extracting fields via AI for brand=${brandId}`);
-  const results = await extractBrandFields(brandId, DISCOVERY_FIELDS, orgId, serviceContext);
-  if (!results) return empty;
-
-  const fieldMap = new Map(results.map(f => [f.key, f.value]));
-  const pitch = fieldMap.get("elevator_pitch");
-  const cats = fieldMap.get("categories");
-  const geo = fieldMap.get("target_geo");
-
-  return {
-    brandName: null,
-    brandDescription: pitch ? (typeof pitch === "string" ? pitch : JSON.stringify(pitch)) : null,
-    industry: cats ? (typeof cats === "string" ? cats : Array.isArray(cats) ? cats.join(", ") : JSON.stringify(cats)) : null,
-    targetGeo: geo ? (typeof geo === "string" ? geo : JSON.stringify(geo)) : null,
-  };
-}
-
 async function fillBufferFromJournalists(params: {
   orgId: string;
   campaignId: string;
@@ -326,36 +268,11 @@ async function fillBufferFromJournalists(params: {
     // No outlets yet — discover them via outlets-service
     console.log(`[fillBufferFromJournalists] No outlets for campaign=${params.campaignId}, discovering...`);
 
-    const [campaign, brand] = await Promise.all([
-      fetchCampaign(params.campaignId, params.orgId, serviceContext),
-      fetchBrand(params.brandId, params.orgId, serviceContext),
-    ]);
-
-    // Resolve brand context: extract-fields (primary) → brandContext (DAG) → legacy brand columns (fallback)
-    const extracted = await resolveBrandContext(params.brandId, params.orgId, serviceContext);
-    const ctx = params.brandContext ?? {};
-
-    const brandName = extracted.brandName ?? (ctx.brandName as string) ?? (ctx.companyName as string) ?? brand?.name ?? null;
-    const brandDescription = extracted.brandDescription ?? (ctx.companyContext as string) ?? (ctx.brandDescription as string) ?? brand?.elevatorPitch ?? brand?.bio ?? null;
-    const industry = extracted.industry ?? (ctx.industry as string) ?? (ctx.categories as string) ?? brand?.categories ?? undefined;
-    const targetGeo = extracted.targetGeo ?? (ctx.targetGeo as string) ?? brand?.location ?? undefined;
-    const targetAudience = (ctx.targetAudience as string) ?? campaign?.targetAudience ?? undefined;
-
-    if (!brandName || !brandDescription) {
-      console.warn(`[fillBufferFromJournalists] Cannot discover outlets — insufficient context (need brandName, brandDescription). extracted=${JSON.stringify(extracted)}, brandContext=${JSON.stringify(ctx)}, brand=${JSON.stringify(brand ? { name: brand.name, elevatorPitch: brand.elevatorPitch, categories: brand.categories } : null)}`);
-
-      return { filled: 0 };
-    }
-
     const discovered = await discoverOutlets(
       {
         campaignId: params.campaignId,
         brandId: params.brandId,
-        brandName,
-        brandDescription,
-        industry: industry ?? undefined,
-        targetGeo,
-        targetAudience,
+        brandContext: params.brandContext,
         workflowName: params.workflowName,
       },
       {

--- a/src/lib/outlet-client.ts
+++ b/src/lib/outlet-client.ts
@@ -14,11 +14,7 @@ export interface OutletDetails {
 export async function discoverOutlets(params: {
   campaignId: string;
   brandId: string;
-  brandName: string;
-  brandDescription: string;
-  industry?: string;
-  targetGeo?: string;
-  targetAudience?: string;
+  brandContext?: Record<string, unknown>;
   workflowName?: string;
 }, context?: {
   orgId?: string | null;
@@ -45,11 +41,7 @@ export async function discoverOutlets(params: {
       body: JSON.stringify({
         campaignId: params.campaignId,
         brandId: params.brandId,
-        brandName: params.brandName,
-        brandDescription: params.brandDescription,
-        industry: params.industry,
-        targetGeo: params.targetGeo,
-        targetAudience: params.targetAudience,
+        brandContext: params.brandContext,
         workflowName: params.workflowName,
       }),
     });

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -52,8 +52,6 @@ vi.mock("../../src/lib/campaign-client.js", () => ({
 // Mock brand-client
 vi.mock("../../src/lib/brand-client.js", () => ({
   fetchBrand: vi.fn().mockResolvedValue(null),
-  fetchExtractedFields: vi.fn().mockResolvedValue(null),
-  extractBrandFields: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock email-gateway-client
@@ -76,7 +74,7 @@ import { checkDeliveryStatus } from "../../src/lib/email-gateway-client.js";
 import { resolveOrCreateLead } from "../../src/lib/leads-registry.js";
 import { fetchOutletsByCampaign, discoverOutlets } from "../../src/lib/outlet-client.js";
 import { fetchCampaign } from "../../src/lib/campaign-client.js";
-import { fetchBrand, fetchExtractedFields, extractBrandFields } from "../../src/lib/brand-client.js";
+import { fetchBrand } from "../../src/lib/brand-client.js";
 import { fetchJournalistsByOutlet } from "../../src/lib/journalist-client.js";
 
 /** Helper: convert camelCase buffer row to snake_case raw SQL row (as returned by pgSql) */
@@ -986,35 +984,8 @@ describe("buffer", () => {
     it("returns found: false when no outlets exist and discovery finds none", async () => {
       pgSqlMock.mockResolvedValue([]);
 
-      // Cursor: no existing cursor
       vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
-
       vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([]);
-
-      // extract-fields returns cached data
-      vi.mocked(fetchExtractedFields).mockResolvedValueOnce([
-        { key: "elevator_pitch", value: "A test brand", cached: true, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
-        { key: "categories", value: "Technology", cached: true, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
-      ]);
-
-      // Brand basic info (name) for discovery
-      vi.mocked(fetchBrand).mockResolvedValueOnce({
-        id: "brand-1",
-        name: "TestBrand",
-        domain: "testbrand.com",
-        elevatorPitch: null,
-        bio: null,
-        mission: null,
-        location: null,
-        categories: null,
-      });
-      vi.mocked(fetchCampaign).mockResolvedValueOnce({
-        id: "campaign-1",
-        name: "Test Campaign",
-        targetAudience: "Tech journalists",
-        targetOutcome: null,
-        valueForTarget: null,
-      });
 
       // Discovery returns empty
       vi.mocked(discoverOutlets).mockResolvedValueOnce([]);
@@ -1024,13 +995,23 @@ describe("buffer", () => {
         campaignId: "campaign-1",
         brandId: "brand-1",
         sourceType: "journalist",
+        brandContext: { companyContext: "A test brand" },
       });
 
       expect(result.found).toBe(false);
       expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
+      // brandContext is passed through as-is
+      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          campaignId: "campaign-1",
+          brandId: "brand-1",
+          brandContext: { companyContext: "A test brand" },
+        }),
+        expect.any(Object),
+      );
     });
 
-    it("discovers outlets and fills buffer when no outlets exist initially", async () => {
+    it("discovers outlets and fills buffer — passes brandContext through as-is", async () => {
       const journalistRow = toClaimedRow({
         id: "buf-j-discover",
         namespace: "campaign-1",
@@ -1052,11 +1033,8 @@ describe("buffer", () => {
         .mockResolvedValueOnce([])              // pullNext: buffer empty
         .mockResolvedValueOnce([journalistRow]); // pullNext retry: claimed journalist lead
 
-      // Cursor: no existing cursor
       vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
 
-      // First fetch: no outlets → triggers discovery
-      // Second fetch (after discovery): outlets found
       vi.mocked(fetchOutletsByCampaign)
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([{
@@ -1069,33 +1047,6 @@ describe("buffer", () => {
           campaignId: "campaign-1",
         }]);
 
-      // extract-fields: trigger AI extraction (no cache)
-      vi.mocked(fetchExtractedFields).mockResolvedValueOnce(null);
-      vi.mocked(extractBrandFields).mockResolvedValueOnce([
-        { key: "elevator_pitch", value: "A test brand", cached: false, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
-        { key: "categories", value: "Technology", cached: false, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
-      ]);
-
-      // Brand + campaign for discovery
-      vi.mocked(fetchBrand).mockResolvedValueOnce({
-        id: "brand-1",
-        name: "TestBrand",
-        domain: "testbrand.com",
-        elevatorPitch: null,
-        bio: null,
-        mission: null,
-        location: null,
-        categories: null,
-      });
-      vi.mocked(fetchCampaign).mockResolvedValueOnce({
-        id: "campaign-1",
-        name: "Test Campaign",
-        targetAudience: "Tech journalists",
-        targetOutcome: null,
-        valueForTarget: null,
-      });
-
-      // Discovery succeeds
       vi.mocked(discoverOutlets).mockResolvedValueOnce([{
         id: "outlet-discovered",
         outletName: "Discovered Outlet",
@@ -1106,7 +1057,6 @@ describe("buffer", () => {
         campaignId: "campaign-1",
       }]);
 
-      // Journalist service returns journalist with email
       vi.mocked(fetchJournalistsByOutlet).mockResolvedValueOnce([{
         id: "j-discovered",
         journalistName: "Jane Reporter",
@@ -1119,10 +1069,8 @@ describe("buffer", () => {
         emails: [{ email: "discovered@outlet.com", isValid: true, confidence: 0.95 }],
       }]);
 
-      // isInBuffer → not in buffer
       vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
 
-      // db.insert for buffer + served_leads
       const returningMock = vi.fn().mockResolvedValue([{ id: "served-1" }]);
       const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
       const valuesMock = vi.fn().mockReturnValue({
@@ -1130,7 +1078,6 @@ describe("buffer", () => {
       });
       vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
 
-      // db.update for cursor + buffer status
       const setMock = vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue(undefined),
       });
@@ -1138,21 +1085,27 @@ describe("buffer", () => {
 
       vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
 
+      const brandContext = {
+        companyContext: "AI-powered PR distribution platform",
+        prAngle: "Launch of the Stripe for Distribution",
+        targetOutlets: "Top-tier tech blogs, SaaS publications",
+      };
+
       const result = await pullNext({
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
         sourceType: "journalist",
+        brandContext,
       });
 
+      // brandContext is forwarded as-is — no field extraction or validation by lead-service
       expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
       expect(vi.mocked(discoverOutlets)).toHaveBeenCalledWith(
         expect.objectContaining({
           campaignId: "campaign-1",
           brandId: "brand-1",
-          brandName: "TestBrand",
-          brandDescription: "A test brand",
-          industry: "Technology",
+          brandContext,
         }),
         expect.any(Object),
       );
@@ -1160,270 +1113,15 @@ describe("buffer", () => {
       expect(result.lead?.email).toBe("discovered@outlet.com");
     });
 
-    it("uses brandContext for outlet discovery when brand-service returns incomplete data", async () => {
-      const journalistRow = toClaimedRow({
-        id: "buf-j-ctx",
-        namespace: "campaign-1",
-        campaignId: "campaign-1",
-        email: "ctx@outlet.com",
-        externalId: "journalist:j-ctx",
-        data: {
-          firstName: "Alice",
-          lastName: "Ctx",
-          organizationName: "Context Outlet",
-          sourceType: "journalist",
-        },
-        brandId: "brand-1",
-        orgId: "org-1",
-        userId: null,
-      });
-
-      pgSqlMock
-        .mockResolvedValueOnce([])              // buffer empty
-        .mockResolvedValueOnce([journalistRow]); // retry: claimed
-
-      vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
-
-      // extract-fields also fails (brand has no URL or scraping failed)
-      vi.mocked(fetchExtractedFields).mockResolvedValueOnce(null);
-      vi.mocked(extractBrandFields).mockResolvedValueOnce(null);
-
-      vi.mocked(fetchOutletsByCampaign)
-        .mockResolvedValueOnce([])   // no outlets → triggers discovery
-        .mockResolvedValueOnce([{
-          id: "outlet-ctx",
-          outletName: "Context Outlet",
-          outletUrl: "https://context-outlet.com",
-          outletDomain: "context-outlet.com",
-          relevanceScore: 0.9,
-          outletStatus: "active",
-          campaignId: "campaign-1",
-        }]);
-
-      // Brand-service returns incomplete data (no elevatorPitch, no categories)
-      vi.mocked(fetchBrand).mockResolvedValueOnce({
-        id: "brand-1",
-        name: "Distribute",
-        domain: "distribute.so",
-        elevatorPitch: null,
-        bio: null,
-        mission: null,
-        location: null,
-        categories: null,
-      });
-      vi.mocked(fetchCampaign).mockResolvedValueOnce({
-        id: "campaign-1",
-        name: "Test Campaign",
-        targetAudience: null,
-        targetOutcome: null,
-        valueForTarget: null,
-      });
-
-      vi.mocked(discoverOutlets).mockResolvedValueOnce([{
-        id: "outlet-ctx",
-        outletName: "Context Outlet",
-        outletUrl: "https://context-outlet.com",
-        outletDomain: "context-outlet.com",
-        relevanceScore: 0.9,
-        outletStatus: "active",
-        campaignId: "campaign-1",
-      }]);
-
-      vi.mocked(fetchJournalistsByOutlet).mockResolvedValueOnce([{
-        id: "j-ctx",
-        journalistName: "Alice Ctx",
-        firstName: "Alice",
-        lastName: "Ctx",
-        entityType: "individual",
-        relevanceScore: 0.8,
-        whyRelevant: "Covers AI",
-        whyNotRelevant: "",
-        emails: [{ email: "ctx@outlet.com", isValid: true, confidence: 0.95 }],
-      }]);
-
-      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
-
-      const returningMock = vi.fn().mockResolvedValue([{ id: "served-ctx" }]);
-      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
-      const valuesMock = vi.fn().mockReturnValue({
-        onConflictDoNothing: onConflictMock,
-      });
-      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
-
-      const setMock = vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(undefined),
-      });
-      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
-
-      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
-
-      // brandContext provides the missing data
-      const result = await pullNext({
-        orgId: "org-1",
-        campaignId: "campaign-1",
-        brandId: "brand-1",
-        sourceType: "journalist",
-        brandContext: {
-          companyContext: "AI-powered PR distribution platform",
-          industry: "Technology",
-          targetGeo: "US",
-        },
-      });
-
-      // Should use brandContext fields for discovery (not fail due to missing brand-service data)
-      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
-      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          brandName: "Distribute",                              // from brand-service (name was available)
-          brandDescription: "AI-powered PR distribution platform", // from brandContext.companyContext
-          industry: "Technology",                                // from brandContext.industry
-          targetGeo: "US",                                       // from brandContext.targetGeo
-        }),
-        expect.any(Object),
-      );
-      expect(result.found).toBe(true);
-      expect(result.lead?.email).toBe("ctx@outlet.com");
-    });
-
-    it("discovers outlets when brandContext has companyContext but no industry", async () => {
-      const journalistRow = toClaimedRow({
-        id: "buf-j-noind",
-        namespace: "campaign-1",
-        campaignId: "campaign-1",
-        email: "noind@outlet.com",
-        externalId: "journalist:j-noind",
-        data: {
-          firstName: "Sam",
-          lastName: "NoIndustry",
-          organizationName: "NoIndustry Outlet",
-          sourceType: "journalist",
-        },
-        brandId: "brand-1",
-        orgId: "org-1",
-        userId: null,
-      });
-
-      pgSqlMock
-        .mockResolvedValueOnce([])              // buffer empty
-        .mockResolvedValueOnce([journalistRow]); // retry: claimed
-
-      vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
-
-      vi.mocked(fetchOutletsByCampaign)
-        .mockResolvedValueOnce([])   // no outlets → triggers discovery
-        .mockResolvedValueOnce([{
-          id: "outlet-noind",
-          outletName: "NoIndustry Outlet",
-          outletUrl: "https://noindustry-outlet.com",
-          outletDomain: "noindustry-outlet.com",
-          relevanceScore: 0.9,
-          outletStatus: "active",
-          campaignId: "campaign-1",
-        }]);
-
-      // Brand-service returns no categories
-      vi.mocked(fetchBrand).mockResolvedValueOnce({
-        id: "brand-1",
-        name: "Distribute",
-        domain: "distribute.so",
-        elevatorPitch: null,
-        bio: null,
-        mission: null,
-        location: null,
-        categories: null,
-      });
-      vi.mocked(fetchCampaign).mockResolvedValueOnce(null);
-
-      vi.mocked(discoverOutlets).mockResolvedValueOnce([{
-        id: "outlet-noind",
-        outletName: "NoIndustry Outlet",
-        outletUrl: "https://noindustry-outlet.com",
-        outletDomain: "noindustry-outlet.com",
-        relevanceScore: 0.9,
-        outletStatus: "active",
-        campaignId: "campaign-1",
-      }]);
-
-      vi.mocked(fetchJournalistsByOutlet).mockResolvedValueOnce([{
-        id: "j-noind",
-        journalistName: "Sam NoIndustry",
-        firstName: "Sam",
-        lastName: "NoIndustry",
-        entityType: "individual",
-        relevanceScore: 0.8,
-        whyRelevant: "Covers SaaS",
-        whyNotRelevant: "",
-        emails: [{ email: "noind@outlet.com", isValid: true, confidence: 0.95 }],
-      }]);
-
-      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
-
-      const returningMock = vi.fn().mockResolvedValue([{ id: "served-noind" }]);
-      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
-      const valuesMock = vi.fn().mockReturnValue({
-        onConflictDoNothing: onConflictMock,
-      });
-      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
-
-      const setMock = vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(undefined),
-      });
-      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
-
-      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
-
-      // brandContext with companyContext but NO industry
-      const result = await pullNext({
-        orgId: "org-1",
-        campaignId: "campaign-1",
-        brandId: "brand-1",
-        sourceType: "journalist",
-        brandContext: {
-          companyContext: "AI-powered marketing automation platform for SaaS founders",
-          targetOutlets: "Top-tier tech blogs, SaaS publications",
-        },
-      });
-
-      // Should proceed with discovery even without industry
-      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
-      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          brandName: "Distribute",
-          brandDescription: "AI-powered marketing automation platform for SaaS founders",
-        }),
-        expect.any(Object),
-      );
-      // industry should be undefined, not blocking discovery
-      const callArgs = vi.mocked(discoverOutlets).mock.calls[0][0];
-      expect(callArgs.industry).toBeUndefined();
-      expect(result.found).toBe(true);
-      expect(result.lead?.email).toBe("noind@outlet.com");
-    });
-
-    it("fails gracefully when neither brandContext nor brand-service provide sufficient data", async () => {
+    it("calls discoverOutlets even without brandContext", async () => {
       pgSqlMock.mockResolvedValue([]);
 
       vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
       vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([]);
 
-      // extract-fields also fails
-      vi.mocked(fetchExtractedFields).mockResolvedValueOnce(null);
-      vi.mocked(extractBrandFields).mockResolvedValueOnce(null);
+      // Discovery returns empty — but it should still be called
+      vi.mocked(discoverOutlets).mockResolvedValueOnce([]);
 
-      // Brand-service returns minimal data
-      vi.mocked(fetchBrand).mockResolvedValueOnce({
-        id: "brand-1",
-        name: "Distribute",
-        domain: "distribute.so",
-        elevatorPitch: null,
-        bio: null,
-        mission: null,
-        location: null,
-        categories: null,
-      });
-      vi.mocked(fetchCampaign).mockResolvedValueOnce(null);
-
-      // No brandContext provided either
       const result = await pullNext({
         orgId: "org-1",
         campaignId: "campaign-1",
@@ -1432,7 +1130,15 @@ describe("buffer", () => {
       });
 
       expect(result.found).toBe(false);
-      expect(vi.mocked(discoverOutlets)).not.toHaveBeenCalled();
+      // discoverOutlets is always called — outlets-service decides what to do
+      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
+      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          campaignId: "campaign-1",
+          brandId: "brand-1",
+        }),
+        expect.any(Object),
+      );
     });
 
     it("uses apolloMatch proactively when resolve returns journalists without emails", async () => {


### PR DESCRIPTION
## Summary
- **-418 lines, +33 lines** — lead-service stops playing middleman for brand field resolution
- Removes `resolveBrandContext`, `DISCOVERY_FIELDS`, `BrandContext` interface, and all `fetchExtractedFields`/`extractBrandFields` usage from buffer.ts
- `discoverOutlets` now takes `brandContext: Record<string, unknown>` and forwards it verbatim to outlets-service
- Outlets-service has its own LLM and can call brand-service directly if it needs more context — each service is autonomous

## Why
Every time the DAG schema changed (new fields, missing fields like `industry`), lead-service broke because it was trying to map arbitrary DAG fields to a fixed schema. This coupling was unnecessary — outlets-service is the one that needs the context, so let it decide what to do with it.

## Test plan
- [x] 109 unit tests pass
- [x] Build passes
- [x] Verified `discoverOutlets` receives `brandContext` as-is
- [x] Verified discovery is called even without `brandContext`

🤖 Generated with [Claude Code](https://claude.com/claude-code)