### PR TITLE
Rename brandContext to featureInput

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -460,7 +460,7 @@
               "nullable": true
             }
           },
-          "brandContext": {
+          "featureInput": {
             "type": "object",
             "nullable": true,
             "additionalProperties": {

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -27,7 +27,7 @@ async function fillBufferFromSearch(params: {
   campaignId: string;
   brandId: string;
   searchParams: ApolloSearchParams;
-  brandContext?: Record<string, unknown>;
+  featureInput?: Record<string, unknown>;
   pushRunId?: string | null;
   userId?: string | null;
   workflowName?: string;
@@ -42,44 +42,29 @@ async function fillBufferFromSearch(params: {
     featureSlug: params.featureSlug,
   };
 
-  // Fetch campaign, brand, and extracted fields in parallel for rich LLM context
-  const [campaign, brand, extracted] = await Promise.all([
+  // Fetch campaign + brand in parallel for rich LLM context
+  const [campaign, brand] = await Promise.all([
     fetchCampaign(params.campaignId, params.orgId, serviceContext),
     fetchBrand(params.brandId, params.orgId, serviceContext),
-    resolveBrandContext(params.brandId, params.orgId, serviceContext),
   ]);
 
-  // Build rich context string from all sources: extract-fields, brandContext (DAG), campaign, brand
+  // Build rich context string from featureInput (DAG), campaign, and brand
   const contextParts: string[] = [];
-  const ctx = params.brandContext ?? {};
+  const ctx = params.featureInput ?? {};
 
   if (campaign?.targetAudience) contextParts.push(`Target audience: ${campaign.targetAudience}`);
   if (campaign?.targetOutcome) contextParts.push(`Expected outcome: ${campaign.targetOutcome}`);
   if (campaign?.valueForTarget) contextParts.push(`Value for the audience: ${campaign.valueForTarget}`);
 
-  // Brand name: extract-fields → brandContext → legacy
-  const brandName = extracted.brandName ?? (ctx.brandName as string) ?? (ctx.companyName as string) ?? brand?.name;
-  if (brandName) contextParts.push(`Brand: ${brandName}`);
-
-  // Brand description: extract-fields → brandContext → legacy
-  const brandDescription = extracted.brandDescription ?? (ctx.companyContext as string) ?? (ctx.brandDescription as string) ?? brand?.elevatorPitch;
-  if (brandDescription) contextParts.push(`Brand pitch: ${brandDescription}`);
-
-  // Additional brand context from brandContext (DAG featureInputs)
-  if (ctx.prAngle) contextParts.push(`PR angle: ${ctx.prAngle}`);
-  if (ctx.targetOutlets) contextParts.push(`Target outlets: ${typeof ctx.targetOutlets === "string" ? ctx.targetOutlets : JSON.stringify(ctx.targetOutlets)}`);
-
-  // Bio/mission: legacy brand columns (if extract-fields didn't cover them)
-  if (brand?.bio && !brandDescription) contextParts.push(`Brand bio: ${brand.bio}`);
+  if (brand?.name) contextParts.push(`Brand: ${brand.name}`);
+  if (brand?.elevatorPitch) contextParts.push(`Brand pitch: ${brand.elevatorPitch}`);
+  if (brand?.bio) contextParts.push(`Brand bio: ${brand.bio}`);
   if (brand?.mission) contextParts.push(`Brand mission: ${brand.mission}`);
+  if (brand?.categories) contextParts.push(`Brand categories: ${brand.categories}`);
+  if (brand?.location) contextParts.push(`Brand location: ${brand.location}`);
 
-  // Industry/categories: extract-fields → brandContext → legacy
-  const industry = extracted.industry ?? (ctx.industry as string) ?? (ctx.categories as string) ?? brand?.categories;
-  if (industry) contextParts.push(`Brand categories: ${industry}`);
-
-  // Location: extract-fields → brandContext → legacy
-  const location = extracted.targetGeo ?? (ctx.targetGeo as string) ?? brand?.location;
-  if (location) contextParts.push(`Brand location: ${location}`);
+  // featureInput from DAG — dump all fields as additional context
+  if (Object.keys(ctx).length > 0) contextParts.push(`Feature input: ${JSON.stringify(ctx)}`);
 
   // Include raw searchParams as additional context
   const rawSearch = typeof params.searchParams === "string"
@@ -256,7 +241,7 @@ async function fillBufferFromJournalists(params: {
   orgId: string;
   campaignId: string;
   brandId: string;
-  brandContext?: Record<string, unknown>;
+  featureInput?: Record<string, unknown>;
   pushRunId?: string | null;
   userId?: string | null;
   workflowName?: string;
@@ -292,7 +277,7 @@ async function fillBufferFromJournalists(params: {
       {
         campaignId: params.campaignId,
         brandId: params.brandId,
-        brandContext: params.brandContext,
+        featureInput: params.featureInput,
         workflowName: params.workflowName,
       },
       {
@@ -443,7 +428,7 @@ export async function pullNext(params: {
   brandId: string;
   runId?: string | null;
   searchParams?: ApolloSearchParams;
-  brandContext?: Record<string, unknown>;
+  featureInput?: Record<string, unknown>;
   userId?: string | null;
   workflowName?: string;
   featureSlug?: string;
@@ -511,7 +496,7 @@ export async function pullNext(params: {
           orgId: params.orgId,
           campaignId: params.campaignId,
           brandId: params.brandId,
-          brandContext: params.brandContext,
+          featureInput: params.featureInput,
           pushRunId: params.runId,
           userId: params.userId,
           workflowName: params.workflowName,
@@ -524,7 +509,7 @@ export async function pullNext(params: {
           campaignId: params.campaignId,
           brandId: params.brandId,
           searchParams: params.searchParams,
-          brandContext: params.brandContext,
+          featureInput: params.featureInput,
           pushRunId: params.runId,
           userId: params.userId,
           workflowName: params.workflowName,

--- a/src/lib/outlet-client.ts
+++ b/src/lib/outlet-client.ts
@@ -14,7 +14,7 @@ export interface OutletDetails {
 export async function discoverOutlets(params: {
   campaignId: string;
   brandId: string;
-  brandContext?: Record<string, unknown>;
+  featureInput?: Record<string, unknown>;
   workflowName?: string;
 }, context?: {
   orgId?: string | null;
@@ -41,7 +41,7 @@ export async function discoverOutlets(params: {
       body: JSON.stringify({
         campaignId: params.campaignId,
         brandId: params.brandId,
-        brandContext: params.brandContext,
+        featureInput: params.featureInput,
         workflowName: params.workflowName,
       }),
     });

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -32,7 +32,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
   }
 
   try {
-    const { campaignId, brandId, searchParams, brandContext, userId, idempotencyKey, sourceType } = parsed.data;
+    const { campaignId, brandId, searchParams, featureInput, userId, idempotencyKey, sourceType } = parsed.data;
 
     // Body workflowName takes precedence; fall back to header injected by workflow-service
     const workflowName = parsed.data.workflowName ?? req.workflowName;
@@ -68,7 +68,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       brandId,
       runId: serveRunId,
       searchParams: searchParams ?? undefined,
-      brandContext: brandContext ?? undefined,
+      featureInput: featureInput ?? undefined,
       userId: userId ?? req.userId ?? null,
       workflowName,
       featureSlug: req.featureSlug,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -189,7 +189,7 @@ export const BufferNextRequestSchema = z
     brandId: z.string().min(1),
     sourceType: z.enum(["apollo", "journalist"]).default("apollo").optional(),
     searchParams: z.record(z.string(), z.unknown()).nullish(),
-    brandContext: z.record(z.string(), z.unknown()).nullish(),
+    featureInput: z.record(z.string(), z.unknown()).nullish(),
     userId: z.string().optional(),
     workflowName: z.string().optional(),
     idempotencyKey: z.string().min(1).optional(),

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -345,7 +345,7 @@ describe("buffer", () => {
       expect(vi.mocked(apolloSearchParams)).toHaveBeenCalledOnce();
     });
 
-    it("passes brandContext and extracted fields as LLM context for Apollo search", async () => {
+    it("passes featureInput as LLM context for Apollo search", async () => {
       const newLeadRow = toClaimedRow({
         id: "buf-ctx-search",
         namespace: "campaign-1",
@@ -363,12 +363,6 @@ describe("buffer", () => {
         .mockResolvedValueOnce([newLeadRow]);
 
       vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
-
-      // extract-fields returns cached brand description
-      vi.mocked(fetchExtractedFields).mockResolvedValueOnce([
-        { key: "elevator_pitch", value: "AI-powered PR platform", cached: true, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
-        { key: "categories", value: "Technology, PR", cached: true, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
-      ]);
 
       vi.mocked(apolloSearchParams).mockResolvedValue({
         searchParams: { personTitles: ["Head of PR"] }, totalResults: 50, attempts: 1,
@@ -395,7 +389,7 @@ describe("buffer", () => {
         campaignId: "campaign-1",
         brandId: "brand-1",
         searchParams: { description: "PR contacts" },
-        brandContext: {
+        featureInput: {
           companyContext: "AI-powered PR distribution",
           prAngle: "Launch of new journalist outreach feature",
           targetOutlets: ["TechCrunch", "The Verge"],
@@ -404,12 +398,11 @@ describe("buffer", () => {
 
       expect(result.found).toBe(true);
 
-      // Verify the LLM context includes extracted fields and brandContext
+      // Verify the LLM context includes featureInput as JSON
       const contextArg = vi.mocked(apolloSearchParams).mock.calls[0][0].context;
-      expect(contextArg).toContain("AI-powered PR platform");       // from extract-fields
-      expect(contextArg).toContain("Technology, PR");                // from extract-fields
-      expect(contextArg).toContain("PR angle:");                     // from brandContext.prAngle
-      expect(contextArg).toContain("Target outlets:");               // from brandContext.targetOutlets
+      expect(contextArg).toContain("AI-powered PR distribution");
+      expect(contextArg).toContain("Launch of new journalist outreach feature");
+      expect(contextArg).toContain("TechCrunch");
     });
 
     it("merges enrichment cache data into buffer when filling from search", async () => {
@@ -1062,23 +1055,23 @@ describe("buffer", () => {
         campaignId: "campaign-1",
         brandId: "brand-1",
         sourceType: "journalist",
-        brandContext: { companyContext: "A test brand" },
+        featureInput: { companyContext: "A test brand" },
       });
 
       expect(result.found).toBe(false);
       expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
-      // brandContext is passed through as-is
+      // featureInput is passed through as-is
       expect(vi.mocked(discoverOutlets)).toHaveBeenCalledWith(
         expect.objectContaining({
           campaignId: "campaign-1",
           brandId: "brand-1",
-          brandContext: { companyContext: "A test brand" },
+          featureInput: { companyContext: "A test brand" },
         }),
         expect.any(Object),
       );
     });
 
-    it("discovers outlets and fills buffer — passes brandContext through as-is", async () => {
+    it("discovers outlets and fills buffer — passes featureInput through as-is", async () => {
       const journalistRow = toClaimedRow({
         id: "buf-j-discover",
         namespace: "campaign-1",
@@ -1152,7 +1145,7 @@ describe("buffer", () => {
 
       vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
 
-      const brandContext = {
+      const featureInput = {
         companyContext: "AI-powered PR distribution platform",
         prAngle: "Launch of the Stripe for Distribution",
         targetOutlets: "Top-tier tech blogs, SaaS publications",
@@ -1163,16 +1156,16 @@ describe("buffer", () => {
         campaignId: "campaign-1",
         brandId: "brand-1",
         sourceType: "journalist",
-        brandContext,
+        featureInput,
       });
 
-      // brandContext is forwarded as-is — no field extraction or validation by lead-service
+      // featureInput is forwarded as-is — no field extraction or validation by lead-service
       expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
       expect(vi.mocked(discoverOutlets)).toHaveBeenCalledWith(
         expect.objectContaining({
           campaignId: "campaign-1",
           brandId: "brand-1",
-          brandContext,
+          featureInput,
         }),
         expect.any(Object),
       );
@@ -1180,7 +1173,7 @@ describe("buffer", () => {
       expect(result.lead?.email).toBe("discovered@outlet.com");
     });
 
-    it("calls discoverOutlets even without brandContext", async () => {
+    it("calls discoverOutlets even without featureInput", async () => {
       pgSqlMock.mockResolvedValue([]);
 
       vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -73,27 +73,27 @@ describe("schema validation", () => {
       }
     });
 
-    it("accepts optional brandContext", () => {
+    it("accepts optional featureInput", () => {
       const result = BufferNextRequestSchema.safeParse({
         campaignId: "c1",
         brandId: "b1",
-        brandContext: { companyContext: "AI startup", industry: "Technology" },
+        featureInput: { companyContext: "AI startup", industry: "Technology" },
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.brandContext).toEqual({ companyContext: "AI startup", industry: "Technology" });
+        expect(result.data.featureInput).toEqual({ companyContext: "AI startup", industry: "Technology" });
       }
     });
 
-    it("accepts null brandContext", () => {
+    it("accepts null featureInput", () => {
       const result = BufferNextRequestSchema.safeParse({
         campaignId: "c1",
         brandId: "b1",
-        brandContext: null,
+        featureInput: null,
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.brandContext).toBeNull();
+        expect(result.data.featureInput).toBeNull();
       }
     });
 


### PR DESCRIPTION
## Summary
- Renames `brandContext` → `featureInput` everywhere: schemas, routes, buffer logic, outlet-client, tests, openapi.json
- `featureInput` is a generic, opaque bag of DAG inputs passed through to downstream services — each service decides what to do with it
- Also fixes broken `resolveBrandContext` call left over in `fillBufferFromSearch` after PR #116 deleted the function

## Test plan
- [x] 110 unit tests pass
- [x] Build + openapi.json regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)