### PR TITLE
Add dynasty slug filtering and groupBy to stats

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1288,14 +1288,54 @@
           },
           {
             "in": "query",
+            "name": "workflowSlug",
+            "required": false,
+            "description": "Filter by exact workflow slug",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "featureSlug",
+            "required": false,
+            "description": "Filter by exact feature slug",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workflowDynastySlug",
+            "required": false,
+            "description": "Filter by workflow dynasty slug. Resolved to all versioned slugs via workflow-service, then filtered with WHERE IN (...). Takes priority over workflowSlug.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "featureDynastySlug",
+            "required": false,
+            "description": "Filter by feature dynasty slug. Resolved to all versioned slugs via features-service, then filtered with WHERE IN (...). Takes priority over featureSlug.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "groupBy",
             "required": false,
-            "description": "Group stats by this dimension. When set, returns { groups: [...] } instead of flat stats. Allowed values: campaignId, brandId",
+            "description": "Group stats by this dimension. When set, returns { groups: [...] } instead of flat stats.",
             "schema": {
               "type": "string",
               "enum": [
                 "campaignId",
-                "brandId"
+                "brandId",
+                "workflowSlug",
+                "featureSlug",
+                "workflowDynastySlug",
+                "featureDynastySlug"
               ]
             }
           }

--- a/src/lib/dynasty-client.ts
+++ b/src/lib/dynasty-client.ts
@@ -1,0 +1,131 @@
+const FEATURES_SERVICE_URL = process.env.FEATURES_SERVICE_URL || "http://localhost:3010";
+const FEATURES_SERVICE_API_KEY = process.env.FEATURES_SERVICE_API_KEY || "";
+const WORKFLOW_SERVICE_URL = process.env.WORKFLOW_SERVICE_URL || "http://localhost:3002";
+const WORKFLOW_SERVICE_API_KEY = process.env.WORKFLOW_SERVICE_API_KEY || "";
+
+interface DynastyEntry {
+  dynastySlug: string;
+  slugs: string[];
+}
+
+function buildHeaders(
+  apiKey: string,
+  context?: { orgId?: string; userId?: string; runId?: string },
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-API-Key": apiKey,
+  };
+  if (context?.orgId) headers["x-org-id"] = context.orgId;
+  if (context?.userId) headers["x-user-id"] = context.userId;
+  if (context?.runId) headers["x-run-id"] = context.runId;
+  return headers;
+}
+
+/**
+ * Resolve a feature dynasty slug to its list of versioned slugs.
+ * Returns empty array if resolution fails or dynasty doesn't exist.
+ */
+export async function resolveFeatureDynastySlugs(
+  dynastySlug: string,
+  context?: { orgId?: string; userId?: string; runId?: string },
+): Promise<string[]> {
+  try {
+    const url = `${FEATURES_SERVICE_URL}/features/dynasty/slugs?dynastySlug=${encodeURIComponent(dynastySlug)}`;
+    const response = await fetch(url, {
+      headers: buildHeaders(FEATURES_SERVICE_API_KEY, context),
+    });
+    if (!response.ok) {
+      console.warn(`[lead-service] Failed to resolve feature dynasty slug ${dynastySlug}: ${response.status}`);
+      return [];
+    }
+    const data = (await response.json()) as { slugs: string[] };
+    return data.slugs ?? [];
+  } catch (error) {
+    console.error("[lead-service] Error resolving feature dynasty slug:", error);
+    return [];
+  }
+}
+
+/**
+ * Resolve a workflow dynasty slug to its list of versioned slugs.
+ * Returns empty array if resolution fails or dynasty doesn't exist.
+ */
+export async function resolveWorkflowDynastySlugs(
+  dynastySlug: string,
+  context?: { orgId?: string; userId?: string; runId?: string },
+): Promise<string[]> {
+  try {
+    const url = `${WORKFLOW_SERVICE_URL}/workflows/dynasty/slugs?dynastySlug=${encodeURIComponent(dynastySlug)}`;
+    const response = await fetch(url, {
+      headers: buildHeaders(WORKFLOW_SERVICE_API_KEY, context),
+    });
+    if (!response.ok) {
+      console.warn(`[lead-service] Failed to resolve workflow dynasty slug ${dynastySlug}: ${response.status}`);
+      return [];
+    }
+    const data = (await response.json()) as { slugs: string[] };
+    return data.slugs ?? [];
+  } catch (error) {
+    console.error("[lead-service] Error resolving workflow dynasty slug:", error);
+    return [];
+  }
+}
+
+/**
+ * Fetch all feature dynasties and build a reverse map: slug → dynastySlug.
+ */
+export async function fetchFeatureDynastyMap(
+  context?: { orgId?: string; userId?: string; runId?: string },
+): Promise<Map<string, string>> {
+  try {
+    const url = `${FEATURES_SERVICE_URL}/features/dynasties`;
+    const response = await fetch(url, {
+      headers: buildHeaders(FEATURES_SERVICE_API_KEY, context),
+    });
+    if (!response.ok) {
+      console.warn(`[lead-service] Failed to fetch feature dynasties: ${response.status}`);
+      return new Map();
+    }
+    const data = (await response.json()) as { dynasties: DynastyEntry[] };
+    return buildSlugToDynastyMap(data.dynasties ?? []);
+  } catch (error) {
+    console.error("[lead-service] Error fetching feature dynasties:", error);
+    return new Map();
+  }
+}
+
+/**
+ * Fetch all workflow dynasties and build a reverse map: slug → dynastySlug.
+ */
+export async function fetchWorkflowDynastyMap(
+  context?: { orgId?: string; userId?: string; runId?: string },
+): Promise<Map<string, string>> {
+  try {
+    const url = `${WORKFLOW_SERVICE_URL}/workflows/dynasties`;
+    const response = await fetch(url, {
+      headers: buildHeaders(WORKFLOW_SERVICE_API_KEY, context),
+    });
+    if (!response.ok) {
+      console.warn(`[lead-service] Failed to fetch workflow dynasties: ${response.status}`);
+      return new Map();
+    }
+    const data = (await response.json()) as { dynasties: DynastyEntry[] };
+    return buildSlugToDynastyMap(data.dynasties ?? []);
+  } catch (error) {
+    console.error("[lead-service] Error fetching workflow dynasties:", error);
+    return new Map();
+  }
+}
+
+function buildSlugToDynastyMap(
+  dynasties: DynastyEntry[],
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const d of dynasties) {
+    for (const slug of d.slugs) {
+      map.set(slug, d.dynastySlug);
+    }
+  }
+  return map;
+}

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -9,20 +9,77 @@ import {
   isContacted,
   type DeliveryStatusItem,
 } from "../lib/email-gateway-client.js";
+import {
+  resolveFeatureDynastySlugs,
+  resolveWorkflowDynastySlugs,
+  fetchFeatureDynastyMap,
+  fetchWorkflowDynastyMap,
+} from "../lib/dynasty-client.js";
 
-const VALID_GROUP_BY = ["campaignId", "brandId"] as const;
+const VALID_GROUP_BY = [
+  "campaignId",
+  "brandId",
+  "workflowSlug",
+  "featureSlug",
+  "workflowDynastySlug",
+  "featureDynastySlug",
+] as const;
 type GroupByField = (typeof VALID_GROUP_BY)[number];
 
 const COLUMN_MAP = {
   campaignId: { served: servedLeads.campaignId, buffer: leadBuffer.campaignId },
   brandId: { served: servedLeads.brandId, buffer: leadBuffer.brandId },
+  workflowSlug: { served: servedLeads.workflowSlug, buffer: leadBuffer.workflowSlug },
+  featureSlug: { served: servedLeads.featureSlug, buffer: leadBuffer.featureSlug },
 } as const;
 
 const router = Router();
 
+/**
+ * Resolve dynasty slug query params into lists of versioned slugs.
+ * Dynasty slugs take priority over exact slugs.
+ */
+async function resolveDynastySlugs(
+  req: AuthenticatedRequest,
+): Promise<{
+  workflowSlugs: string[] | null;
+  featureSlugs: string[] | null;
+  emptyDynasty: boolean;
+}> {
+  const str = (v: unknown): string | undefined =>
+    typeof v === "string" ? v : undefined;
+
+  const workflowDynastySlug = str(req.query.workflowDynastySlug);
+  const featureDynastySlug = str(req.query.featureDynastySlug);
+  const workflowSlug = str(req.query.workflowSlug);
+  const featureSlug = str(req.query.featureSlug);
+
+  const context = { orgId: req.orgId, userId: req.userId, runId: req.runId };
+
+  let workflowSlugs: string[] | null = null;
+  let featureSlugs: string[] | null = null;
+
+  if (workflowDynastySlug) {
+    workflowSlugs = await resolveWorkflowDynastySlugs(workflowDynastySlug, context);
+    if (workflowSlugs.length === 0) return { workflowSlugs: [], featureSlugs: null, emptyDynasty: true };
+  } else if (workflowSlug) {
+    workflowSlugs = [workflowSlug];
+  }
+
+  if (featureDynastySlug) {
+    featureSlugs = await resolveFeatureDynastySlugs(featureDynastySlug, context);
+    if (featureSlugs.length === 0) return { workflowSlugs, featureSlugs: [], emptyDynasty: true };
+  } else if (featureSlug) {
+    featureSlugs = [featureSlug];
+  }
+
+  return { workflowSlugs, featureSlugs, emptyDynasty: false };
+}
+
 function buildConditions(
   req: AuthenticatedRequest,
   table: "served" | "buffer",
+  dynastyResolved: { workflowSlugs: string[] | null; featureSlugs: string[] | null },
 ) {
   const { brandId, campaignId, orgId, userId, runIds } = req.query;
   const str = (v: unknown): string | undefined =>
@@ -48,6 +105,12 @@ function buildConditions(
         )!,
       );
     }
+    if (dynastyResolved.workflowSlugs && dynastyResolved.workflowSlugs.length > 0) {
+      conds.push(inArray(servedLeads.workflowSlug, dynastyResolved.workflowSlugs));
+    }
+    if (dynastyResolved.featureSlugs && dynastyResolved.featureSlugs.length > 0) {
+      conds.push(inArray(servedLeads.featureSlug, dynastyResolved.featureSlugs));
+    }
     return { conds, runIdList, brandIdStr, campaignIdStr, orgIdStr };
   }
 
@@ -58,6 +121,12 @@ function buildConditions(
   if (userIdStr) conds.push(eq(leadBuffer.userId, userIdStr));
   if (runIdList.length > 0) {
     conds.push(inArray(leadBuffer.pushRunId, runIdList));
+  }
+  if (dynastyResolved.workflowSlugs && dynastyResolved.workflowSlugs.length > 0) {
+    conds.push(inArray(leadBuffer.workflowSlug, dynastyResolved.workflowSlugs));
+  }
+  if (dynastyResolved.featureSlugs && dynastyResolved.featureSlugs.length > 0) {
+    conds.push(inArray(leadBuffer.featureSlug, dynastyResolved.featureSlugs));
   }
   return { conds, runIdList, brandIdStr, campaignIdStr, orgIdStr };
 }
@@ -119,11 +188,11 @@ async function countContacted(
 }
 
 /**
- * Count contacted leads per groupBy dimension (brandId or campaignId).
+ * Count contacted leads per groupBy dimension.
  */
 async function countContactedGrouped(
   servedConds: SQL[],
-  groupByField: GroupByField,
+  groupByField: "campaignId" | "brandId" | "workflowSlug" | "featureSlug",
   context: ServiceContext,
 ): Promise<Map<string, number>> {
   const groupCol = COLUMN_MAP[groupByField].served;
@@ -189,6 +258,8 @@ async function countContactedGrouped(
   return result;
 }
 
+const ZERO_STATS = { groups: [] };
+
 router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
   try {
     const groupByParam =
@@ -201,13 +272,90 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
       return;
     }
 
-    const served = buildConditions(req, "served");
-    const buffer = buildConditions(req, "buffer");
+    // Resolve dynasty slugs (if provided) before building conditions
+    const dynastyResolved = await resolveDynastySlugs(req);
+    if (dynastyResolved.emptyDynasty) {
+      // Dynasty resolved to zero slugs — return zero stats immediately
+      if (groupByParam) {
+        res.json(ZERO_STATS);
+      } else {
+        res.json({
+          served: 0,
+          contacted: 0,
+          buffered: 0,
+          skipped: 0,
+          apollo: { enrichedLeadsCount: 0, searchCount: 0, fetchedPeopleCount: 0, totalMatchingPeople: 0 },
+        });
+      }
+      return;
+    }
+
+    const served = buildConditions(req, "served", dynastyResolved);
+    const buffer = buildConditions(req, "buffer", dynastyResolved);
     const egContext = getServiceContext(req);
 
-    // --- Grouped response ---
+    // --- Dynasty groupBy (requires reverse map) ---
+    if (groupByParam === "workflowDynastySlug" || groupByParam === "featureDynastySlug") {
+      const isWorkflow = groupByParam === "workflowDynastySlug";
+      const dbField = isWorkflow ? "workflowSlug" : "featureSlug";
+      const servedCol = COLUMN_MAP[dbField].served;
+      const bufferCol = COLUMN_MAP[dbField].buffer;
+      const context = { orgId: req.orgId, userId: req.userId, runId: req.runId };
+
+      const [dynastyMap, servedRows, contactedMap, bufferRows] = await Promise.all([
+        isWorkflow ? fetchWorkflowDynastyMap(context) : fetchFeatureDynastyMap(context),
+        db
+          .select({ key: servedCol, count: count() })
+          .from(servedLeads)
+          .where(and(...served.conds))
+          .groupBy(servedCol),
+        countContactedGrouped(served.conds, dbField, egContext),
+        db
+          .select({ key: bufferCol, status: leadBuffer.status, count: count() })
+          .from(leadBuffer)
+          .where(and(...buffer.conds))
+          .groupBy(bufferCol, leadBuffer.status),
+      ]);
+
+      // Aggregate by dynasty slug using reverse map
+      const groups = new Map<
+        string,
+        { served: number; contacted: number; buffered: number; skipped: number }
+      >();
+
+      const getGroup = (dynastyKey: string) => {
+        if (!groups.has(dynastyKey))
+          groups.set(dynastyKey, { served: 0, contacted: 0, buffered: 0, skipped: 0 });
+        return groups.get(dynastyKey)!;
+      };
+
+      const toDynasty = (slug: string | null): string =>
+        dynastyMap.get(slug ?? "") ?? slug ?? "unknown";
+
+      for (const row of servedRows) {
+        getGroup(toDynasty(row.key)).served += row.count;
+      }
+      for (const [key, contacted] of contactedMap) {
+        getGroup(toDynasty(key)).contacted += contacted;
+      }
+      for (const row of bufferRows) {
+        const g = getGroup(toDynasty(row.key));
+        if (row.status === "buffered") g.buffered += row.count;
+        if (row.status === "skipped") g.skipped += row.count;
+      }
+
+      res.json({
+        groups: Array.from(groups.entries()).map(([key, stats]) => ({
+          key,
+          ...stats,
+        })),
+      });
+      return;
+    }
+
+    // --- Standard groupBy (exact slug columns) ---
     if (groupByParam) {
-      const field = groupByParam as GroupByField;
+      const field = groupByParam as keyof typeof COLUMN_MAP;
       const servedCol = COLUMN_MAP[field].served;
       const bufferCol = COLUMN_MAP[field].buffer;
 
@@ -296,7 +444,7 @@ router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
       apollo,
     });
   } catch (error) {
-    console.error("[stats] Error:", error);
+    console.error("[lead-service] Stats error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -453,11 +453,51 @@ registry.registerPath({
     },
     {
       in: "query" as const,
+      name: "workflowSlug",
+      required: false,
+      description: "Filter by exact workflow slug",
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
+      name: "featureSlug",
+      required: false,
+      description: "Filter by exact feature slug",
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
+      name: "workflowDynastySlug",
+      required: false,
+      description:
+        "Filter by workflow dynasty slug. Resolved to all versioned slugs via workflow-service, then filtered with WHERE IN (...). Takes priority over workflowSlug.",
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
+      name: "featureDynastySlug",
+      required: false,
+      description:
+        "Filter by feature dynasty slug. Resolved to all versioned slugs via features-service, then filtered with WHERE IN (...). Takes priority over featureSlug.",
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
       name: "groupBy",
       required: false,
       description:
-        "Group stats by this dimension. When set, returns { groups: [...] } instead of flat stats. Allowed values: campaignId, brandId",
-      schema: { type: "string" as const, enum: ["campaignId", "brandId"] },
+        "Group stats by this dimension. When set, returns { groups: [...] } instead of flat stats.",
+      schema: {
+        type: "string" as const,
+        enum: [
+          "campaignId",
+          "brandId",
+          "workflowSlug",
+          "featureSlug",
+          "workflowDynastySlug",
+          "featureDynastySlug",
+        ],
+      },
     },
   ],
   responses: {

--- a/tests/unit/dynasty-client.test.ts
+++ b/tests/unit/dynasty-client.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Set env vars before importing
+process.env.FEATURES_SERVICE_URL = "http://features:3010";
+process.env.FEATURES_SERVICE_API_KEY = "feat-key";
+process.env.WORKFLOW_SERVICE_URL = "http://workflows:3002";
+process.env.WORKFLOW_SERVICE_API_KEY = "wf-key";
+
+const {
+  resolveFeatureDynastySlugs,
+  resolveWorkflowDynastySlugs,
+  fetchFeatureDynastyMap,
+  fetchWorkflowDynastyMap,
+} = await import("../../src/lib/dynasty-client.js");
+
+describe("dynasty-client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("resolveFeatureDynastySlugs", () => {
+    it("returns slugs from features-service", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ slugs: ["feat-alpha", "feat-alpha-v2", "feat-alpha-v3"] }),
+      });
+
+      const result = await resolveFeatureDynastySlugs("feat-alpha");
+      expect(result).toEqual(["feat-alpha", "feat-alpha-v2", "feat-alpha-v3"]);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://features:3010/features/dynasty/slugs?dynastySlug=feat-alpha",
+        expect.objectContaining({
+          headers: expect.objectContaining({ "X-API-Key": "feat-key" }),
+        }),
+      );
+    });
+
+    it("passes context headers when provided", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ slugs: ["s1"] }),
+      });
+
+      await resolveFeatureDynastySlugs("s1", { orgId: "org-1", userId: "user-1", runId: "run-1" });
+      const headers = mockFetch.mock.calls[0][1].headers;
+      expect(headers["x-org-id"]).toBe("org-1");
+      expect(headers["x-user-id"]).toBe("user-1");
+      expect(headers["x-run-id"]).toBe("run-1");
+    });
+
+    it("returns empty array on non-ok response", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+      const result = await resolveFeatureDynastySlugs("unknown");
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array on fetch error", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("network error"));
+      const result = await resolveFeatureDynastySlugs("fail");
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("resolveWorkflowDynastySlugs", () => {
+    it("returns slugs from workflow-service", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ slugs: ["cold-email", "cold-email-v2"] }),
+      });
+
+      const result = await resolveWorkflowDynastySlugs("cold-email");
+      expect(result).toEqual(["cold-email", "cold-email-v2"]);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://workflows:3002/workflows/dynasty/slugs?dynastySlug=cold-email",
+        expect.objectContaining({
+          headers: expect.objectContaining({ "X-API-Key": "wf-key" }),
+        }),
+      );
+    });
+
+    it("returns empty array on non-ok response", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+      const result = await resolveWorkflowDynastySlugs("broken");
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("fetchFeatureDynastyMap", () => {
+    it("builds reverse map from dynasties", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          dynasties: [
+            { dynastySlug: "feat-alpha", slugs: ["feat-alpha", "feat-alpha-v2"] },
+            { dynastySlug: "feat-beta", slugs: ["feat-beta"] },
+          ],
+        }),
+      });
+
+      const map = await fetchFeatureDynastyMap();
+      expect(map.get("feat-alpha")).toBe("feat-alpha");
+      expect(map.get("feat-alpha-v2")).toBe("feat-alpha");
+      expect(map.get("feat-beta")).toBe("feat-beta");
+      expect(map.get("unknown-slug")).toBeUndefined();
+    });
+
+    it("returns empty map on error", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("fail"));
+      const map = await fetchFeatureDynastyMap();
+      expect(map.size).toBe(0);
+    });
+  });
+
+  describe("fetchWorkflowDynastyMap", () => {
+    it("builds reverse map from workflow dynasties", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          dynasties: [
+            { dynastySlug: "cold-email", slugs: ["cold-email", "cold-email-v2", "cold-email-v3"] },
+          ],
+        }),
+      });
+
+      const map = await fetchWorkflowDynastyMap();
+      expect(map.get("cold-email")).toBe("cold-email");
+      expect(map.get("cold-email-v2")).toBe("cold-email");
+      expect(map.get("cold-email-v3")).toBe("cold-email");
+    });
+  });
+});

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -39,6 +39,18 @@ vi.mock("../../src/lib/email-gateway-client.js", () => ({
     !!(result.broadcast?.campaign.lead.contacted),
 }));
 
+const mockResolveFeatureDynastySlugs = vi.fn();
+const mockResolveWorkflowDynastySlugs = vi.fn();
+const mockFetchFeatureDynastyMap = vi.fn();
+const mockFetchWorkflowDynastyMap = vi.fn();
+
+vi.mock("../../src/lib/dynasty-client.js", () => ({
+  resolveFeatureDynastySlugs: (...args: unknown[]) => mockResolveFeatureDynastySlugs(...args),
+  resolveWorkflowDynastySlugs: (...args: unknown[]) => mockResolveWorkflowDynastySlugs(...args),
+  fetchFeatureDynastyMap: (...args: unknown[]) => mockFetchFeatureDynastyMap(...args),
+  fetchWorkflowDynastyMap: (...args: unknown[]) => mockFetchWorkflowDynastyMap(...args),
+}));
+
 vi.mock("../../src/middleware/auth.js", () => ({
   authenticate: (_req: unknown, _res: unknown, next: () => void) => next(),
   getServiceContext: (req: any) => ({
@@ -82,6 +94,11 @@ describe("GET /stats", () => {
     // Default: all queries return zero/empty
     mockWhere.mockReturnValue(queryResult([{ count: 0 }]));
     mockCheckDeliveryStatus.mockResolvedValue(null);
+    // Default dynasty mocks
+    mockResolveFeatureDynastySlugs.mockResolvedValue([]);
+    mockResolveWorkflowDynastySlugs.mockResolvedValue([]);
+    mockFetchFeatureDynastyMap.mockResolvedValue(new Map());
+    mockFetchWorkflowDynastyMap.mockResolvedValue(new Map());
   });
 
   it("returns 400 for invalid groupBy value", async () => {
@@ -102,6 +119,20 @@ describe("GET /stats", () => {
   it("accepts groupBy=brandId", async () => {
     const app = createApp();
     const res = await request(app).get("/stats?groupBy=brandId");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("groups");
+  });
+
+  it("accepts groupBy=workflowSlug", async () => {
+    const app = createApp();
+    const res = await request(app).get("/stats?groupBy=workflowSlug");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("groups");
+  });
+
+  it("accepts groupBy=featureSlug", async () => {
+    const app = createApp();
+    const res = await request(app).get("/stats?groupBy=featureSlug");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
   });
@@ -195,5 +226,127 @@ describe("GET /stats", () => {
     expect(res.status).toBe(200);
     expect(res.body.served).toBe(1);
     expect(res.body.contacted).toBe(0);
+  });
+
+  // --- Dynasty slug filtering ---
+
+  it("filters by workflowSlug query param", async () => {
+    const app = createApp();
+    const res = await request(app).get("/stats?workflowSlug=cold-email-v2");
+    expect(res.status).toBe(200);
+    // Verify dynasty resolver was NOT called (exact slug, not dynasty)
+    expect(mockResolveWorkflowDynastySlugs).not.toHaveBeenCalled();
+  });
+
+  it("filters by featureSlug query param", async () => {
+    const app = createApp();
+    const res = await request(app).get("/stats?featureSlug=feat-alpha");
+    expect(res.status).toBe(200);
+    expect(mockResolveFeatureDynastySlugs).not.toHaveBeenCalled();
+  });
+
+  it("resolves workflowDynastySlug to versioned slugs", async () => {
+    mockResolveWorkflowDynastySlugs.mockResolvedValue(["cold-email", "cold-email-v2"]);
+
+    const app = createApp();
+    const res = await request(app).get("/stats?workflowDynastySlug=cold-email");
+    expect(res.status).toBe(200);
+    expect(mockResolveWorkflowDynastySlugs).toHaveBeenCalledWith("cold-email", expect.any(Object));
+  });
+
+  it("resolves featureDynastySlug to versioned slugs", async () => {
+    mockResolveFeatureDynastySlugs.mockResolvedValue(["feat-alpha", "feat-alpha-v2"]);
+
+    const app = createApp();
+    const res = await request(app).get("/stats?featureDynastySlug=feat-alpha");
+    expect(res.status).toBe(200);
+    expect(mockResolveFeatureDynastySlugs).toHaveBeenCalledWith("feat-alpha", expect.any(Object));
+  });
+
+  it("returns zero stats when workflowDynastySlug resolves to empty list", async () => {
+    mockResolveWorkflowDynastySlugs.mockResolvedValue([]);
+
+    const app = createApp();
+    const res = await request(app).get("/stats?workflowDynastySlug=nonexistent");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      served: 0,
+      contacted: 0,
+      buffered: 0,
+      skipped: 0,
+      apollo: { enrichedLeadsCount: 0, searchCount: 0, fetchedPeopleCount: 0, totalMatchingPeople: 0 },
+    });
+    // Should NOT hit the database
+    expect(mockWhere).not.toHaveBeenCalled();
+  });
+
+  it("returns zero stats when featureDynastySlug resolves to empty list", async () => {
+    mockResolveFeatureDynastySlugs.mockResolvedValue([]);
+
+    const app = createApp();
+    const res = await request(app).get("/stats?featureDynastySlug=nonexistent");
+    expect(res.status).toBe(200);
+    expect(res.body.served).toBe(0);
+    expect(mockWhere).not.toHaveBeenCalled();
+  });
+
+  it("returns empty groups for grouped empty dynasty", async () => {
+    mockResolveWorkflowDynastySlugs.mockResolvedValue([]);
+
+    const app = createApp();
+    const res = await request(app).get("/stats?workflowDynastySlug=nonexistent&groupBy=campaignId");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ groups: [] });
+  });
+
+  it("workflowDynastySlug takes priority over workflowSlug", async () => {
+    mockResolveWorkflowDynastySlugs.mockResolvedValue(["cold-email", "cold-email-v2"]);
+
+    const app = createApp();
+    const res = await request(app).get("/stats?workflowDynastySlug=cold-email&workflowSlug=cold-email-v2");
+    expect(res.status).toBe(200);
+    // Dynasty resolver should be called (takes priority)
+    expect(mockResolveWorkflowDynastySlugs).toHaveBeenCalledWith("cold-email", expect.any(Object));
+  });
+
+  // --- Dynasty groupBy ---
+
+  it("accepts groupBy=workflowDynastySlug and fetches dynasty map", async () => {
+    mockFetchWorkflowDynastyMap.mockResolvedValue(
+      new Map([
+        ["cold-email", "cold-email"],
+        ["cold-email-v2", "cold-email"],
+      ]),
+    );
+
+    const app = createApp();
+    const res = await request(app).get("/stats?groupBy=workflowDynastySlug");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("groups");
+    expect(mockFetchWorkflowDynastyMap).toHaveBeenCalled();
+  });
+
+  it("accepts groupBy=featureDynastySlug and fetches dynasty map", async () => {
+    mockFetchFeatureDynastyMap.mockResolvedValue(
+      new Map([
+        ["feat-alpha", "feat-alpha"],
+        ["feat-alpha-v2", "feat-alpha"],
+      ]),
+    );
+
+    const app = createApp();
+    const res = await request(app).get("/stats?groupBy=featureDynastySlug");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("groups");
+    expect(mockFetchFeatureDynastyMap).toHaveBeenCalled();
+  });
+
+  it("combines workflowDynastySlug filter with other filters", async () => {
+    mockResolveWorkflowDynastySlugs.mockResolvedValue(["cold-email", "cold-email-v2"]);
+
+    const app = createApp();
+    const res = await request(app).get("/stats?workflowDynastySlug=cold-email&brandId=b1&campaignId=c1");
+    expect(res.status).toBe(200);
+    expect(mockResolveWorkflowDynastySlugs).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Add `workflowDynastySlug` and `featureDynastySlug` query params for filtering `/stats` (resolved to versioned slugs via workflow-service and features-service)
- Add `workflowSlug` and `featureSlug` exact-match filter params
- Add `groupBy` support for `workflowSlug`, `featureSlug`, `workflowDynastySlug`, `featureDynastySlug` (dynasty groupBy uses reverse map aggregation)
- Empty dynasty resolution returns zero stats immediately (no DB hit)
- New `dynasty-client.ts` with resolve + dynasty map functions
- Updated OpenAPI spec with all new query params

## Env vars required (Railway)
- `FEATURES_SERVICE_URL` + `FEATURES_SERVICE_API_KEY`
- `WORKFLOW_SERVICE_URL` + `WORKFLOW_SERVICE_API_KEY`

## Test plan
- [x] Unit tests for dynasty-client (resolve slugs, fetch dynasty maps, error handling)
- [x] Unit tests for stats: filter by workflowSlug, featureSlug, workflowDynastySlug, featureDynastySlug
- [x] Unit tests for stats: empty dynasty → zero stats
- [x] Unit tests for stats: groupBy workflowDynastySlug and featureDynastySlug
- [x] Unit tests for stats: dynasty slug takes priority over exact slug
- [x] All 139 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)