### PR TITLE
Add maxArticles param to journalist-client

### DIFF
--- a/src/lib/journalist-client.ts
+++ b/src/lib/journalist-client.ts
@@ -31,6 +31,7 @@ export async function fetchJournalistsByOutlet(
     featureSlug?: string;
     count?: number;
     acceptanceThreshold?: number;
+    maxArticles?: number;
   }
 ): Promise<JournalistWithEmails[] | null> {
   try {
@@ -49,6 +50,7 @@ export async function fetchJournalistsByOutlet(
     const body: Record<string, unknown> = { outletId };
     if (options?.count != null) body.count = options.count;
     if (options?.acceptanceThreshold != null) body.acceptanceThreshold = options.acceptanceThreshold;
+    if (options?.maxArticles != null) body.maxArticles = options.maxArticles;
 
     const response = await fetch(`${JOURNALISTS_SERVICE_URL}/journalists/resolve`, {
       method: "POST",

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -329,12 +329,12 @@ describe("service client headers", () => {
       expect(opts.headers["x-feature-slug"]).toBe("feat-1");
     });
 
-    it("forwards count and acceptanceThreshold in request body", async () => {
+    it("forwards count, acceptanceThreshold, and maxArticles in request body", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ journalists: [], cached: false }));
 
       const { fetchJournalistsByOutlet } = await import("../../src/lib/journalist-client.js");
       await fetchJournalistsByOutlet("outlet-uuid-1", {
-        orgId: "org-1", count: 5, acceptanceThreshold: 60,
+        orgId: "org-1", count: 5, acceptanceThreshold: 60, maxArticles: 10,
       });
 
       const [, opts] = fetchSpy.mock.calls[0];
@@ -342,6 +342,7 @@ describe("service client headers", () => {
       expect(body.outletId).toBe("outlet-uuid-1");
       expect(body.count).toBe(5);
       expect(body.acceptanceThreshold).toBe(60);
+      expect(body.maxArticles).toBe(10);
     });
 
     it("omits count and acceptanceThreshold when not provided", async () => {


### PR DESCRIPTION
## Summary
- Forwards new optional `maxArticles` parameter (1-30, default 15) to journalists-service `/journalists/resolve`
- Aligns journalist-client with updated journalists-service OpenAPI spec
- No behavior change — param is omitted when not provided (service default: 15)

## Test plan
- [x] Updated existing test to verify maxArticles is forwarded in request body
- [x] All 113 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)