### PR TITLE
Forward count and acceptanceThreshold to journalists-service

### DIFF
--- a/src/lib/journalist-client.ts
+++ b/src/lib/journalist-client.ts
@@ -29,6 +29,8 @@ export async function fetchJournalistsByOutlet(
     brandId?: string;
     workflowName?: string;
     featureSlug?: string;
+    count?: number;
+    acceptanceThreshold?: number;
   }
 ): Promise<JournalistWithEmails[] | null> {
   try {
@@ -44,10 +46,14 @@ export async function fetchJournalistsByOutlet(
     if (options?.workflowName) headers["x-workflow-name"] = options.workflowName;
     if (options?.featureSlug) headers["x-feature-slug"] = options.featureSlug;
 
+    const body: Record<string, unknown> = { outletId };
+    if (options?.count != null) body.count = options.count;
+    if (options?.acceptanceThreshold != null) body.acceptanceThreshold = options.acceptanceThreshold;
+
     const response = await fetch(`${JOURNALISTS_SERVICE_URL}/journalists/resolve`, {
       method: "POST",
       headers,
-      body: JSON.stringify({ outletId }),
+      body: JSON.stringify(body),
     });
 
     if (!response.ok) {

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -329,6 +329,32 @@ describe("service client headers", () => {
       expect(opts.headers["x-feature-slug"]).toBe("feat-1");
     });
 
+    it("forwards count and acceptanceThreshold in request body", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ journalists: [], cached: false }));
+
+      const { fetchJournalistsByOutlet } = await import("../../src/lib/journalist-client.js");
+      await fetchJournalistsByOutlet("outlet-uuid-1", {
+        orgId: "org-1", count: 5, acceptanceThreshold: 60,
+      });
+
+      const [, opts] = fetchSpy.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.outletId).toBe("outlet-uuid-1");
+      expect(body.count).toBe(5);
+      expect(body.acceptanceThreshold).toBe(60);
+    });
+
+    it("omits count and acceptanceThreshold when not provided", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ journalists: [], cached: false }));
+
+      const { fetchJournalistsByOutlet } = await import("../../src/lib/journalist-client.js");
+      await fetchJournalistsByOutlet("outlet-uuid-1", { orgId: "org-1" });
+
+      const [, opts] = fetchSpy.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body).toEqual({ outletId: "outlet-uuid-1" });
+    });
+
     it("returns null on error", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ error: "not found" }, 404));
 


### PR DESCRIPTION
## Summary
- Passes new optional `count` and `acceptanceThreshold` parameters through `fetchJournalistsByOutlet` to journalists-service `/journalists/resolve`
- Enables early-stop scoring on journalists-service side, reducing LLM costs during buffer fill
- No behavior change for existing callers — params are omitted when not provided (journalists-service defaults apply: count=1, threshold=70)

## Test plan
- [x] Unit tests added: verifies params are forwarded in request body when provided
- [x] Unit tests added: verifies params are omitted when not provided
- [x] All 113 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)