### PR TITLE
Fix outlet discovery 404 by using buffer/next

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -6,7 +6,7 @@ import { resolveOrCreateLead, findLeadByApolloPersonId } from "./leads-registry.
 import { apolloSearchNext, apolloEnrich, apolloMatch, apolloSearchParams, type ApolloSearchParams } from "./apollo-client.js";
 import { fetchCampaign } from "./campaign-client.js";
 import { extractBrandFields } from "./brand-client.js";
-import { fetchOutletsByCampaign, discoverOutlets } from "./outlet-client.js";
+import { fetchOutletsByCampaign, fetchNextOutlet } from "./outlet-client.js";
 import { fetchNextJournalist } from "./journalist-client.js";
 
 async function isInBuffer(orgId: string, campaignId: string, externalId: string): Promise<boolean> {
@@ -289,25 +289,20 @@ async function fillBufferFromJournalists(params: {
   // Fetch outlets for this campaign
   let outlets = await fetchOutletsByCampaign(params.campaignId, params.orgId, serviceContext);
   if (!outlets || outlets.length === 0) {
-    // No outlets yet — discover them via outlets-service
-    console.log(`[fillBufferFromJournalists] No outlets for campaign=${params.campaignId}, discovering...`);
+    // No outlets yet — trigger auto-discovery via buffer/next on outlets-service
+    console.log(`[fillBufferFromJournalists] No outlets for campaign=${params.campaignId}, triggering discovery via buffer/next...`);
 
-    const discovered = await discoverOutlets(
-      {
-        campaignId: params.campaignId,
-        brandId: params.brandId,
-        featureInput: params.featureInput,
-        workflowName: params.workflowName,
-      },
-      {
-        orgId: params.orgId,
-        userId: params.userId ?? undefined,
-        runId: params.pushRunId ?? undefined,
-        featureSlug: params.featureSlug,
-      }
-    );
+    const nextResult = await fetchNextOutlet({
+      orgId: params.orgId,
+      userId: params.userId ?? undefined,
+      runId: params.pushRunId ?? undefined,
+      campaignId: params.campaignId,
+      brandId: params.brandId,
+      workflowName: params.workflowName,
+      featureSlug: params.featureSlug,
+    });
 
-    if (!discovered || discovered.length === 0) {
+    if (!nextResult.found) {
       console.log(`[fillBufferFromJournalists] Outlet discovery returned 0 results for campaign=${params.campaignId}`);
       return { filled: 0 };
     }

--- a/src/lib/outlet-client.ts
+++ b/src/lib/outlet-client.ts
@@ -50,54 +50,6 @@ function buildHeaders(context?: {
   return headers;
 }
 
-export async function discoverOutlets(params: {
-  campaignId: string;
-  brandId: string;
-  featureInput?: Record<string, unknown>;
-  workflowName?: string;
-}, context?: {
-  orgId?: string | null;
-  userId?: string;
-  runId?: string;
-  featureSlug?: string;
-}): Promise<OutletDetails[] | null> {
-  try {
-    const headers = buildHeaders({
-      orgId: context?.orgId,
-      userId: context?.userId,
-      runId: context?.runId,
-      campaignId: params.campaignId,
-      brandId: params.brandId,
-      workflowName: params.workflowName,
-      featureSlug: context?.featureSlug,
-    });
-
-    const response = await fetch(`${OUTLETS_SERVICE_URL}/outlets/discover`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({}),
-    });
-
-    if (response.status === 200) {
-      // 200 = no outlets found
-      console.log(`[outlet-client] Discover returned 0 outlets for campaign ${params.campaignId}`);
-      return [];
-    }
-
-    if (!response.ok) {
-      console.warn(`[outlet-client] Failed to discover outlets for campaign ${params.campaignId}: ${response.status}`);
-      return null;
-    }
-
-    const data = (await response.json()) as { discoveredCount: number; outlets: OutletDetails[] };
-    console.log(`[outlet-client] Discovered ${data.discoveredCount} outlets for campaign ${params.campaignId}`);
-    return data.outlets;
-  } catch (error) {
-    console.error("[outlet-client] Error discovering outlets:", error);
-    return null;
-  }
-}
-
 export async function fetchNextOutlet(context: {
   orgId: string;
   userId?: string;

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -36,7 +36,6 @@ vi.mock("../../src/lib/apollo-client.js", () => ({
 // Mock outlet-client
 vi.mock("../../src/lib/outlet-client.js", () => ({
   fetchOutletsByCampaign: vi.fn().mockResolvedValue(null),
-  discoverOutlets: vi.fn().mockResolvedValue(null),
   fetchNextOutlet: vi.fn().mockResolvedValue({ found: false }),
 }));
 
@@ -73,7 +72,7 @@ import { pullNext } from "../../src/lib/buffer.js";
 import { apolloSearchNext, apolloSearchParams, apolloEnrich, apolloMatch } from "../../src/lib/apollo-client.js";
 import { checkDeliveryStatus } from "../../src/lib/email-gateway-client.js";
 import { resolveOrCreateLead } from "../../src/lib/leads-registry.js";
-import { fetchOutletsByCampaign, discoverOutlets } from "../../src/lib/outlet-client.js";
+import { fetchOutletsByCampaign, fetchNextOutlet } from "../../src/lib/outlet-client.js";
 import { fetchCampaign } from "../../src/lib/campaign-client.js";
 import { extractBrandFields } from "../../src/lib/brand-client.js";
 import { fetchNextJournalist } from "../../src/lib/journalist-client.js";
@@ -1149,8 +1148,8 @@ describe("buffer", () => {
       vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
       vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([]);
 
-      // Discovery returns empty
-      vi.mocked(discoverOutlets).mockResolvedValueOnce([]);
+      // buffer/next triggers auto-discovery but finds nothing
+      vi.mocked(fetchNextOutlet).mockResolvedValueOnce({ found: false });
 
       const result = await pullNext({
         orgId: "org-1",
@@ -1161,15 +1160,13 @@ describe("buffer", () => {
       });
 
       expect(result.found).toBe(false);
-      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
-      // featureInput is passed through as-is
-      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledWith(
+      expect(vi.mocked(fetchNextOutlet)).toHaveBeenCalledOnce();
+      expect(vi.mocked(fetchNextOutlet)).toHaveBeenCalledWith(
         expect.objectContaining({
           campaignId: "campaign-1",
           brandId: "brand-1",
-          featureInput: { companyContext: "A test brand" },
+          orgId: "org-1",
         }),
-        expect.any(Object),
       );
     });
 
@@ -1209,15 +1206,19 @@ describe("buffer", () => {
           campaignId: "campaign-1",
         }]);
 
-      vi.mocked(discoverOutlets).mockResolvedValueOnce([{
-        id: "outlet-discovered",
+      // buffer/next triggers auto-discovery and finds an outlet
+      vi.mocked(fetchNextOutlet).mockResolvedValueOnce({ found: true, outlet: {
+        outletId: "outlet-discovered",
         outletName: "Discovered Outlet",
         outletUrl: "https://discovered-outlet.com",
         outletDomain: "discovered-outlet.com",
-        relevanceScore: 0.9,
-        outletStatus: "active",
         campaignId: "campaign-1",
-      }]);
+        brandId: "brand-1",
+        relevanceScore: 0.9,
+        whyRelevant: "Relevant outlet",
+        whyNotRelevant: "",
+        overallRelevance: null,
+      }});
 
       vi.mocked(fetchNextJournalist)
         .mockResolvedValueOnce({
@@ -1266,28 +1267,27 @@ describe("buffer", () => {
         featureInput,
       });
 
-      // featureInput is forwarded as-is — no field extraction or validation by lead-service
-      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
-      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledWith(
+      // fetchNextOutlet triggers auto-discovery on outlets-service
+      expect(vi.mocked(fetchNextOutlet)).toHaveBeenCalledOnce();
+      expect(vi.mocked(fetchNextOutlet)).toHaveBeenCalledWith(
         expect.objectContaining({
           campaignId: "campaign-1",
           brandId: "brand-1",
-          featureInput,
+          orgId: "org-1",
         }),
-        expect.any(Object),
       );
       expect(result.found).toBe(true);
       expect(result.lead?.email).toBe("discovered@outlet.com");
     });
 
-    it("calls discoverOutlets even without featureInput", async () => {
+    it("calls fetchNextOutlet even without featureInput", async () => {
       pgSqlMock.mockResolvedValue([]);
 
       vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
       vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([]);
 
-      // Discovery returns empty — but it should still be called
-      vi.mocked(discoverOutlets).mockResolvedValueOnce([]);
+      // buffer/next triggers auto-discovery but finds nothing
+      vi.mocked(fetchNextOutlet).mockResolvedValueOnce({ found: false });
 
       const result = await pullNext({
         orgId: "org-1",
@@ -1297,14 +1297,13 @@ describe("buffer", () => {
       });
 
       expect(result.found).toBe(false);
-      // discoverOutlets is always called — outlets-service decides what to do
-      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledOnce();
-      expect(vi.mocked(discoverOutlets)).toHaveBeenCalledWith(
+      // fetchNextOutlet is always called — outlets-service handles discovery internally
+      expect(vi.mocked(fetchNextOutlet)).toHaveBeenCalledOnce();
+      expect(vi.mocked(fetchNextOutlet)).toHaveBeenCalledWith(
         expect.objectContaining({
           campaignId: "campaign-1",
           brandId: "brand-1",
         }),
-        expect.any(Object),
       );
     });
 

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -354,21 +354,21 @@ describe("service client headers", () => {
       expect(result.found).toBe(false);
     });
 
-    it("sends empty body to /outlets/discover (campaignId/brandId via headers)", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ discoveredCount: 1, outlets: [{ id: "o1" }] }, 201));
+    it("sends headers to /buffer/next for outlet discovery", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ found: true, outlet: { outletId: "o1" } }));
 
-      const { discoverOutlets } = await import("../../src/lib/outlet-client.js");
-      await discoverOutlets(
-        { campaignId: "camp-1", brandId: "brand-1" },
-        { orgId: "org-1", userId: "user-1", runId: "run-1" },
-      );
+      const { fetchNextOutlet } = await import("../../src/lib/outlet-client.js");
+      await fetchNextOutlet({
+        campaignId: "camp-1", brandId: "brand-1",
+        orgId: "org-1", userId: "user-1", runId: "run-1",
+      });
 
       const [url, opts] = fetchSpy.mock.calls[0];
-      expect(url).toContain("/outlets/discover");
+      expect(url).toContain("/buffer/next");
+      expect(opts.method).toBe("POST");
       expect(opts.headers["x-campaign-id"]).toBe("camp-1");
       expect(opts.headers["x-brand-id"]).toBe("brand-1");
-      const body = JSON.parse(opts.body);
-      expect(body).toEqual({});
+      expect(opts.headers["x-org-id"]).toBe("org-1");
     });
   });
 


### PR DESCRIPTION
## Summary
- **Root cause:** `discoverOutlets()` called `POST /outlets/discover` — an endpoint that doesn't exist on the outlets-service, causing a 404 every time the journalist buffer tried to discover outlets for a new campaign.
- **Fix:** Replaced with `fetchNextOutlet()` which calls `POST /buffer/next` — this endpoint handles auto-discovery internally when the buffer is empty (triggers a mini-discover: 3 queries × 5 Google results, LLM scoring).
- Removed the dead `discoverOutlets` function from `outlet-client.ts` and updated all related tests.

## Test plan
- [x] All 117 unit tests pass
- [x] TypeScript build succeeds
- [ ] Deploy and verify journalist-source campaigns discover outlets successfully (no more 404 in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)