### PR TITLE
Add workflowSlugs/featureSlugs multi-filter to GET /stats

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1256,7 +1256,16 @@
             "in": "query",
             "name": "workflowSlug",
             "required": false,
-            "description": "Filter by exact workflow slug",
+            "description": "Filter by exact workflow slug (single value)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workflowSlugs",
+            "required": false,
+            "description": "Filter by multiple workflow slugs (comma-separated). Takes priority over workflowSlug.",
             "schema": {
               "type": "string"
             }
@@ -1265,7 +1274,16 @@
             "in": "query",
             "name": "featureSlug",
             "required": false,
-            "description": "Filter by exact feature slug",
+            "description": "Filter by exact feature slug (single value)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "featureSlugs",
+            "required": false,
+            "description": "Filter by multiple feature slugs (comma-separated). Takes priority over featureSlug.",
             "schema": {
               "type": "string"
             }

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -52,7 +52,9 @@ async function resolveDynastySlugs(
   const workflowDynastySlug = str(req.query.workflowDynastySlug);
   const featureDynastySlug = str(req.query.featureDynastySlug);
   const workflowSlug = str(req.query.workflowSlug);
+  const workflowSlugsParam = str(req.query.workflowSlugs);
   const featureSlug = str(req.query.featureSlug);
+  const featureSlugsParam = str(req.query.featureSlugs);
 
   const context = { orgId: req.orgId, userId: req.userId, runId: req.runId };
 
@@ -62,6 +64,8 @@ async function resolveDynastySlugs(
   if (workflowDynastySlug) {
     workflowSlugs = await resolveWorkflowDynastySlugs(workflowDynastySlug, context);
     if (workflowSlugs.length === 0) return { workflowSlugs: [], featureSlugs: null, emptyDynasty: true };
+  } else if (workflowSlugsParam) {
+    workflowSlugs = workflowSlugsParam.split(",").filter(Boolean);
   } else if (workflowSlug) {
     workflowSlugs = [workflowSlug];
   }
@@ -69,6 +73,8 @@ async function resolveDynastySlugs(
   if (featureDynastySlug) {
     featureSlugs = await resolveFeatureDynastySlugs(featureDynastySlug, context);
     if (featureSlugs.length === 0) return { workflowSlugs, featureSlugs: [], emptyDynasty: true };
+  } else if (featureSlugsParam) {
+    featureSlugs = featureSlugsParam.split(",").filter(Boolean);
   } else if (featureSlug) {
     featureSlugs = [featureSlug];
   }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -455,14 +455,30 @@ registry.registerPath({
       in: "query" as const,
       name: "workflowSlug",
       required: false,
-      description: "Filter by exact workflow slug",
+      description: "Filter by exact workflow slug (single value)",
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
+      name: "workflowSlugs",
+      required: false,
+      description:
+        "Filter by multiple workflow slugs (comma-separated). Takes priority over workflowSlug.",
       schema: { type: "string" as const },
     },
     {
       in: "query" as const,
       name: "featureSlug",
       required: false,
-      description: "Filter by exact feature slug",
+      description: "Filter by exact feature slug (single value)",
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
+      name: "featureSlugs",
+      required: false,
+      description:
+        "Filter by multiple feature slugs (comma-separated). Takes priority over featureSlug.",
       schema: { type: "string" as const },
     },
     {

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -299,6 +299,47 @@ describe("GET /stats", () => {
     expect(res.body).toEqual({ groups: [] });
   });
 
+  // --- Multi-slug filtering ---
+
+  it("filters by comma-separated workflowSlugs", async () => {
+    const app = createApp();
+    const res = await request(app).get("/stats?workflowSlugs=cold-email-v1,cold-email-v2");
+    expect(res.status).toBe(200);
+    // Dynasty resolver should NOT be called
+    expect(mockResolveWorkflowDynastySlugs).not.toHaveBeenCalled();
+  });
+
+  it("filters by comma-separated featureSlugs", async () => {
+    const app = createApp();
+    const res = await request(app).get("/stats?featureSlugs=feat-a,feat-b");
+    expect(res.status).toBe(200);
+    expect(mockResolveFeatureDynastySlugs).not.toHaveBeenCalled();
+  });
+
+  it("workflowSlugs takes priority over workflowSlug", async () => {
+    const app = createApp();
+    const res = await request(app).get("/stats?workflowSlugs=v1,v2&workflowSlug=v3");
+    expect(res.status).toBe(200);
+    // Should use the plural param, not the singular
+    expect(mockResolveWorkflowDynastySlugs).not.toHaveBeenCalled();
+  });
+
+  it("workflowDynastySlug takes priority over workflowSlugs", async () => {
+    mockResolveWorkflowDynastySlugs.mockResolvedValue(["cold-email", "cold-email-v2"]);
+
+    const app = createApp();
+    const res = await request(app).get("/stats?workflowDynastySlug=cold-email&workflowSlugs=v1,v2");
+    expect(res.status).toBe(200);
+    expect(mockResolveWorkflowDynastySlugs).toHaveBeenCalledWith("cold-email", expect.any(Object));
+  });
+
+  it("groupBy=workflowSlug with workflowSlugs filter returns grouped stats", async () => {
+    const app = createApp();
+    const res = await request(app).get("/stats?groupBy=workflowSlug&workflowSlugs=slug1,slug2");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("groups");
+  });
+
   it("workflowDynastySlug takes priority over workflowSlug", async () => {
     mockResolveWorkflowDynastySlugs.mockResolvedValue(["cold-email", "cold-email-v2"]);
 


### PR DESCRIPTION
## Summary
- Adds `workflowSlugs` and `featureSlugs` comma-separated query params to `GET /stats`
- Enables filtering stats by multiple workflow/feature slugs in a single request (e.g. `?workflowSlugs=slug1,slug2&groupBy=workflowSlug`)
- Priority: dynastySlug > plural slugs param > singular slug param
- Needed for dynamic workflow ranking (cost-per-lead calculation)

## Test plan
- [x] Unit tests for comma-separated workflowSlugs filter
- [x] Unit tests for comma-separated featureSlugs filter
- [x] Priority test: workflowSlugs takes priority over workflowSlug
- [x] Priority test: workflowDynastySlug takes priority over workflowSlugs
- [x] Combined groupBy + workflowSlugs test
- [x] All 143 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)