### PR TITLE
Fix lead-serve run marked completed without persisted lead

### DIFF
--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -39,35 +39,44 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
     return res.status(400).json({ error: "x-campaign-id and x-brand-id headers required" });
   }
 
-  try {
-    const { idempotencyKey, sourceType } = parsed.data;
-    const workflowSlug = req.workflowSlug;
+  const { idempotencyKey, sourceType } = parsed.data;
+  const workflowSlug = req.workflowSlug;
 
-    // Idempotency: return cached response if this key was already processed
-    if (idempotencyKey) {
-      const cached = await db.query.idempotencyCache.findFirst({
-        where: eq(idempotencyCache.idempotencyKey, idempotencyKey),
-      });
-      if (cached) {
-        console.log(`[buffer/next] Idempotency hit for key=${idempotencyKey}`);
-        return res.json(cached.response);
-      }
-    }
+  const runMeta = {
+    orgId: req.orgId,
+    userId: req.userId,
+    campaignId,
+    brandId,
+    workflowSlug,
+    featureSlug: req.featureSlug,
+  };
 
-    // Create child run for traceability (x-run-id from caller becomes our parentRunId)
-    const childRun = await createRun({
-      orgId: req.orgId!,
-      serviceName: "lead-service",
-      taskName: "lead-serve",
-      parentRunId: req.runId!,
-      userId: req.userId,
-      brandId,
-      campaignId,
-      workflowSlug,
-      featureSlug: req.featureSlug,
+  // Idempotency: return cached response if this key was already processed
+  if (idempotencyKey) {
+    const cached = await db.query.idempotencyCache.findFirst({
+      where: eq(idempotencyCache.idempotencyKey, idempotencyKey),
     });
-    const serveRunId = childRun.id;
+    if (cached) {
+      console.log(`[buffer/next] Idempotency hit for key=${idempotencyKey}`);
+      return res.json(cached.response);
+    }
+  }
 
+  // Create child run for traceability (x-run-id from caller becomes our parentRunId)
+  const childRun = await createRun({
+    orgId: req.orgId!,
+    serviceName: "lead-service",
+    taskName: "lead-serve",
+    parentRunId: req.runId!,
+    userId: req.userId,
+    brandId,
+    campaignId,
+    workflowSlug,
+    featureSlug: req.featureSlug,
+  });
+  const serveRunId = childRun.id;
+
+  try {
     const result = await pullNext({
       orgId: req.orgId!,
       campaignId,
@@ -94,22 +103,19 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       }
     }
 
-    try {
-      await updateRun(serveRunId, "completed", {
-        orgId: req.orgId,
-        userId: req.userId,
-        campaignId,
-        brandId,
-        workflowSlug,
-        featureSlug: req.featureSlug,
-      });
-    } catch (err) {
-      console.error("[buffer/next] Failed to update run:", err);
-    }
+    // Only mark completed when a lead was actually served to served_leads
+    const runStatus = result.found ? "completed" : "failed";
+    await updateRun(serveRunId, runStatus, runMeta);
 
     res.json(result);
   } catch (error) {
     console.error("[buffer/next] Error:", error);
+    // Best-effort close the run as failed on unhandled errors
+    try {
+      await updateRun(serveRunId, "failed", runMeta);
+    } catch (runErr) {
+      console.error("[buffer/next] Failed to close run after error:", runErr);
+    }
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/tests/unit/buffer-route.test.ts
+++ b/tests/unit/buffer-route.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+
+const { mockCreateRun, mockUpdateRun, mockPullNext } = vi.hoisted(() => ({
+  mockCreateRun: vi.fn().mockResolvedValue({ id: "mock-run-id" }),
+  mockUpdateRun: vi.fn().mockResolvedValue(undefined),
+  mockPullNext: vi.fn(),
+}));
+
+vi.mock("../../src/lib/runs-client.js", () => ({
+  createRun: mockCreateRun,
+  updateRun: mockUpdateRun,
+  addCosts: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/lib/buffer.js", () => ({
+  pullNext: mockPullNext,
+}));
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    query: {
+      idempotencyCache: { findFirst: vi.fn().mockResolvedValue(null) },
+    },
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue([]),
+    }),
+    delete: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue([]),
+    }),
+  },
+  sql: vi.fn(),
+}));
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (_req: any, _res: any, next: any) => {
+    _req.orgId = "test-org";
+    _req.userId = "test-user";
+    _req.runId = "parent-run";
+    _req.campaignId = _req.headers["x-campaign-id"];
+    _req.brandId = _req.headers["x-brand-id"];
+    next();
+  },
+  AuthenticatedRequest: {},
+}));
+
+vi.mock("../../src/db/schema.js", () => ({
+  idempotencyCache: { idempotencyKey: "idempotency_key", createdAt: "created_at" },
+}));
+
+import bufferRoutes from "../../src/routes/buffer.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(bufferRoutes);
+  return app;
+}
+
+describe("POST /buffer/next run status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRun.mockResolvedValue({ id: "mock-run-id" });
+    mockUpdateRun.mockResolvedValue(undefined);
+  });
+
+  it("marks run as failed when pullNext returns found: false", async () => {
+    mockPullNext.mockResolvedValue({ found: false });
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/buffer/next")
+      .set("x-campaign-id", "c1")
+      .set("x-brand-id", "b1")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.found).toBe(false);
+    expect(mockUpdateRun).toHaveBeenCalledWith(
+      "mock-run-id",
+      "failed",
+      expect.objectContaining({ campaignId: "c1", brandId: "b1" })
+    );
+  });
+
+  it("marks run as completed when pullNext returns found: true", async () => {
+    mockPullNext.mockResolvedValue({
+      found: true,
+      lead: { leadId: "lid", email: "a@b.com", externalId: null, data: {}, brandId: "b1", orgId: "test-org", userId: null },
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/buffer/next")
+      .set("x-campaign-id", "c1")
+      .set("x-brand-id", "b1")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.found).toBe(true);
+    expect(mockUpdateRun).toHaveBeenCalledWith(
+      "mock-run-id",
+      "completed",
+      expect.objectContaining({ campaignId: "c1", brandId: "b1" })
+    );
+  });
+
+  it("marks run as failed when pullNext throws", async () => {
+    mockPullNext.mockRejectedValue(new Error("DB down"));
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/buffer/next")
+      .set("x-campaign-id", "c1")
+      .set("x-brand-id", "b1")
+      .send({});
+
+    expect(res.status).toBe(500);
+    expect(mockUpdateRun).toHaveBeenCalledWith(
+      "mock-run-id",
+      "failed",
+      expect.objectContaining({ campaignId: "c1", brandId: "b1" })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- **Root cause**: `POST /buffer/next` always marked the child run as `"completed"` regardless of whether `pullNext()` actually found and served a lead. When `pullNext()` returned `{ found: false }` (empty buffer, no search results), no row was written to `served_leads` but the run was still marked completed.
- **Impact**: The sidebar count (from completed `lead-serve` runs) showed 1 while the leads tab (from `served_leads` query) showed 0 — a data integrity mismatch.
- **Fix**: Run status is now `"completed"` only when `found: true` (lead actually persisted to `served_leads`), and `"failed"` otherwise. Also closes the run as `"failed"` on unhandled errors (previously left dangling).

## Test plan
- [x] Unit tests for all three scenarios: found=true → completed, found=false → failed, pullNext throws → failed
- [x] All 144 unit tests pass
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)