### PR TITLE
Add fetchNextOutlet and align outlet-client with updated spec

### DIFF
--- a/src/lib/outlet-client.ts
+++ b/src/lib/outlet-client.ts
@@ -7,8 +7,47 @@ export interface OutletDetails {
   outletUrl: string;
   outletDomain: string;
   relevanceScore: number;
+  whyRelevant: string;
+  whyNotRelevant: string;
+  overallRelevance: string;
   outletStatus: string;
   campaignId: string;
+}
+
+export interface BufferNextOutlet {
+  outletId: string;
+  outletName: string;
+  outletUrl: string;
+  outletDomain: string;
+  campaignId: string;
+  brandId: string;
+  relevanceScore: number;
+  whyRelevant: string;
+  whyNotRelevant: string;
+  overallRelevance: string | null;
+}
+
+function buildHeaders(context?: {
+  orgId?: string | null;
+  userId?: string;
+  runId?: string;
+  campaignId?: string;
+  brandId?: string;
+  workflowName?: string;
+  featureSlug?: string;
+}): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-API-Key": OUTLETS_SERVICE_API_KEY,
+  };
+  if (context?.orgId) headers["x-org-id"] = context.orgId;
+  if (context?.userId) headers["x-user-id"] = context.userId;
+  if (context?.runId) headers["x-run-id"] = context.runId;
+  if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
+  if (context?.brandId) headers["x-brand-id"] = context.brandId;
+  if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
+  if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
+  return headers;
 }
 
 export async function discoverOutlets(params: {
@@ -23,27 +62,20 @@ export async function discoverOutlets(params: {
   featureSlug?: string;
 }): Promise<OutletDetails[] | null> {
   try {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      "X-API-Key": OUTLETS_SERVICE_API_KEY,
-    };
-    if (context?.orgId) headers["x-org-id"] = context.orgId;
-    if (context?.userId) headers["x-user-id"] = context.userId;
-    if (context?.runId) headers["x-run-id"] = context.runId;
-    if (params.campaignId) headers["x-campaign-id"] = params.campaignId;
-    if (params.brandId) headers["x-brand-id"] = params.brandId;
-    if (params.workflowName) headers["x-workflow-name"] = params.workflowName;
-    if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
+    const headers = buildHeaders({
+      orgId: context?.orgId,
+      userId: context?.userId,
+      runId: context?.runId,
+      campaignId: params.campaignId,
+      brandId: params.brandId,
+      workflowName: params.workflowName,
+      featureSlug: context?.featureSlug,
+    });
 
     const response = await fetch(`${OUTLETS_SERVICE_URL}/outlets/discover`, {
       method: "POST",
       headers,
-      body: JSON.stringify({
-        campaignId: params.campaignId,
-        brandId: params.brandId,
-        featureInput: params.featureInput,
-        workflowName: params.workflowName,
-      }),
+      body: JSON.stringify({}),
     });
 
     if (response.status === 200) {
@@ -66,23 +98,56 @@ export async function discoverOutlets(params: {
   }
 }
 
+export async function fetchNextOutlet(context: {
+  orgId: string;
+  userId?: string;
+  runId?: string;
+  campaignId: string;
+  brandId: string;
+  workflowName?: string;
+  featureSlug?: string;
+  idempotencyKey?: string;
+}): Promise<{ found: boolean; outlet?: BufferNextOutlet }> {
+  try {
+    const headers = buildHeaders(context);
+
+    const body: Record<string, unknown> = {};
+    if (context.idempotencyKey) body.idempotencyKey = context.idempotencyKey;
+
+    const response = await fetch(`${OUTLETS_SERVICE_URL}/buffer/next`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      console.warn(`[outlet-client] buffer/next failed for campaign ${context.campaignId}: ${response.status}`);
+      return { found: false };
+    }
+
+    const data = (await response.json()) as { found: boolean; outlet?: BufferNextOutlet };
+    return data;
+  } catch (error) {
+    console.error("[outlet-client] Error fetching next outlet:", error);
+    return { found: false };
+  }
+}
+
 export async function fetchOutletsByCampaign(
   campaignId: string,
   orgId?: string | null,
   context?: { userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowName?: string; featureSlug?: string }
 ): Promise<OutletDetails[] | null> {
   try {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      "X-API-Key": OUTLETS_SERVICE_API_KEY,
-    };
-    if (orgId) headers["x-org-id"] = orgId;
-    if (context?.userId) headers["x-user-id"] = context.userId;
-    if (context?.runId) headers["x-run-id"] = context.runId;
-    if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
-    if (context?.brandId) headers["x-brand-id"] = context.brandId;
-    if (context?.workflowName) headers["x-workflow-name"] = context.workflowName;
-    if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
+    const headers = buildHeaders({
+      orgId,
+      userId: context?.userId,
+      runId: context?.runId,
+      campaignId: context?.campaignId,
+      brandId: context?.brandId,
+      workflowName: context?.workflowName,
+      featureSlug: context?.featureSlug,
+    });
 
     const response = await fetch(
       `${OUTLETS_SERVICE_URL}/internal/outlets/by-campaign/${campaignId}`,

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -37,6 +37,7 @@ vi.mock("../../src/lib/apollo-client.js", () => ({
 vi.mock("../../src/lib/outlet-client.js", () => ({
   fetchOutletsByCampaign: vi.fn().mockResolvedValue(null),
   discoverOutlets: vi.fn().mockResolvedValue(null),
+  fetchNextOutlet: vi.fn().mockResolvedValue({ found: false }),
 }));
 
 // Mock journalist-client

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -303,6 +303,73 @@ describe("service client headers", () => {
 
       expect(result).toBeNull();
     });
+
+    it("sends POST to /buffer/next with headers and optional idempotencyKey", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ found: true, outlet: { outletId: "o1", outletName: "TechCrunch" } }));
+
+      const { fetchNextOutlet } = await import("../../src/lib/outlet-client.js");
+      const result = await fetchNextOutlet({
+        orgId: "org-1", userId: "user-1", runId: "run-1",
+        campaignId: "camp-1", brandId: "brand-1", workflowName: "wf-1", featureSlug: "feat-1",
+        idempotencyKey: "idem-123",
+      });
+
+      expect(result.found).toBe(true);
+      expect(result.outlet?.outletId).toBe("o1");
+
+      const [url, opts] = fetchSpy.mock.calls[0];
+      expect(url).toContain("/buffer/next");
+      expect(opts.method).toBe("POST");
+      expect(opts.headers["x-org-id"]).toBe("org-1");
+      expect(opts.headers["x-campaign-id"]).toBe("camp-1");
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
+      expect(opts.headers["x-workflow-name"]).toBe("wf-1");
+      expect(opts.headers["x-feature-slug"]).toBe("feat-1");
+      const body = JSON.parse(opts.body);
+      expect(body.idempotencyKey).toBe("idem-123");
+    });
+
+    it("sends empty body to /buffer/next when no idempotencyKey", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ found: false }));
+
+      const { fetchNextOutlet } = await import("../../src/lib/outlet-client.js");
+      const result = await fetchNextOutlet({
+        orgId: "org-1", campaignId: "camp-1", brandId: "brand-1",
+      });
+
+      expect(result.found).toBe(false);
+      const [, opts] = fetchSpy.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body).toEqual({});
+    });
+
+    it("returns found: false on /buffer/next error", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ error: "fail" }, 502));
+
+      const { fetchNextOutlet } = await import("../../src/lib/outlet-client.js");
+      const result = await fetchNextOutlet({
+        orgId: "org-1", campaignId: "camp-1", brandId: "brand-1",
+      });
+
+      expect(result.found).toBe(false);
+    });
+
+    it("sends empty body to /outlets/discover (campaignId/brandId via headers)", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ discoveredCount: 1, outlets: [{ id: "o1" }] }, 201));
+
+      const { discoverOutlets } = await import("../../src/lib/outlet-client.js");
+      await discoverOutlets(
+        { campaignId: "camp-1", brandId: "brand-1" },
+        { orgId: "org-1", userId: "user-1", runId: "run-1" },
+      );
+
+      const [url, opts] = fetchSpy.mock.calls[0];
+      expect(url).toContain("/outlets/discover");
+      expect(opts.headers["x-campaign-id"]).toBe("camp-1");
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
+      const body = JSON.parse(opts.body);
+      expect(body).toEqual({});
+    });
   });
 
   describe("journalist-client", () => {


### PR DESCRIPTION
## Summary
- Add `fetchNextOutlet()` client for the new `POST /buffer/next` endpoint on outlets-service (PR #21) — single outlet retrieval with idempotency support
- Update `OutletDetails` interface with `whyRelevant`, `whyNotRelevant`, `overallRelevance` fields from updated spec
- Add `BufferNextOutlet` type matching the `/buffer/next` response schema
- Clean up `discoverOutlets` to send empty body (campaignId/brandId now sent exclusively via headers per updated spec)
- Extract shared `buildHeaders` helper to reduce duplication across client functions

## Test plan
- [x] 4 new tests: fetchNextOutlet with/without idempotencyKey, error handling, discoverOutlets empty body
- [x] All 117 tests pass (113 existing + 4 new)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)