### PR TITLE
Replace idempotencyKey with automatic x-run-id idempotency

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -443,10 +443,6 @@
               "apollo",
               "journalist"
             ]
-          },
-          "idempotencyKey": {
-            "type": "string",
-            "minLength": 1
           }
         },
         "required": [

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -17,11 +17,11 @@ function pruneExpiredIdempotencyCache(): void {
     .where(lt(idempotencyCache.createdAt, cutoff))
     .then((result) => {
       if (result.length > 0) {
-        console.log(`[idempotency] Pruned ${result.length} expired cache entries`);
+        console.log(`[lead-service] Pruned ${result.length} expired idempotency cache entries`);
       }
     })
     .catch((err) => {
-      console.warn("[idempotency] Failed to prune expired cache:", err);
+      console.warn("[lead-service] Failed to prune expired idempotency cache:", err);
     });
 }
 
@@ -31,7 +31,6 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
     return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });
   }
 
-  // All identity/context comes from headers (injected by workflow-service)
   const campaignId = req.campaignId;
   const brandId = req.brandId;
 
@@ -39,8 +38,9 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
     return res.status(400).json({ error: "x-campaign-id and x-brand-id headers required" });
   }
 
-  const { idempotencyKey, sourceType } = parsed.data;
+  const { sourceType } = parsed.data;
   const workflowSlug = req.workflowSlug;
+  const runId = req.runId!;
 
   const runMeta = {
     orgId: req.orgId,
@@ -51,15 +51,13 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
     featureSlug: req.featureSlug,
   };
 
-  // Idempotency: return cached response if this key was already processed
-  if (idempotencyKey) {
-    const cached = await db.query.idempotencyCache.findFirst({
-      where: eq(idempotencyCache.idempotencyKey, idempotencyKey),
-    });
-    if (cached) {
-      console.log(`[buffer/next] Idempotency hit for key=${idempotencyKey}`);
-      return res.json(cached.response);
-    }
+  // Idempotency on x-run-id: if this run already got a lead, return the cached response
+  const cached = await db.query.idempotencyCache.findFirst({
+    where: eq(idempotencyCache.idempotencyKey, runId),
+  });
+  if (cached) {
+    console.log(`[lead-service] Idempotency hit for runId=${runId}`);
+    return res.json(cached.response);
   }
 
   // Create child run for traceability (x-run-id from caller becomes our parentRunId)
@@ -67,7 +65,7 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
     orgId: req.orgId!,
     serviceName: "lead-service",
     taskName: "lead-serve",
-    parentRunId: req.runId!,
+    parentRunId: runId,
     userId: req.userId,
     brandId,
     campaignId,
@@ -88,33 +86,29 @@ router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res)
       sourceType,
     });
 
-    // Cache the response for idempotency + probabilistic TTL cleanup (~1% of requests)
-    if (idempotencyKey) {
-      if (Math.random() < 0.01) pruneExpiredIdempotencyCache();
-      try {
-        await db.insert(idempotencyCache).values({
-          idempotencyKey,
-          orgId: req.orgId!,
-          response: result,
-        });
-      } catch (err) {
-        // Ignore duplicate key errors (race condition between concurrent retries)
-        console.warn("[buffer/next] Failed to cache idempotency response:", err);
-      }
+    // Cache response keyed by caller's runId for idempotency
+    if (Math.random() < 0.01) pruneExpiredIdempotencyCache();
+    try {
+      await db.insert(idempotencyCache).values({
+        idempotencyKey: runId,
+        orgId: req.orgId!,
+        response: result,
+      });
+    } catch (err) {
+      // Ignore duplicate key errors (race condition between concurrent retries)
+      console.warn("[lead-service] Failed to cache idempotency response:", err);
     }
 
-    // Only mark completed when a lead was actually served to served_leads
     const runStatus = result.found ? "completed" : "failed";
     await updateRun(serveRunId, runStatus, runMeta);
 
     res.json(result);
   } catch (error) {
-    console.error("[buffer/next] Error:", error);
-    // Best-effort close the run as failed on unhandled errors
+    console.error("[lead-service] buffer/next error:", error);
     try {
       await updateRun(serveRunId, "failed", runMeta);
     } catch (runErr) {
-      console.error("[buffer/next] Failed to close run after error:", runErr);
+      console.error("[lead-service] Failed to close run after error:", runErr);
     }
     res.status(500).json({ error: "Internal server error" });
   }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -193,7 +193,6 @@ export const ApolloPersonDataSchema = z
 export const BufferNextRequestSchema = z
   .object({
     sourceType: z.enum(["apollo", "journalist"]),
-    idempotencyKey: z.string().min(1).optional(),
   })
   .openapi("BufferNextRequest");
 

--- a/tests/unit/buffer-route.test.ts
+++ b/tests/unit/buffer-route.test.ts
@@ -73,7 +73,7 @@ describe("POST /buffer/next run status", () => {
       .post("/buffer/next")
       .set("x-campaign-id", "c1")
       .set("x-brand-id", "b1")
-      .send({});
+      .send({ sourceType: "apollo" });
 
     expect(res.status).toBe(200);
     expect(res.body.found).toBe(false);
@@ -95,7 +95,7 @@ describe("POST /buffer/next run status", () => {
       .post("/buffer/next")
       .set("x-campaign-id", "c1")
       .set("x-brand-id", "b1")
-      .send({});
+      .send({ sourceType: "apollo" });
 
     expect(res.status).toBe(200);
     expect(res.body.found).toBe(true);
@@ -114,7 +114,7 @@ describe("POST /buffer/next run status", () => {
       .post("/buffer/next")
       .set("x-campaign-id", "c1")
       .set("x-brand-id", "b1")
-      .send({});
+      .send({ sourceType: "apollo" });
 
     expect(res.status).toBe(500);
     expect(mockUpdateRun).toHaveBeenCalledWith(

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -8,22 +8,6 @@ describe("schema validation", () => {
       expect(result.success).toBe(false);
     });
 
-    it("accepts optional idempotencyKey", () => {
-      const result = BufferNextRequestSchema.safeParse({
-        sourceType: "apollo",
-        idempotencyKey: "run-123",
-      });
-      expect(result.success).toBe(true);
-    });
-
-    it("rejects empty idempotencyKey", () => {
-      const result = BufferNextRequestSchema.safeParse({
-        sourceType: "apollo",
-        idempotencyKey: "",
-      });
-      expect(result.success).toBe(false);
-    });
-
     it("accepts sourceType apollo", () => {
       const result = BufferNextRequestSchema.safeParse({
         sourceType: "apollo",


### PR DESCRIPTION
## Summary
- Remove `idempotencyKey` from request body — zero workflows ever used it
- Idempotency now automatic: uses caller's `x-run-id` header (already required) as cache key
- If same runId calls `/buffer/next` twice, returns cached response
- Body is now just `{ sourceType: "apollo" | "journalist" }`

## Test plan
- [x] All 138 unit tests pass
- [x] TypeScript builds clean
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)