### PR TITLE
Crash at startup on missing env vars

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,55 @@
+/**
+ * Centralized environment configuration.
+ * Validates all required env vars at import time — if anything is missing,
+ * the process crashes immediately instead of failing silently at runtime.
+ */
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`[lead-service] Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function optional(name: string, fallback: string): string {
+  return process.env[name] || fallback;
+}
+
+// --- Core ---
+export const PORT = optional("PORT", "3006");
+export const LEAD_SERVICE_API_KEY = required("LEAD_SERVICE_API_KEY");
+
+// --- Database (validated separately in db/index.ts) ---
+// LEAD_SERVICE_DATABASE_URL is validated in db/index.ts at import time
+
+// --- Downstream services ---
+export const APOLLO_SERVICE_URL = required("APOLLO_SERVICE_URL");
+export const APOLLO_SERVICE_API_KEY = required("APOLLO_SERVICE_API_KEY");
+
+export const BRAND_SERVICE_URL = required("BRAND_SERVICE_URL");
+export const BRAND_SERVICE_API_KEY = required("BRAND_SERVICE_API_KEY");
+
+export const CAMPAIGN_SERVICE_URL = required("CAMPAIGN_SERVICE_URL");
+export const CAMPAIGN_SERVICE_API_KEY = required("CAMPAIGN_SERVICE_API_KEY");
+
+export const EMAIL_GATEWAY_SERVICE_URL = required("EMAIL_GATEWAY_SERVICE_URL");
+export const EMAIL_GATEWAY_SERVICE_API_KEY = required("EMAIL_GATEWAY_SERVICE_API_KEY");
+
+export const JOURNALISTS_SERVICE_URL = required("JOURNALISTS_SERVICE_URL");
+export const JOURNALISTS_SERVICE_API_KEY = required("JOURNALISTS_SERVICE_API_KEY");
+
+export const OUTLETS_SERVICE_URL = required("OUTLETS_SERVICE_URL");
+export const OUTLETS_SERVICE_API_KEY = required("OUTLETS_SERVICE_API_KEY");
+
+export const RUNS_SERVICE_URL = required("RUNS_SERVICE_URL");
+export const RUNS_SERVICE_API_KEY = required("RUNS_SERVICE_API_KEY");
+
+export const KEY_SERVICE_URL = required("KEY_SERVICE_URL");
+export const KEY_SERVICE_API_KEY = required("KEY_SERVICE_API_KEY");
+
+export const FEATURES_SERVICE_URL = required("FEATURES_SERVICE_URL");
+export const FEATURES_SERVICE_API_KEY = required("FEATURES_SERVICE_API_KEY");
+
+export const WORKFLOW_SERVICE_URL = required("WORKFLOW_SERVICE_URL");
+export const WORKFLOW_SERVICE_API_KEY = required("WORKFLOW_SERVICE_API_KEY");

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import { db, sql } from "./db/index.js";
+import { PORT } from "./config.js";
 import healthRoutes from "./routes/health.js";
 import bufferRoutes from "./routes/buffer.js";
 import cursorRoutes from "./routes/cursor.js";
@@ -18,7 +19,6 @@ const __dirname = dirname(__filename);
 const openapiPath = join(__dirname, "..", "openapi.json");
 
 const app = express();
-const PORT = process.env.PORT || 3006;
 
 app.use(cors());
 app.use(express.json());

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -1,5 +1,4 @@
-const APOLLO_SERVICE_URL = process.env.APOLLO_SERVICE_URL || "http://localhost:3003";
-const APOLLO_SERVICE_API_KEY = process.env.APOLLO_SERVICE_API_KEY || "";
+import { APOLLO_SERVICE_URL, APOLLO_SERVICE_API_KEY } from "../config.js";
 
 async function callApolloService<T>(
   path: string,

--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -1,5 +1,4 @@
-const BRAND_SERVICE_URL = process.env.BRAND_SERVICE_URL || "http://localhost:3005";
-const BRAND_SERVICE_API_KEY = process.env.BRAND_SERVICE_API_KEY || "";
+import { BRAND_SERVICE_URL, BRAND_SERVICE_API_KEY } from "../config.js";
 
 export interface BrandDetails {
   id: string;

--- a/src/lib/campaign-client.ts
+++ b/src/lib/campaign-client.ts
@@ -1,5 +1,4 @@
-const CAMPAIGN_SERVICE_URL = process.env.CAMPAIGN_SERVICE_URL || "http://localhost:3003";
-const CAMPAIGN_SERVICE_API_KEY = process.env.CAMPAIGN_SERVICE_API_KEY || "";
+import { CAMPAIGN_SERVICE_URL, CAMPAIGN_SERVICE_API_KEY } from "../config.js";
 
 export interface CampaignDetails {
   id: string;

--- a/src/lib/dynasty-client.ts
+++ b/src/lib/dynasty-client.ts
@@ -1,7 +1,9 @@
-const FEATURES_SERVICE_URL = process.env.FEATURES_SERVICE_URL || "http://localhost:3010";
-const FEATURES_SERVICE_API_KEY = process.env.FEATURES_SERVICE_API_KEY || "";
-const WORKFLOW_SERVICE_URL = process.env.WORKFLOW_SERVICE_URL || "http://localhost:3002";
-const WORKFLOW_SERVICE_API_KEY = process.env.WORKFLOW_SERVICE_API_KEY || "";
+import {
+  FEATURES_SERVICE_URL,
+  FEATURES_SERVICE_API_KEY,
+  WORKFLOW_SERVICE_URL,
+  WORKFLOW_SERVICE_API_KEY,
+} from "../config.js";
 
 interface DynastyEntry {
   dynastySlug: string;

--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -1,7 +1,4 @@
-const EMAIL_GATEWAY_SERVICE_URL =
-  process.env.EMAIL_GATEWAY_SERVICE_URL || "http://localhost:3009";
-const EMAIL_GATEWAY_SERVICE_API_KEY =
-  process.env.EMAIL_GATEWAY_SERVICE_API_KEY || "";
+import { EMAIL_GATEWAY_SERVICE_URL, EMAIL_GATEWAY_SERVICE_API_KEY } from "../config.js";
 
 export interface DeliveryStatusItem {
   leadId: string;

--- a/src/lib/journalist-client.ts
+++ b/src/lib/journalist-client.ts
@@ -1,5 +1,4 @@
-const JOURNALISTS_SERVICE_URL = process.env.JOURNALISTS_SERVICE_URL || "http://localhost:3011";
-const JOURNALISTS_SERVICE_API_KEY = process.env.JOURNALISTS_SERVICE_API_KEY || "";
+import { JOURNALISTS_SERVICE_URL, JOURNALISTS_SERVICE_API_KEY } from "../config.js";
 
 export interface JournalistEmail {
   email: string;

--- a/src/lib/key-service-client.ts
+++ b/src/lib/key-service-client.ts
@@ -1,10 +1,7 @@
+import { KEY_SERVICE_URL, KEY_SERVICE_API_KEY } from "../config.js";
+
 function getKeyServiceConfig() {
-  const url = process.env.KEY_SERVICE_URL;
-  const apiKey = process.env.KEY_SERVICE_API_KEY;
-  if (!url || !apiKey) {
-    throw new Error("KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set");
-  }
-  return { url, apiKey };
+  return { url: KEY_SERVICE_URL, apiKey: KEY_SERVICE_API_KEY };
 }
 
 export interface ProviderRequirement {

--- a/src/lib/outlet-client.ts
+++ b/src/lib/outlet-client.ts
@@ -1,5 +1,4 @@
-const OUTLETS_SERVICE_URL = process.env.OUTLETS_SERVICE_URL || "http://localhost:3010";
-const OUTLETS_SERVICE_API_KEY = process.env.OUTLETS_SERVICE_API_KEY || "";
+import { OUTLETS_SERVICE_URL, OUTLETS_SERVICE_API_KEY } from "../config.js";
 
 export interface OutletDetails {
   id: string;

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -1,5 +1,4 @@
-const RUNS_SERVICE_URL = process.env.RUNS_SERVICE_URL || "https://runs.distribute.org";
-const RUNS_SERVICE_API_KEY = process.env.RUNS_SERVICE_API_KEY || "";
+import { RUNS_SERVICE_URL, RUNS_SERVICE_API_KEY } from "../config.js";
 
 async function callRunsService(path: string, options: {
   method?: string;

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from "express";
+import { LEAD_SERVICE_API_KEY } from "../config.js";
 
 export interface ServiceContext {
   orgId?: string;
@@ -39,7 +40,7 @@ export async function authenticate(
 ) {
   try {
     const apiKey = req.headers["x-api-key"] as string;
-    if (!apiKey || apiKey !== process.env.LEAD_SERVICE_API_KEY) {
+    if (!apiKey || apiKey !== LEAD_SERVICE_API_KEY) {
       return res.status(401).json({ error: "Invalid API key" });
     }
 

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -24,6 +24,7 @@ vi.mock("../../src/lib/email-gateway-client.js", () => ({
 
 describe("API Integration Tests", () => {
   beforeAll(async () => {
+    // LEAD_SERVICE_API_KEY is set by tests/setup.ts; override with test-specific key
     process.env.LEAD_SERVICE_API_KEY = TEST_API_KEY;
   });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,36 @@
+/**
+ * Vitest global setup — sets all required env vars before any module imports.
+ * This prevents config.ts from throwing during test runs.
+ */
+
+const TEST_ENV_VARS: Record<string, string> = {
+  LEAD_SERVICE_API_KEY: "test-api-key",
+  LEAD_SERVICE_DATABASE_URL: "postgresql://test:test@localhost:5432/test",
+  APOLLO_SERVICE_URL: "http://apollo:3003",
+  APOLLO_SERVICE_API_KEY: "test-apollo-key",
+  BRAND_SERVICE_URL: "http://brand:3005",
+  BRAND_SERVICE_API_KEY: "test-brand-key",
+  CAMPAIGN_SERVICE_URL: "http://campaign:3003",
+  CAMPAIGN_SERVICE_API_KEY: "test-campaign-key",
+  EMAIL_GATEWAY_SERVICE_URL: "http://email-gateway:3009",
+  EMAIL_GATEWAY_SERVICE_API_KEY: "test-email-gateway-key",
+  JOURNALISTS_SERVICE_URL: "http://journalists:3011",
+  JOURNALISTS_SERVICE_API_KEY: "test-journalists-key",
+  OUTLETS_SERVICE_URL: "http://outlets:3010",
+  OUTLETS_SERVICE_API_KEY: "test-outlets-key",
+  RUNS_SERVICE_URL: "http://runs:3007",
+  RUNS_SERVICE_API_KEY: "test-runs-key",
+  KEY_SERVICE_URL: "http://key-service:3001",
+  KEY_SERVICE_API_KEY: "test-key-service-key",
+  FEATURES_SERVICE_URL: "http://features:3010",
+  FEATURES_SERVICE_API_KEY: "test-features-key",
+  WORKFLOW_SERVICE_URL: "http://workflows:3002",
+  WORKFLOW_SERVICE_API_KEY: "test-workflows-key",
+  NODE_ENV: "test",
+};
+
+for (const [key, value] of Object.entries(TEST_ENV_VARS)) {
+  if (!process.env[key]) {
+    process.env[key] = value;
+  }
+}

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("config", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("exports all required env vars when they are set", async () => {
+    const config = await import("../../src/config.js");
+
+    expect(config.APOLLO_SERVICE_URL).toBe(process.env.APOLLO_SERVICE_URL);
+    expect(config.APOLLO_SERVICE_API_KEY).toBe(process.env.APOLLO_SERVICE_API_KEY);
+    expect(config.BRAND_SERVICE_URL).toBe(process.env.BRAND_SERVICE_URL);
+    expect(config.JOURNALISTS_SERVICE_URL).toBe(process.env.JOURNALISTS_SERVICE_URL);
+    expect(config.OUTLETS_SERVICE_URL).toBe(process.env.OUTLETS_SERVICE_URL);
+    expect(config.EMAIL_GATEWAY_SERVICE_URL).toBe(process.env.EMAIL_GATEWAY_SERVICE_URL);
+    expect(config.RUNS_SERVICE_URL).toBe(process.env.RUNS_SERVICE_URL);
+    expect(config.KEY_SERVICE_URL).toBe(process.env.KEY_SERVICE_URL);
+    expect(config.LEAD_SERVICE_API_KEY).toBe(process.env.LEAD_SERVICE_API_KEY);
+  });
+
+  it("throws when a required env var is missing", async () => {
+    const original = process.env.JOURNALISTS_SERVICE_URL;
+    delete process.env.JOURNALISTS_SERVICE_URL;
+
+    try {
+      await expect(
+        import("../../src/config.js")
+      ).rejects.toThrow("Missing required environment variable: JOURNALISTS_SERVICE_URL");
+    } finally {
+      process.env.JOURNALISTS_SERVICE_URL = original;
+    }
+  });
+
+  it("throws when a required env var is empty string", async () => {
+    const original = process.env.APOLLO_SERVICE_API_KEY;
+    process.env.APOLLO_SERVICE_API_KEY = "";
+
+    try {
+      await expect(
+        import("../../src/config.js")
+      ).rejects.toThrow("Missing required environment variable: APOLLO_SERVICE_API_KEY");
+    } finally {
+      process.env.APOLLO_SERVICE_API_KEY = original;
+    }
+  });
+});

--- a/tests/unit/dynasty-client.test.ts
+++ b/tests/unit/dynasty-client.test.ts
@@ -3,11 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-// Set env vars before importing
-process.env.FEATURES_SERVICE_URL = "http://features:3010";
-process.env.FEATURES_SERVICE_API_KEY = "feat-key";
-process.env.WORKFLOW_SERVICE_URL = "http://workflows:3002";
-process.env.WORKFLOW_SERVICE_API_KEY = "wf-key";
+// Env vars are set by tests/setup.ts before module imports
 
 const {
   resolveFeatureDynastySlugs,
@@ -33,7 +29,7 @@ describe("dynasty-client", () => {
       expect(mockFetch).toHaveBeenCalledWith(
         "http://features:3010/features/dynasty/slugs?dynastySlug=feat-alpha",
         expect.objectContaining({
-          headers: expect.objectContaining({ "X-API-Key": "feat-key" }),
+          headers: expect.objectContaining({ "X-API-Key": process.env.FEATURES_SERVICE_API_KEY }),
         }),
       );
     });
@@ -76,7 +72,7 @@ describe("dynasty-client", () => {
       expect(mockFetch).toHaveBeenCalledWith(
         "http://workflows:3002/workflows/dynasty/slugs?dynastySlug=cold-email",
         expect.objectContaining({
-          headers: expect.objectContaining({ "X-API-Key": "wf-key" }),
+          headers: expect.objectContaining({ "X-API-Key": process.env.WORKFLOW_SERVICE_API_KEY }),
         }),
       );
     });

--- a/tests/unit/register-providers.test.ts
+++ b/tests/unit/register-providers.test.ts
@@ -3,9 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-// Set env vars before importing modules that read them
-vi.stubEnv("KEY_SERVICE_URL", "http://key-service:3001");
-vi.stubEnv("KEY_SERVICE_API_KEY", "test-key-service-api-key");
+// Env vars are set by tests/setup.ts before module imports
 
 import { queryProviderRequirements, registerProviderRequirement } from "../../src/lib/key-service-client.js";
 import { registerProviders } from "../../src/lib/register-providers.js";
@@ -17,28 +15,6 @@ describe("key-service-client", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-  });
-
-  describe("env var guard", () => {
-    it("throws when KEY_SERVICE_URL is missing", async () => {
-      vi.stubEnv("KEY_SERVICE_URL", "");
-
-      await expect(
-        queryProviderRequirements([{ service: "apollo", method: "POST", path: "/search" }])
-      ).rejects.toThrow("KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set");
-
-      vi.stubEnv("KEY_SERVICE_URL", "http://key-service:3001");
-    });
-
-    it("throws when KEY_SERVICE_API_KEY is missing", async () => {
-      vi.stubEnv("KEY_SERVICE_API_KEY", "");
-
-      await expect(
-        registerProviderRequirement("apollo", "lead", "POST", "/buffer/next")
-      ).rejects.toThrow("KEY_SERVICE_URL and KEY_SERVICE_API_KEY must be set");
-
-      vi.stubEnv("KEY_SERVICE_API_KEY", "test-key-service-api-key");
-    });
   });
 
   describe("queryProviderRequirements", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: ["./tests/setup.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Centralized all env var reads into `src/config.ts` with hard validation at import time — missing any required env var now crashes the process immediately instead of silently falling back to localhost URLs or empty API keys
- Removed `|| "http://localhost:..."` and `|| ""` fallbacks from all 10 service clients
- Added `tests/unit/config.test.ts` verifying crash behavior, updated existing tests with a shared `tests/setup.ts`

## Context
Silent env var fallbacks caused a production issue where `JOURNALISTS_SERVICE_URL` was never configured, resulting in zero journalist leads served with no error — the service happily made requests to `http://localhost:3011` which silently failed.

## Test plan
- [x] `npm run test:unit` — 140 tests pass
- [x] `npx tsc --noEmit` — clean build
- [x] New `config.test.ts` verifies: exports correct values when set, throws on missing var, throws on empty string
- [ ] Verify Railway env vars include all required vars before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)