### PR TITLE
Use brand extract-fields and campaign featureInputs for LLM context

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -5,7 +5,7 @@ import { checkContacted, markServed } from "./dedup.js";
 import { resolveOrCreateLead, findLeadByApolloPersonId } from "./leads-registry.js";
 import { apolloSearchNext, apolloEnrich, apolloMatch, apolloSearchParams, type ApolloSearchParams } from "./apollo-client.js";
 import { fetchCampaign } from "./campaign-client.js";
-import { fetchBrand } from "./brand-client.js";
+import { extractBrandFields } from "./brand-client.js";
 import { fetchOutletsByCampaign, discoverOutlets } from "./outlet-client.js";
 import { fetchJournalistsByOutlet } from "./journalist-client.js";
 
@@ -42,29 +42,48 @@ async function fillBufferFromSearch(params: {
     featureSlug: params.featureSlug,
   };
 
-  // Fetch campaign + brand in parallel for rich LLM context
-  const [campaign, brand] = await Promise.all([
+  // Fetch campaign + brand fields in parallel for rich LLM context
+  const [campaign, brandFields] = await Promise.all([
     fetchCampaign(params.campaignId, params.orgId, serviceContext),
-    fetchBrand(params.brandId, params.orgId, serviceContext),
+    extractBrandFields(
+      params.brandId,
+      [
+        { key: "brand_name", description: "The brand's display name" },
+        { key: "elevator_pitch", description: "A short elevator pitch describing the brand" },
+        { key: "industry", description: "The brand's primary industry vertical" },
+        { key: "target_geography", description: "Priority geographic markets for outreach" },
+        { key: "ideal_lead_type", description: "Type of leads to target (journalists, editors, producers, executives...)" },
+        { key: "target_job_titles", description: "Job titles to prioritize in outreach" },
+        { key: "offerings", description: "Key products or services the brand offers" },
+      ],
+      params.orgId,
+      serviceContext,
+    ),
   ]);
 
-  // Build rich context string from featureInput (DAG), campaign, and brand
+  // Build rich context string from campaign, brand fields, and featureInputs
   const contextParts: string[] = [];
-  const ctx = params.featureInput ?? {};
 
   if (campaign?.targetAudience) contextParts.push(`Target audience: ${campaign.targetAudience}`);
   if (campaign?.targetOutcome) contextParts.push(`Expected outcome: ${campaign.targetOutcome}`);
   if (campaign?.valueForTarget) contextParts.push(`Value for the audience: ${campaign.valueForTarget}`);
 
-  if (brand?.name) contextParts.push(`Brand: ${brand.name}`);
-  if (brand?.elevatorPitch) contextParts.push(`Brand pitch: ${brand.elevatorPitch}`);
-  if (brand?.bio) contextParts.push(`Brand bio: ${brand.bio}`);
-  if (brand?.mission) contextParts.push(`Brand mission: ${brand.mission}`);
-  if (brand?.categories) contextParts.push(`Brand categories: ${brand.categories}`);
-  if (brand?.location) contextParts.push(`Brand location: ${brand.location}`);
+  // Inject campaign featureInputs (convention 2)
+  const featureInputs = campaign?.featureInputs ?? params.featureInput;
+  if (featureInputs && Object.keys(featureInputs).length > 0) {
+    contextParts.push(`Campaign context: ${JSON.stringify(featureInputs)}`);
+  }
 
-  // featureInput from DAG — dump all fields as additional context
-  if (Object.keys(ctx).length > 0) contextParts.push(`Feature input: ${JSON.stringify(ctx)}`);
+  // Inject brand fields from extract-fields (convention 1)
+  if (brandFields) {
+    for (const field of brandFields) {
+      if (field.value != null) {
+        const label = field.key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+        const value = typeof field.value === "string" ? field.value : JSON.stringify(field.value);
+        contextParts.push(`${label}: ${value}`);
+      }
+    }
+  }
 
   // Include raw searchParams as additional context
   const rawSearch = typeof params.searchParams === "string"

--- a/src/lib/campaign-client.ts
+++ b/src/lib/campaign-client.ts
@@ -7,6 +7,7 @@ export interface CampaignDetails {
   targetAudience: string | null;
   targetOutcome: string | null;
   valueForTarget: string | null;
+  featureInputs: Record<string, unknown> | null;
 }
 
 export async function fetchCampaign(

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -51,7 +51,7 @@ vi.mock("../../src/lib/campaign-client.js", () => ({
 
 // Mock brand-client
 vi.mock("../../src/lib/brand-client.js", () => ({
-  fetchBrand: vi.fn().mockResolvedValue(null),
+  extractBrandFields: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock email-gateway-client
@@ -74,7 +74,7 @@ import { checkDeliveryStatus } from "../../src/lib/email-gateway-client.js";
 import { resolveOrCreateLead } from "../../src/lib/leads-registry.js";
 import { fetchOutletsByCampaign, discoverOutlets } from "../../src/lib/outlet-client.js";
 import { fetchCampaign } from "../../src/lib/campaign-client.js";
-import { fetchBrand } from "../../src/lib/brand-client.js";
+import { extractBrandFields } from "../../src/lib/brand-client.js";
 import { fetchJournalistsByOutlet } from "../../src/lib/journalist-client.js";
 
 /** Helper: convert camelCase buffer row to snake_case raw SQL row (as returned by pgSql) */
@@ -403,6 +403,101 @@ describe("buffer", () => {
       expect(contextArg).toContain("AI-powered PR distribution");
       expect(contextArg).toContain("Launch of new journalist outreach feature");
       expect(contextArg).toContain("TechCrunch");
+    });
+
+    it("injects campaign featureInputs and brand extract-fields into LLM context", async () => {
+      const newLeadRow = toClaimedRow({
+        id: "buf-conv",
+        namespace: "campaign-1",
+        campaignId: "campaign-1",
+        email: "conv@example.com",
+        externalId: "apollo-conv",
+        data: { firstName: "Conv" },
+        brandId: "brand-1",
+        orgId: "org-1",
+        userId: null,
+      });
+
+      pgSqlMock
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([newLeadRow]);
+
+      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
+
+      // Campaign returns featureInputs
+      vi.mocked(fetchCampaign).mockResolvedValueOnce({
+        id: "campaign-1",
+        name: "Sustainability Launch",
+        targetAudience: "Tech journalists",
+        targetOutcome: "Press coverage",
+        valueForTarget: "Exclusive story",
+        featureInputs: {
+          editorialAngle: "sustainability in AI",
+          targetRegion: "North America",
+        },
+      });
+
+      // Brand extract-fields returns extracted values
+      vi.mocked(extractBrandFields).mockResolvedValueOnce([
+        { key: "brand_name", value: "GreenTech Co", cached: true, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
+        { key: "industry", value: "Clean Technology", cached: true, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
+        { key: "target_job_titles", value: ["Editor", "Reporter"], cached: false, extractedAt: "2026-01-01", expiresAt: null, sourceUrls: null },
+      ]);
+
+      vi.mocked(apolloSearchParams).mockResolvedValue({
+        searchParams: { personTitles: ["Editor"] }, totalResults: 50, attempts: 1,
+      });
+
+      vi.mocked(apolloSearchNext).mockResolvedValue({
+        people: [{ id: "apollo-conv", email: "conv@example.com", firstName: "Conv" }],
+        done: true,
+        totalEntries: 1,
+      });
+
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
+
+      const returningMock = vi.fn().mockResolvedValue([{ id: "served-conv" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandId: "brand-1",
+        searchParams: { description: "clean tech editors" },
+      });
+
+      expect(result.found).toBe(true);
+
+      // Verify campaign featureInputs injected
+      const contextArg = vi.mocked(apolloSearchParams).mock.calls[0][0].context;
+      expect(contextArg).toContain("sustainability in AI");
+      expect(contextArg).toContain("North America");
+      expect(contextArg).toContain("Campaign context:");
+
+      // Verify brand extract-fields injected
+      expect(contextArg).toContain("GreenTech Co");
+      expect(contextArg).toContain("Clean Technology");
+      expect(contextArg).toContain("Editor");
+
+      // Verify campaign fields still included
+      expect(contextArg).toContain("Tech journalists");
+      expect(contextArg).toContain("Press coverage");
+
+      // Verify extractBrandFields was called with the right field descriptors
+      expect(vi.mocked(extractBrandFields)).toHaveBeenCalledWith(
+        "brand-1",
+        expect.arrayContaining([
+          expect.objectContaining({ key: "industry" }),
+          expect.objectContaining({ key: "target_job_titles" }),
+        ]),
+        "org-1",
+        expect.any(Object),
+      );
     });
 
     it("merges enrichment cache data into buffer when filling from search", async () => {


### PR DESCRIPTION
## Summary
- Replaced `fetchBrand()` with `extractBrandFields()` in `fillBufferFromSearch` — brand data now comes from brand-service's extract-fields endpoint with specific field descriptors (industry, target_geography, ideal_lead_type, target_job_titles, offerings, etc.)
- Added `featureInputs` to `CampaignDetails` interface and inject campaign featureInputs from campaign-service into the LLM context for Apollo search param generation
- Falls back to request-body `featureInput` when campaign-service doesn't return featureInputs

## Test plan
- [x] New test: verifies campaign featureInputs and brand extract-fields are both injected into the LLM context string
- [x] Existing test: featureInput from request body still works as fallback
- [x] All 111 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)