### PR TITLE
Align journalist-client with POST /buffer/next

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -7,7 +7,7 @@ import { apolloSearchNext, apolloEnrich, apolloMatch, apolloSearchParams, type A
 import { fetchCampaign } from "./campaign-client.js";
 import { extractBrandFields } from "./brand-client.js";
 import { fetchOutletsByCampaign, discoverOutlets } from "./outlet-client.js";
-import { fetchJournalistsByOutlet } from "./journalist-client.js";
+import { fetchNextJournalist } from "./journalist-client.js";
 
 async function isInBuffer(orgId: string, campaignId: string, externalId: string): Promise<boolean> {
   const row = await db.query.leadBuffer.findFirst({
@@ -283,8 +283,8 @@ async function fillBufferFromJournalists(params: {
       eq(cursors.namespace, cursorNamespace)
     ),
   });
-  const cursorState = (existingCursor?.state as { outletIndex: number; journalistIndex: number } | null)
-    ?? { outletIndex: 0, journalistIndex: 0 };
+  const cursorState = (existingCursor?.state as { outletIndex: number } | null)
+    ?? { outletIndex: 0 };
 
   // Fetch outlets for this campaign
   let outlets = await fetchOutletsByCampaign(params.campaignId, params.orgId, serviceContext);
@@ -324,24 +324,24 @@ async function fillBufferFromJournalists(params: {
 
   for (let oi = cursorState.outletIndex; oi < outlets.length; oi++) {
     const outlet = outlets[oi];
-
-    const journalists = await fetchJournalistsByOutlet(outlet.id, {
-      ...serviceContext,
-      campaignId: params.campaignId,
-      orgId: params.orgId,
-    });
-
-    if (!journalists || journalists.length === 0) {
-      // No journalists for this outlet — advance to next
-      continue;
-    }
-
     const organizationDomain = outlet.outletDomain || extractDomain(outlet.outletUrl);
 
-    const startJ = oi === cursorState.outletIndex ? cursorState.journalistIndex : 0;
+    // Call journalists-service buffer/next in a loop for this outlet
+    // journalists-service manages its own internal buffer per (campaign, outlet)
+    const MAX_JOURNALIST_PULLS = 50;
+    for (let pull = 0; pull < MAX_JOURNALIST_PULLS; pull++) {
+      const result = await fetchNextJournalist(outlet.id, {
+        ...serviceContext,
+        campaignId: params.campaignId,
+        orgId: params.orgId,
+      });
 
-    for (let ji = startJ; ji < journalists.length; ji++) {
-      const journalist = journalists[ji];
+      if (!result.found || !result.journalist) {
+        // No more journalists for this outlet
+        break;
+      }
+
+      const journalist = result.journalist;
 
       // Skip organization-type entities (we need individual people)
       if (journalist.entityType === "organization") continue;
@@ -350,7 +350,7 @@ async function fillBufferFromJournalists(params: {
 
       if (await isInBuffer(params.orgId, params.campaignId, externalId)) continue;
 
-      // Try email from resolve response first
+      // Try email from buffer/next response first
       let validEmail = journalist.emails
         ?.filter(e => e.isValid)
         ?.sort((a, b) => b.confidence - a.confidence)
@@ -358,7 +358,7 @@ async function fillBufferFromJournalists(params: {
 
       let enrichedData: Record<string, unknown> | null = null;
 
-      // No email from resolve — proactively match via Apollo Service
+      // No email — proactively match via Apollo Service
       if (!validEmail && journalist.firstName && journalist.lastName && organizationDomain) {
         const matchResult = await apolloMatch(
           {
@@ -430,14 +430,14 @@ async function fillBufferFromJournalists(params: {
 
     // Save cursor after each outlet
     if (totalFilled > 0) {
-      await saveCursor(params.orgId, cursorNamespace, { outletIndex: oi + 1, journalistIndex: 0 });
+      await saveCursor(params.orgId, cursorNamespace, { outletIndex: oi + 1 });
       console.log(`[fillBufferFromJournalists] Buffered ${totalFilled} journalists from outlet ${outlet.outletName}`);
       return { filled: totalFilled };
     }
   }
 
   // All outlets exhausted
-  await saveCursor(params.orgId, cursorNamespace, { outletIndex: outlets.length, journalistIndex: 0 });
+  await saveCursor(params.orgId, cursorNamespace, { outletIndex: outlets.length });
   return { filled: totalFilled };
 }
 

--- a/src/lib/journalist-client.ts
+++ b/src/lib/journalist-client.ts
@@ -19,7 +19,7 @@ export interface JournalistWithEmails {
   emails: JournalistEmail[];
 }
 
-export async function fetchJournalistsByOutlet(
+export async function fetchNextJournalist(
   outletId: string,
   options?: {
     campaignId?: string;
@@ -29,11 +29,10 @@ export async function fetchJournalistsByOutlet(
     brandId?: string;
     workflowName?: string;
     featureSlug?: string;
-    count?: number;
-    acceptanceThreshold?: number;
+    idempotencyKey?: string;
     maxArticles?: number;
   }
-): Promise<JournalistWithEmails[] | null> {
+): Promise<{ found: boolean; journalist?: JournalistWithEmails }> {
   try {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -48,28 +47,24 @@ export async function fetchJournalistsByOutlet(
     if (options?.featureSlug) headers["x-feature-slug"] = options.featureSlug;
 
     const body: Record<string, unknown> = { outletId };
-    if (options?.count != null) body.count = options.count;
-    if (options?.acceptanceThreshold != null) body.acceptanceThreshold = options.acceptanceThreshold;
+    if (options?.idempotencyKey) body.idempotencyKey = options.idempotencyKey;
     if (options?.maxArticles != null) body.maxArticles = options.maxArticles;
 
-    const response = await fetch(`${JOURNALISTS_SERVICE_URL}/journalists/resolve`, {
+    const response = await fetch(`${JOURNALISTS_SERVICE_URL}/buffer/next`, {
       method: "POST",
       headers,
       body: JSON.stringify(body),
     });
 
     if (!response.ok) {
-      console.warn(`[journalist-client] Failed to resolve journalists for outlet ${outletId}: ${response.status}`);
-      return null;
+      console.warn(`[journalist-client] buffer/next failed for outlet ${outletId}: ${response.status}`);
+      return { found: false };
     }
 
-    const data = (await response.json()) as { journalists: JournalistWithEmails[]; cached: boolean };
-    if (data.cached) {
-      console.log(`[journalist-client] Resolved journalists for outlet ${outletId} (cached)`);
-    }
-    return data.journalists;
+    const data = (await response.json()) as { found: boolean; journalist?: JournalistWithEmails };
+    return data;
   } catch (error) {
-    console.error("[journalist-client] Error resolving journalists:", error);
-    return null;
+    console.error("[journalist-client] Error fetching next journalist:", error);
+    return { found: false };
   }
 }

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -42,7 +42,7 @@ vi.mock("../../src/lib/outlet-client.js", () => ({
 
 // Mock journalist-client
 vi.mock("../../src/lib/journalist-client.js", () => ({
-  fetchJournalistsByOutlet: vi.fn().mockResolvedValue(null),
+  fetchNextJournalist: vi.fn().mockResolvedValue({ found: false }),
 }));
 
 // Mock campaign-client
@@ -76,7 +76,7 @@ import { resolveOrCreateLead } from "../../src/lib/leads-registry.js";
 import { fetchOutletsByCampaign, discoverOutlets } from "../../src/lib/outlet-client.js";
 import { fetchCampaign } from "../../src/lib/campaign-client.js";
 import { extractBrandFields } from "../../src/lib/brand-client.js";
-import { fetchJournalistsByOutlet } from "../../src/lib/journalist-client.js";
+import { fetchNextJournalist } from "../../src/lib/journalist-client.js";
 
 /** Helper: convert camelCase buffer row to snake_case raw SQL row (as returned by pgSql) */
 function toClaimedRow(row: {
@@ -995,17 +995,23 @@ describe("buffer", () => {
         { id: "outlet-1", outletName: "TechCrunch", outletUrl: "https://techcrunch.com", outletDomain: "techcrunch.com", relevanceScore: 85, outletStatus: "open", campaignId: "campaign-1" },
       ]);
 
-      // Journalist service returns journalist with email
-      vi.mocked(fetchJournalistsByOutlet).mockResolvedValueOnce([
-        {
-          id: "j-uuid-1",
-          journalistName: "Jane Reporter",
-          firstName: "Jane",
-          lastName: "Reporter",
-          entityType: "individual" as const,
-          emails: [{ email: "jane@techcrunch.com", isValid: true, confidence: 0.95 }],
-        },
-      ]);
+      // Journalist service returns journalist via buffer/next, then exhausted
+      vi.mocked(fetchNextJournalist)
+        .mockResolvedValueOnce({
+          found: true,
+          journalist: {
+            id: "j-uuid-1",
+            journalistName: "Jane Reporter",
+            firstName: "Jane",
+            lastName: "Reporter",
+            entityType: "individual" as const,
+            relevanceScore: 0.85,
+            whyRelevant: "Covers tech",
+            whyNotRelevant: "",
+            emails: [{ email: "jane@techcrunch.com", isValid: true, confidence: 0.95 }],
+          },
+        })
+        .mockResolvedValueOnce({ found: false });
 
       vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
 
@@ -1031,7 +1037,7 @@ describe("buffer", () => {
       expect(vi.mocked(fetchOutletsByCampaign)).toHaveBeenCalledWith(
         "campaign-1", "org-1", expect.objectContaining({ campaignId: "campaign-1" })
       );
-      expect(vi.mocked(fetchJournalistsByOutlet)).toHaveBeenCalledWith(
+      expect(vi.mocked(fetchNextJournalist)).toHaveBeenCalledWith(
         "outlet-1", expect.objectContaining({ campaignId: "campaign-1" })
       );
     });
@@ -1213,17 +1219,22 @@ describe("buffer", () => {
         campaignId: "campaign-1",
       }]);
 
-      vi.mocked(fetchJournalistsByOutlet).mockResolvedValueOnce([{
-        id: "j-discovered",
-        journalistName: "Jane Reporter",
-        firstName: "Jane",
-        lastName: "Reporter",
-        entityType: "individual",
-        relevanceScore: 0.8,
-        whyRelevant: "Covers tech",
-        whyNotRelevant: "",
-        emails: [{ email: "discovered@outlet.com", isValid: true, confidence: 0.95 }],
-      }]);
+      vi.mocked(fetchNextJournalist)
+        .mockResolvedValueOnce({
+          found: true,
+          journalist: {
+            id: "j-discovered",
+            journalistName: "Jane Reporter",
+            firstName: "Jane",
+            lastName: "Reporter",
+            entityType: "individual" as const,
+            relevanceScore: 0.8,
+            whyRelevant: "Covers tech",
+            whyNotRelevant: "",
+            emails: [{ email: "discovered@outlet.com", isValid: true, confidence: 0.95 }],
+          },
+        })
+        .mockResolvedValueOnce({ found: false });
 
       vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
 
@@ -1328,20 +1339,23 @@ describe("buffer", () => {
         { id: "outlet-1", outletName: "TechCrunch", outletUrl: "https://techcrunch.com", outletDomain: "techcrunch.com", relevanceScore: 85, outletStatus: "open", campaignId: "campaign-1" },
       ]);
 
-      // Resolve returns journalist WITHOUT emails
-      vi.mocked(fetchJournalistsByOutlet).mockResolvedValueOnce([
-        {
-          id: "j-noemail",
-          journalistName: "Bob Writer",
-          firstName: "Bob",
-          lastName: "Writer",
-          entityType: "individual" as const,
-          relevanceScore: 0.8,
-          whyRelevant: "Covers tech",
-          whyNotRelevant: "",
-          emails: [],
-        },
-      ]);
+      // buffer/next returns journalist WITHOUT emails, then exhausted
+      vi.mocked(fetchNextJournalist)
+        .mockResolvedValueOnce({
+          found: true,
+          journalist: {
+            id: "j-noemail",
+            journalistName: "Bob Writer",
+            firstName: "Bob",
+            lastName: "Writer",
+            entityType: "individual" as const,
+            relevanceScore: 0.8,
+            whyRelevant: "Covers tech",
+            whyNotRelevant: "",
+            emails: [],
+          },
+        })
+        .mockResolvedValueOnce({ found: false });
 
       // apolloMatch finds the email
       vi.mocked(apolloMatch).mockResolvedValueOnce({

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -373,17 +373,17 @@ describe("service client headers", () => {
   });
 
   describe("journalist-client", () => {
-    it("sends POST to /journalists/resolve with outletId in body and headers", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ journalists: [{ id: "j1", journalistName: "Jane Doe" }], cached: false }));
+    it("sends POST to /buffer/next with outletId in body and headers", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ found: true, journalist: { id: "j1", journalistName: "Jane Doe" } }));
 
-      const { fetchJournalistsByOutlet } = await import("../../src/lib/journalist-client.js");
-      await fetchJournalistsByOutlet("outlet-uuid-1", {
+      const { fetchNextJournalist } = await import("../../src/lib/journalist-client.js");
+      await fetchNextJournalist("outlet-uuid-1", {
         campaignId: "camp-1", orgId: "org-1", userId: "user-1", runId: "run-1", brandId: "brand-1", workflowName: "wf-1", featureSlug: "feat-1",
       });
 
       expect(fetchSpy).toHaveBeenCalledOnce();
       const [url, opts] = fetchSpy.mock.calls[0];
-      expect(url).toContain("/journalists/resolve");
+      expect(url).toContain("/buffer/next");
       expect(opts.method).toBe("POST");
       const body = JSON.parse(opts.body);
       expect(body.outletId).toBe("outlet-uuid-1");
@@ -396,40 +396,39 @@ describe("service client headers", () => {
       expect(opts.headers["x-feature-slug"]).toBe("feat-1");
     });
 
-    it("forwards count, acceptanceThreshold, and maxArticles in request body", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ journalists: [], cached: false }));
+    it("forwards idempotencyKey and maxArticles in request body", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ found: false }));
 
-      const { fetchJournalistsByOutlet } = await import("../../src/lib/journalist-client.js");
-      await fetchJournalistsByOutlet("outlet-uuid-1", {
-        orgId: "org-1", count: 5, acceptanceThreshold: 60, maxArticles: 10,
+      const { fetchNextJournalist } = await import("../../src/lib/journalist-client.js");
+      await fetchNextJournalist("outlet-uuid-1", {
+        orgId: "org-1", idempotencyKey: "idem-123", maxArticles: 10,
       });
 
       const [, opts] = fetchSpy.mock.calls[0];
       const body = JSON.parse(opts.body);
       expect(body.outletId).toBe("outlet-uuid-1");
-      expect(body.count).toBe(5);
-      expect(body.acceptanceThreshold).toBe(60);
+      expect(body.idempotencyKey).toBe("idem-123");
       expect(body.maxArticles).toBe(10);
     });
 
-    it("omits count and acceptanceThreshold when not provided", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ journalists: [], cached: false }));
+    it("sends only outletId when no optional params provided", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ found: false }));
 
-      const { fetchJournalistsByOutlet } = await import("../../src/lib/journalist-client.js");
-      await fetchJournalistsByOutlet("outlet-uuid-1", { orgId: "org-1" });
+      const { fetchNextJournalist } = await import("../../src/lib/journalist-client.js");
+      await fetchNextJournalist("outlet-uuid-1", { orgId: "org-1" });
 
       const [, opts] = fetchSpy.mock.calls[0];
       const body = JSON.parse(opts.body);
       expect(body).toEqual({ outletId: "outlet-uuid-1" });
     });
 
-    it("returns null on error", async () => {
+    it("returns found: false on error", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ error: "not found" }, 404));
 
-      const { fetchJournalistsByOutlet } = await import("../../src/lib/journalist-client.js");
-      const result = await fetchJournalistsByOutlet("bad-outlet");
+      const { fetchNextJournalist } = await import("../../src/lib/journalist-client.js");
+      const result = await fetchNextJournalist("bad-outlet");
 
-      expect(result).toBeNull();
+      expect(result).toEqual({ found: false });
     });
   });
 


### PR DESCRIPTION
## Summary
- Replaces `fetchJournalistsByOutlet` (`POST /journalists/resolve`) with `fetchNextJournalist` (`POST /buffer/next`) to match the new buffer pattern in journalists-service (PR #21)
- `fillBufferFromJournalists` now pulls one journalist at a time in a loop instead of batch-fetching, since journalists-service manages its own internal buffer
- Cursor state simplified (no more `journalistIndex`, only `outletIndex`) since journalists-service tracks per-(campaign, outlet) state internally
- Supports `idempotencyKey` and `maxArticles` body params per the new spec

## Test plan
- [x] All 117 unit tests pass
- [x] Build succeeds
- [ ] Verify end-to-end with a `sourceType: "journalist"` pullNext call after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)