### PR TITLE
Forward all service headers to downstream calls in stats route

### DIFF
--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -265,13 +265,17 @@ export interface ApolloStats {
 export async function fetchApolloStats(
   filters: { runIds?: string[]; brandId?: string; campaignId?: string },
   orgId?: string | null,
-  context?: { userId?: string; runId?: string }
+  context?: { userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string; featureSlug?: string }
 ): Promise<ApolloStats> {
   try {
     const headers: Record<string, string> = {};
     if (orgId) headers["x-org-id"] = orgId;
     if (context?.userId) headers["x-user-id"] = context.userId;
     if (context?.runId) headers["x-run-id"] = context.runId;
+    if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
+    if (context?.brandId) headers["x-brand-id"] = context.brandId;
+    if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
+    if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
 
     const result = await callApolloService<{ stats: ApolloStats }>("/stats", {
       method: "POST",

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,5 +1,15 @@
 import { Request, Response, NextFunction } from "express";
 
+export interface ServiceContext {
+  orgId?: string;
+  userId?: string;
+  runId?: string;
+  campaignId?: string;
+  brandId?: string;
+  workflowName?: string;
+  featureSlug?: string;
+}
+
 export interface AuthenticatedRequest extends Request {
   orgId?: string;
   userId?: string;
@@ -8,6 +18,18 @@ export interface AuthenticatedRequest extends Request {
   brandId?: string;
   workflowName?: string;
   featureSlug?: string;
+}
+
+export function getServiceContext(req: AuthenticatedRequest): ServiceContext {
+  return {
+    orgId: req.orgId,
+    userId: req.userId,
+    runId: req.runId,
+    campaignId: req.campaignId,
+    brandId: req.brandId,
+    workflowName: req.workflowName,
+    featureSlug: req.featureSlug,
+  };
 }
 
 export async function authenticate(

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { eq, and, count, inArray, or, sql, type SQL } from "drizzle-orm";
-import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
+import { type AuthenticatedRequest, type ServiceContext, authenticate, getServiceContext } from "../middleware/auth.js";
 import { db } from "../db/index.js";
 import { servedLeads, leadBuffer } from "../db/schema.js";
 import { fetchApolloStats } from "../lib/apollo-client.js";
@@ -69,7 +69,7 @@ function buildConditions(
  */
 async function countContacted(
   servedConds: SQL[],
-  context: { orgId?: string; userId?: string; runId?: string },
+  context: ServiceContext,
 ): Promise<number> {
   const rows = await db
     .select({
@@ -124,7 +124,7 @@ async function countContacted(
 async function countContactedGrouped(
   servedConds: SQL[],
   groupByField: GroupByField,
-  context: { orgId?: string; userId?: string; runId?: string },
+  context: ServiceContext,
 ): Promise<Map<string, number>> {
   const groupCol = COLUMN_MAP[groupByField].served;
 
@@ -203,7 +203,7 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
 
     const served = buildConditions(req, "served");
     const buffer = buildConditions(req, "buffer");
-    const egContext = { orgId: req.orgId, userId: req.userId, runId: req.runId };
+    const egContext = getServiceContext(req);
 
     // --- Grouped response ---
     if (groupByParam) {
@@ -280,7 +280,7 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
       fetchApolloStats(
         apolloFilters as Parameters<typeof fetchApolloStats>[0],
         served.orgIdStr ?? req.orgId,
-        { userId: req.userId, runId: req.runId },
+        egContext,
       ),
     ]);
 

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -41,6 +41,15 @@ vi.mock("../../src/lib/email-gateway-client.js", () => ({
 
 vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (_req: unknown, _res: unknown, next: () => void) => next(),
+  getServiceContext: (req: any) => ({
+    orgId: req.orgId,
+    userId: req.userId,
+    runId: req.runId,
+    campaignId: req.campaignId,
+    brandId: req.brandId,
+    workflowName: req.workflowName,
+    featureSlug: req.featureSlug,
+  }),
 }));
 
 import request from "supertest";


### PR DESCRIPTION
## Summary
- Stats route was only forwarding `x-org-id`, `x-user-id`, `x-run-id` to email-gateway and apollo-service calls — missing `x-campaign-id`, `x-brand-id`, `x-workflow-name`, `x-feature-slug`
- Added shared `getServiceContext()` helper in auth middleware for consistent header extraction
- Updated `fetchApolloStats` context type to accept all standard headers

## Test plan
- [x] All 111 unit tests pass
- [x] Stats route tests updated with `getServiceContext` mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)