### PR TITLE
Make sourceType required in /buffer/next body

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -442,14 +442,16 @@
             "enum": [
               "apollo",
               "journalist"
-            ],
-            "default": "apollo"
+            ]
           },
           "idempotencyKey": {
             "type": "string",
             "minLength": 1
           }
-        }
+        },
+        "required": [
+          "sourceType"
+        ]
       },
       "CursorGetResponse": {
         "type": "object",

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -435,7 +435,7 @@ export async function pullNext(params: {
   userId?: string | null;
   workflowSlug?: string;
   featureSlug?: string;
-  sourceType?: "apollo" | "journalist";
+  sourceType: "apollo" | "journalist";
 }): Promise<{
   found: boolean;
   lead?: {
@@ -491,7 +491,7 @@ export async function pullNext(params: {
 
     if (!row) {
       // Buffer empty — fill from the appropriate source
-      const st = params.sourceType ?? "apollo";
+      const st = params.sourceType;
       let filled = 0;
 
       if (st === "journalist") {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -192,7 +192,7 @@ export const ApolloPersonDataSchema = z
 
 export const BufferNextRequestSchema = z
   .object({
-    sourceType: z.enum(["apollo", "journalist"]).default("apollo").optional(),
+    sourceType: z.enum(["apollo", "journalist"]),
     idempotencyKey: z.string().min(1).optional(),
   })
   .openapi("BufferNextRequest");

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -137,6 +137,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
       });
 
       expect(result.found).toBe(false);
@@ -197,6 +198,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
         // No searchParams!
       });
 
@@ -239,6 +241,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
         runId: "child-run-1",
       });
 
@@ -285,6 +288,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
       });
 
       expect(result.found).toBe(true);
@@ -356,6 +360,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
       });
 
       expect(result.found).toBe(true);
@@ -409,6 +414,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
 
       });
 
@@ -475,6 +481,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
       });
 
       expect(result.found).toBe(true);
@@ -549,6 +556,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
       });
 
       expect(result.found).toBe(true);
@@ -653,6 +661,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
 
       });
 
@@ -683,6 +692,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
 
       });
 
@@ -735,6 +745,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
         runId: "run-1",
       });
 
@@ -793,6 +804,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
       });
 
       expect(result.found).toBe(true);
@@ -852,6 +864,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
 
         workflowSlug: "cold-email-outreach",
       });
@@ -900,6 +913,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
       });
 
       expect(result.found).toBe(true);
@@ -935,6 +949,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
       });
 
       expect(result.found).toBe(false);
@@ -989,6 +1004,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
       });
 
       expect(result.found).toBe(true);
@@ -1025,6 +1041,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
       });
 
       // Should still serve the lead (fallback: not delivered)
@@ -1163,6 +1180,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
       });
 
       expect(result.found).toBe(true);
@@ -1210,6 +1228,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
       });
 
       expect(result.found).toBe(false);
@@ -1527,6 +1546,7 @@ describe("buffer", () => {
         orgId: "org-1",
         campaignId: "campaign-1",
         brandId: "brand-1",
+        sourceType: "apollo",
       });
 
       // Should skip the duplicate and serve the next lead

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -3,13 +3,14 @@ import { BufferNextRequestSchema, ApolloPersonDataSchema } from "../../src/schem
 
 describe("schema validation", () => {
   describe("BufferNextRequestSchema", () => {
-    it("accepts empty body (all fields optional)", () => {
+    it("rejects missing sourceType", () => {
       const result = BufferNextRequestSchema.safeParse({});
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
 
     it("accepts optional idempotencyKey", () => {
       const result = BufferNextRequestSchema.safeParse({
+        sourceType: "apollo",
         idempotencyKey: "run-123",
       });
       expect(result.success).toBe(true);
@@ -17,6 +18,7 @@ describe("schema validation", () => {
 
     it("rejects empty idempotencyKey", () => {
       const result = BufferNextRequestSchema.safeParse({
+        sourceType: "apollo",
         idempotencyKey: "",
       });
       expect(result.success).toBe(false);
@@ -47,14 +49,6 @@ describe("schema validation", () => {
         sourceType: "invalid",
       });
       expect(result.success).toBe(false);
-    });
-
-    it("defaults sourceType to apollo", () => {
-      const result = BufferNextRequestSchema.safeParse({});
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.sourceType).toBe("apollo");
-      }
     });
   });
 


### PR DESCRIPTION
## Summary
- `sourceType` is now required (no default) — callers must explicitly specify `"apollo"` or `"journalist"`
- Prevents silent misrouting when a workflow forgets to set it
- `pullNext` internal function also requires `sourceType` now

## Test plan
- [x] All 137 unit tests pass
- [x] TypeScript builds clean
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)