### PR TITLE
Remove searchParams and featureInput from /buffer/next body

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -437,14 +437,6 @@
       "BufferNextRequest": {
         "type": "object",
         "properties": {
-          "campaignId": {
-            "type": "string",
-            "minLength": 1
-          },
-          "brandId": {
-            "type": "string",
-            "minLength": 1
-          },
           "sourceType": {
             "type": "string",
             "enum": [
@@ -453,35 +445,11 @@
             ],
             "default": "apollo"
           },
-          "searchParams": {
-            "type": "object",
-            "nullable": true,
-            "additionalProperties": {
-              "nullable": true
-            }
-          },
-          "featureInput": {
-            "type": "object",
-            "nullable": true,
-            "additionalProperties": {
-              "nullable": true
-            }
-          },
-          "userId": {
-            "type": "string"
-          },
-          "workflowSlug": {
-            "type": "string"
-          },
           "idempotencyKey": {
             "type": "string",
             "minLength": 1
           }
-        },
-        "required": [
-          "campaignId",
-          "brandId"
-        ]
+        }
       },
       "CursorGetResponse": {
         "type": "object",
@@ -751,7 +719,7 @@
           {
             "in": "header",
             "name": "x-campaign-id",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             },
@@ -760,7 +728,7 @@
           {
             "in": "header",
             "name": "x-brand-id",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             },

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -3,7 +3,7 @@ import { db, sql as pgSql } from "../db/index.js";
 import { leadBuffer, enrichments, cursors } from "../db/schema.js";
 import { checkContacted, markServed } from "./dedup.js";
 import { resolveOrCreateLead, findLeadByApolloPersonId } from "./leads-registry.js";
-import { apolloSearchNext, apolloEnrich, apolloMatch, apolloSearchParams, type ApolloSearchParams } from "./apollo-client.js";
+import { apolloSearchNext, apolloEnrich, apolloMatch, apolloSearchParams } from "./apollo-client.js";
 import { fetchCampaign } from "./campaign-client.js";
 import { extractBrandFields } from "./brand-client.js";
 import { fetchOutletsByCampaign, fetchNextOutlet } from "./outlet-client.js";
@@ -26,8 +26,6 @@ async function fillBufferFromSearch(params: {
   orgId: string;
   campaignId: string;
   brandId: string;
-  searchParams: ApolloSearchParams;
-  featureInput?: Record<string, unknown>;
   pushRunId?: string | null;
   userId?: string | null;
   workflowSlug?: string;
@@ -68,8 +66,8 @@ async function fillBufferFromSearch(params: {
   if (campaign?.targetOutcome) contextParts.push(`Expected outcome: ${campaign.targetOutcome}`);
   if (campaign?.valueForTarget) contextParts.push(`Value for the audience: ${campaign.valueForTarget}`);
 
-  // Inject campaign featureInputs (convention 2)
-  const featureInputs = campaign?.featureInputs ?? params.featureInput;
+  // Inject campaign featureInputs
+  const featureInputs = campaign?.featureInputs;
   if (featureInputs && Object.keys(featureInputs).length > 0) {
     contextParts.push(`Campaign context: ${JSON.stringify(featureInputs)}`);
   }
@@ -84,12 +82,6 @@ async function fillBufferFromSearch(params: {
       }
     }
   }
-
-  // Include raw searchParams as additional context
-  const rawSearch = typeof params.searchParams === "string"
-    ? params.searchParams
-    : JSON.stringify(params.searchParams);
-  contextParts.push(`Search parameters: ${rawSearch}`);
 
   const context = contextParts.join("\n");
 
@@ -260,7 +252,6 @@ async function fillBufferFromJournalists(params: {
   orgId: string;
   campaignId: string;
   brandId: string;
-  featureInput?: Record<string, unknown>;
   pushRunId?: string | null;
   userId?: string | null;
   workflowSlug?: string;
@@ -441,8 +432,6 @@ export async function pullNext(params: {
   campaignId: string;
   brandId: string;
   runId?: string | null;
-  searchParams?: ApolloSearchParams;
-  featureInput?: Record<string, unknown>;
   userId?: string | null;
   workflowSlug?: string;
   featureSlug?: string;
@@ -510,7 +499,6 @@ export async function pullNext(params: {
           orgId: params.orgId,
           campaignId: params.campaignId,
           brandId: params.brandId,
-          featureInput: params.featureInput,
           pushRunId: params.runId,
           userId: params.userId,
           workflowSlug: params.workflowSlug,
@@ -518,15 +506,10 @@ export async function pullNext(params: {
         });
         filled = result.filled;
       } else {
-        // Always attempt Apollo search — fillBufferFromSearch generates its own
-        // search params via LLM (apolloSearchParams) using campaign+brand context.
-        // Caller-provided searchParams are just additional context, not required.
         const result = await fillBufferFromSearch({
           orgId: params.orgId,
           campaignId: params.campaignId,
           brandId: params.brandId,
-          searchParams: params.searchParams ?? {},
-          featureInput: params.featureInput,
           pushRunId: params.runId,
           userId: params.userId,
           workflowSlug: params.workflowSlug,

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -52,15 +52,14 @@ export async function authenticate(
       return res.status(400).json({ error: "x-org-id, x-user-id, and x-run-id headers required" });
     }
 
-    req.orgId = orgId;
-    req.userId = userId;
-    req.runId = runId;
-
-    // Optional workflow tracking headers (injected by workflow-service)
     const campaignId = req.headers["x-campaign-id"] as string | undefined;
     const brandId = req.headers["x-brand-id"] as string | undefined;
     const workflowSlug = req.headers["x-workflow-slug"] as string | undefined;
     const featureSlug = req.headers["x-feature-slug"] as string | undefined;
+
+    req.orgId = orgId;
+    req.userId = userId;
+    req.runId = runId;
     if (campaignId) req.campaignId = campaignId;
     if (brandId) req.brandId = brandId;
     if (workflowSlug) req.workflowSlug = workflowSlug;

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -31,11 +31,17 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
     return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  try {
-    const { campaignId, brandId, searchParams, featureInput, userId, idempotencyKey, sourceType } = parsed.data;
+  // All identity/context comes from headers (injected by workflow-service)
+  const campaignId = req.campaignId;
+  const brandId = req.brandId;
 
-    // Body workflowSlug takes precedence; fall back to header injected by workflow-service
-    const workflowSlug = parsed.data.workflowSlug ?? req.workflowSlug;
+  if (!campaignId || !brandId) {
+    return res.status(400).json({ error: "x-campaign-id and x-brand-id headers required" });
+  }
+
+  try {
+    const { idempotencyKey, sourceType } = parsed.data;
+    const workflowSlug = req.workflowSlug;
 
     // Idempotency: return cached response if this key was already processed
     if (idempotencyKey) {
@@ -54,7 +60,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       serviceName: "lead-service",
       taskName: "lead-serve",
       parentRunId: req.runId!,
-      userId: userId ?? req.userId,
+      userId: req.userId,
       brandId,
       campaignId,
       workflowSlug,
@@ -67,9 +73,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       campaignId,
       brandId,
       runId: serveRunId,
-      searchParams: searchParams ?? undefined,
-      featureInput: featureInput ?? undefined,
-      userId: userId ?? req.userId ?? null,
+      userId: req.userId ?? null,
       workflowSlug,
       featureSlug: req.featureSlug,
       sourceType,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -73,6 +73,13 @@ const AuthHeaders = [
   },
 ];
 
+// buffer/next requires x-campaign-id and x-brand-id
+const BufferNextHeaders = AuthHeaders.map((h) =>
+  h.name === "x-campaign-id" || h.name === "x-brand-id"
+    ? { ...h, required: true }
+    : h
+);
+
 // --- Health ---
 
 const HealthResponseSchema = z
@@ -185,13 +192,7 @@ export const ApolloPersonDataSchema = z
 
 export const BufferNextRequestSchema = z
   .object({
-    campaignId: z.string().min(1),
-    brandId: z.string().min(1),
     sourceType: z.enum(["apollo", "journalist"]).default("apollo").optional(),
-    searchParams: z.record(z.string(), z.unknown()).nullish(),
-    featureInput: z.record(z.string(), z.unknown()).nullish(),
-    userId: z.string().optional(),
-    workflowSlug: z.string().optional(),
     idempotencyKey: z.string().min(1).optional(),
   })
   .openapi("BufferNextRequest");
@@ -317,7 +318,7 @@ registry.registerPath({
       content: { "application/json": { schema: BufferNextRequestSchema } },
     },
   },
-  parameters: AuthHeaders,
+  parameters: BufferNextHeaders,
   responses: {
     200: {
       description: "Next lead from buffer",

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -410,8 +410,6 @@ describe("buffer", () => {
         campaignId: "campaign-1",
         brandId: "brand-1",
 
-        searchParams: { description: "tech CEOs" },
-
       });
 
       expect(result.found).toBe(true);
@@ -420,7 +418,7 @@ describe("buffer", () => {
       expect(vi.mocked(apolloSearchParams)).toHaveBeenCalledOnce();
     });
 
-    it("passes featureInput as LLM context for Apollo search", async () => {
+    it("injects campaign featureInputs from campaign-service into LLM context", async () => {
       const newLeadRow = toClaimedRow({
         id: "buf-ctx-search",
         namespace: "campaign-1",
@@ -438,6 +436,20 @@ describe("buffer", () => {
         .mockResolvedValueOnce([newLeadRow]);
 
       vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
+
+      // Campaign-service returns featureInputs
+      vi.mocked(fetchCampaign).mockResolvedValueOnce({
+        id: "campaign-1",
+        name: "PR Outreach",
+        targetAudience: null,
+        targetOutcome: null,
+        valueForTarget: null,
+        featureInputs: {
+          companyContext: "AI-powered PR distribution",
+          prAngle: "Launch of new journalist outreach feature",
+          targetOutlets: ["TechCrunch", "The Verge"],
+        },
+      });
 
       vi.mocked(apolloSearchParams).mockResolvedValue({
         searchParams: { personTitles: ["Head of PR"] }, totalResults: 50, attempts: 1,
@@ -463,24 +475,18 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-        searchParams: { description: "PR contacts" },
-        featureInput: {
-          companyContext: "AI-powered PR distribution",
-          prAngle: "Launch of new journalist outreach feature",
-          targetOutlets: ["TechCrunch", "The Verge"],
-        },
       });
 
       expect(result.found).toBe(true);
 
-      // Verify the LLM context includes featureInput as JSON
+      // Verify the LLM context includes featureInputs fetched from campaign-service
       const contextArg = vi.mocked(apolloSearchParams).mock.calls[0][0].context;
       expect(contextArg).toContain("AI-powered PR distribution");
       expect(contextArg).toContain("Launch of new journalist outreach feature");
       expect(contextArg).toContain("TechCrunch");
     });
 
-    it("injects campaign featureInputs and brand extract-fields into LLM context", async () => {
+    it("fetches campaign featureInputs and brand extract-fields for LLM context", async () => {
       const newLeadRow = toClaimedRow({
         id: "buf-conv",
         namespace: "campaign-1",
@@ -543,7 +549,6 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-        searchParams: { description: "clean tech editors" },
       });
 
       expect(result.found).toBe(true);
@@ -649,8 +654,6 @@ describe("buffer", () => {
         campaignId: "campaign-1",
         brandId: "brand-1",
 
-        searchParams: { description: "community directors" },
-
       });
 
       expect(result.found).toBe(true);
@@ -680,8 +683,6 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-
-        searchParams: { description: "impossible search" },
 
       });
 
@@ -851,8 +852,6 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
-
-        searchParams: { description: "tech CEOs" },
 
         workflowSlug: "cold-email-outreach",
       });

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -3,38 +3,13 @@ import { BufferNextRequestSchema, ApolloPersonDataSchema } from "../../src/schem
 
 describe("schema validation", () => {
   describe("BufferNextRequestSchema", () => {
-    it("rejects empty brandId", () => {
-      const result = BufferNextRequestSchema.safeParse({
-        campaignId: "c1",
-        brandId: "",
-      });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        const fields = result.error.flatten().fieldErrors;
-        expect(fields.brandId).toBeDefined();
-      }
-    });
-
-    it("rejects empty campaignId", () => {
-      const result = BufferNextRequestSchema.safeParse({
-        campaignId: "",
-        brandId: "b1",
-      });
-      expect(result.success).toBe(false);
-    });
-
-    it("accepts valid request", () => {
-      const result = BufferNextRequestSchema.safeParse({
-        campaignId: "c1",
-        brandId: "b1",
-      });
+    it("accepts empty body (all fields optional)", () => {
+      const result = BufferNextRequestSchema.safeParse({});
       expect(result.success).toBe(true);
     });
 
     it("accepts optional idempotencyKey", () => {
       const result = BufferNextRequestSchema.safeParse({
-        campaignId: "c1",
-        brandId: "b1",
         idempotencyKey: "run-123",
       });
       expect(result.success).toBe(true);
@@ -42,69 +17,43 @@ describe("schema validation", () => {
 
     it("rejects empty idempotencyKey", () => {
       const result = BufferNextRequestSchema.safeParse({
-        campaignId: "c1",
-        brandId: "b1",
         idempotencyKey: "",
       });
       expect(result.success).toBe(false);
     });
 
-    it("accepts optional workflowSlug", () => {
+    it("accepts sourceType apollo", () => {
       const result = BufferNextRequestSchema.safeParse({
-        campaignId: "c1",
-        brandId: "b1",
-        workflowSlug: "cold-email-outreach",
+        sourceType: "apollo",
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.workflowSlug).toBe("cold-email-outreach");
+        expect(result.data.sourceType).toBe("apollo");
       }
     });
 
-    it("accepts null searchParams", () => {
+    it("accepts sourceType journalist", () => {
       const result = BufferNextRequestSchema.safeParse({
-        campaignId: "c1",
-        brandId: "b1",
-        searchParams: null,
+        sourceType: "journalist",
       });
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.searchParams).toBeNull();
+        expect(result.data.sourceType).toBe("journalist");
       }
     });
 
-    it("accepts optional featureInput", () => {
+    it("rejects invalid sourceType", () => {
       const result = BufferNextRequestSchema.safeParse({
-        campaignId: "c1",
-        brandId: "b1",
-        featureInput: { companyContext: "AI startup", industry: "Technology" },
+        sourceType: "invalid",
       });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.featureInput).toEqual({ companyContext: "AI startup", industry: "Technology" });
-      }
+      expect(result.success).toBe(false);
     });
 
-    it("accepts null featureInput", () => {
-      const result = BufferNextRequestSchema.safeParse({
-        campaignId: "c1",
-        brandId: "b1",
-        featureInput: null,
-      });
+    it("defaults sourceType to apollo", () => {
+      const result = BufferNextRequestSchema.safeParse({});
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.featureInput).toBeNull();
-      }
-    });
-
-    it("accepts request without workflowSlug", () => {
-      const result = BufferNextRequestSchema.safeParse({
-        campaignId: "c1",
-        brandId: "b1",
-      });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.workflowSlug).toBeUndefined();
+        expect(result.data.sourceType).toBe("apollo");
       }
     });
   });


### PR DESCRIPTION
## Summary
- `searchParams` and `featureInput` were redundant body fields — `fillBufferFromSearch` already fetches campaign featureInputs from campaign-service and brand fields from brand-service internally
- The LLM (`apolloSearchParams`) generates Apollo search filters from this context — no workflow ever passed these fields
- `/buffer/next` body now only accepts `sourceType` (optional) + `idempotencyKey` (optional)
- `campaignId` and `brandId` now come from required headers `x-campaign-id` / `x-brand-id` (auto-injected by workflow-service)

## Test plan
- [x] All 138 unit tests pass
- [x] TypeScript builds clean
- [x] OpenAPI spec regenerated
- [x] No workflow passes these removed fields (verified from DAG: only `brandId` + `campaignId` were mapped, now covered by headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)