### PR TITLE
Add GET /leads/status for per-lead delivery status

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -644,6 +644,57 @@
         "required": [
           "groups"
         ]
+      },
+      "LeadStatusResponse": {
+        "type": "object",
+        "properties": {
+          "statuses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LeadStatusItem"
+            }
+          }
+        },
+        "required": [
+          "statuses"
+        ]
+      },
+      "LeadStatusItem": {
+        "type": "object",
+        "properties": {
+          "leadId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "email": {
+            "type": "string"
+          },
+          "contacted": {
+            "type": "boolean"
+          },
+          "delivered": {
+            "type": "boolean"
+          },
+          "bounced": {
+            "type": "boolean"
+          },
+          "replied": {
+            "type": "boolean"
+          },
+          "lastDeliveredAt": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "leadId",
+          "email",
+          "contacted",
+          "delivered",
+          "bounced",
+          "replied",
+          "lastDeliveredAt"
+        ]
       }
     },
     "parameters": {},
@@ -1344,6 +1395,129 @@
           },
           "400": {
             "description": "Invalid groupBy value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/leads/status": {
+      "get": {
+        "summary": "Get per-lead delivery status for a campaign",
+        "description": "Returns delivery status (contacted, delivered, bounced, replied) for each served lead in a campaign. Calls email-gateway internally to resolve status.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "API key for authenticating requests"
+          },
+          {
+            "in": "header",
+            "name": "x-org-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Internal organization UUID from client-service"
+          },
+          {
+            "in": "header",
+            "name": "x-user-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Internal user UUID from client-service"
+          },
+          {
+            "in": "header",
+            "name": "x-run-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The caller's run ID (used as parentRunId when creating this service's own run)"
+          },
+          {
+            "in": "header",
+            "name": "x-campaign-id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign identifier (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-brand-id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Brand identifier (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-workflow-slug",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workflow slug (auto-injected by workflow-service)"
+          },
+          {
+            "in": "header",
+            "name": "x-feature-slug",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature slug for tracking (propagated through the call chain)"
+          },
+          {
+            "in": "query",
+            "name": "campaignId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Campaign ID to fetch lead statuses for"
+          },
+          {
+            "in": "query",
+            "name": "brandId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional brand ID filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Per-lead delivery statuses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeadStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing campaignId",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import bufferRoutes from "./routes/buffer.js";
 import cursorRoutes from "./routes/cursor.js";
 import leadsRoutes from "./routes/leads.js";
 import statsRoutes from "./routes/stats.js";
+import leadStatusRoutes from "./routes/lead-status.js";
 import { registerProviders } from "./lib/register-providers.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -36,6 +37,7 @@ app.use(bufferRoutes);
 app.use(cursorRoutes);
 app.use(leadsRoutes);
 app.use(statsRoutes);
+app.use(leadStatusRoutes);
 
 app.use((req, res) => {
   res.status(404).json({ error: "Not found" });

--- a/src/routes/lead-status.ts
+++ b/src/routes/lead-status.ts
@@ -1,0 +1,138 @@
+import { Router } from "express";
+import { eq, and, type SQL } from "drizzle-orm";
+import { type AuthenticatedRequest, authenticate, getServiceContext } from "../middleware/auth.js";
+import { db } from "../db/index.js";
+import { servedLeads } from "../db/schema.js";
+import {
+  checkDeliveryStatus,
+  type StatusResult,
+  type DeliveryStatusItem,
+} from "../lib/email-gateway-client.js";
+
+const router = Router();
+
+function flattenStatus(result: StatusResult) {
+  const bc = result.broadcast;
+  const tx = result.transactional;
+
+  const contacted = !!(
+    bc?.campaign.lead.contacted ||
+    bc?.campaign.email.contacted ||
+    bc?.brand.lead.contacted ||
+    bc?.brand.email.contacted ||
+    bc?.global.email.contacted ||
+    tx?.campaign.lead.contacted ||
+    tx?.campaign.email.contacted ||
+    tx?.brand.lead.contacted ||
+    tx?.brand.email.contacted ||
+    tx?.global.email.contacted
+  );
+
+  const delivered = !!(
+    bc?.campaign.email.delivered ||
+    tx?.campaign.email.delivered
+  );
+
+  const bounced = !!(
+    bc?.campaign.email.bounced ||
+    tx?.campaign.email.bounced
+  );
+
+  const replied = !!(
+    bc?.campaign.lead.replied ||
+    tx?.campaign.lead.replied
+  );
+
+  const lastDeliveredAt =
+    bc?.campaign.email.lastDeliveredAt ??
+    tx?.campaign.email.lastDeliveredAt ??
+    null;
+
+  return { contacted, delivered, bounced, replied, lastDeliveredAt };
+}
+
+router.get("/leads/status", authenticate, async (req: AuthenticatedRequest, res) => {
+  try {
+    const campaignId = typeof req.query.campaignId === "string" ? req.query.campaignId : undefined;
+    if (!campaignId) {
+      res.status(400).json({ error: "campaignId query parameter is required" });
+      return;
+    }
+
+    const conditions: SQL[] = [
+      eq(servedLeads.orgId, req.orgId!),
+      eq(servedLeads.campaignId, campaignId),
+    ];
+
+    const brandId = typeof req.query.brandId === "string" ? req.query.brandId : undefined;
+    if (brandId) {
+      conditions.push(eq(servedLeads.brandId, brandId));
+    }
+
+    const rows = await db
+      .select({
+        leadId: servedLeads.leadId,
+        email: servedLeads.email,
+        brandId: servedLeads.brandId,
+      })
+      .from(servedLeads)
+      .where(and(...conditions));
+
+    if (rows.length === 0) {
+      res.json({ statuses: [] });
+      return;
+    }
+
+    // Group by brandId since email-gateway scopes status per brand/campaign
+    const groups = new Map<string, { brandId: string; items: DeliveryStatusItem[] }>();
+    for (const row of rows) {
+      if (!row.leadId) continue;
+      const key = row.brandId;
+      if (!groups.has(key)) {
+        groups.set(key, { brandId: row.brandId, items: [] });
+      }
+      groups.get(key)!.items.push({ leadId: row.leadId, email: row.email });
+    }
+
+    const context = getServiceContext(req);
+    const statusMap = new Map<string, StatusResult>();
+
+    await Promise.all(
+      Array.from(groups.values()).map(async (group) => {
+        const response = await checkDeliveryStatus(
+          group.brandId,
+          campaignId,
+          group.items,
+          context,
+        );
+        if (!response) return;
+        for (const result of response.results) {
+          statusMap.set(result.email, result);
+        }
+      }),
+    );
+
+    const statuses = rows
+      .filter((row) => row.leadId)
+      .map((row) => {
+        const result = statusMap.get(row.email);
+        const flat = result
+          ? flattenStatus(result)
+          : { contacted: false, delivered: false, bounced: false, replied: false, lastDeliveredAt: null };
+
+        return {
+          leadId: row.leadId!,
+          email: row.email,
+          ...flat,
+        };
+      });
+
+    res.json({ statuses });
+  } catch (error) {
+    console.error("[lead-service] Lead status error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export { flattenStatus };
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -293,6 +293,26 @@ const StatsGroupedResponseSchema = z
   })
   .openapi("StatsGroupedResponse");
 
+// --- Lead Status ---
+
+const LeadStatusItemSchema = z
+  .object({
+    leadId: z.string().uuid(),
+    email: z.string(),
+    contacted: z.boolean(),
+    delivered: z.boolean(),
+    bounced: z.boolean(),
+    replied: z.boolean(),
+    lastDeliveredAt: z.string().nullable(),
+  })
+  .openapi("LeadStatusItem");
+
+const LeadStatusResponseSchema = z
+  .object({
+    statuses: z.array(LeadStatusItemSchema),
+  })
+  .openapi("LeadStatusResponse");
+
 // --- Register Paths ---
 
 registry.registerPath({
@@ -528,6 +548,43 @@ registry.registerPath({
     },
     400: {
       description: "Invalid groupBy value",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    401: { description: "Unauthorized" },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/leads/status",
+  summary: "Get per-lead delivery status for a campaign",
+  description:
+    "Returns delivery status (contacted, delivered, bounced, replied) for each served lead in a campaign. " +
+    "Calls email-gateway internally to resolve status.",
+  parameters: [
+    ...AuthHeaders,
+    {
+      in: "query" as const,
+      name: "campaignId",
+      required: true,
+      schema: { type: "string" as const },
+      description: "Campaign ID to fetch lead statuses for",
+    },
+    {
+      in: "query" as const,
+      name: "brandId",
+      required: false,
+      schema: { type: "string" as const },
+      description: "Optional brand ID filter",
+    },
+  ],
+  responses: {
+    200: {
+      description: "Per-lead delivery statuses",
+      content: { "application/json": { schema: LeadStatusResponseSchema } },
+    },
+    400: {
+      description: "Missing campaignId",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
     401: { description: "Unauthorized" },

--- a/tests/unit/lead-status.test.ts
+++ b/tests/unit/lead-status.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock db
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockSelect = vi.fn();
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    select: (...args: unknown[]) => {
+      mockSelect(...args);
+      return {
+        from: (...fArgs: unknown[]) => {
+          mockFrom(...fArgs);
+          return {
+            where: (...wArgs: unknown[]) => mockWhere(...wArgs),
+          };
+        },
+      };
+    },
+  },
+}));
+
+const mockCheckDeliveryStatus = vi.fn();
+vi.mock("../../src/lib/email-gateway-client.js", () => ({
+  checkDeliveryStatus: (...args: unknown[]) => mockCheckDeliveryStatus(...args),
+  isContacted: () => false,
+}));
+
+vi.mock("../../src/middleware/auth.js", () => ({
+  authenticate: (_req: unknown, _res: unknown, next: () => void) => next(),
+  getServiceContext: (req: any) => ({
+    orgId: req.orgId,
+    userId: req.userId,
+    runId: req.runId,
+    campaignId: req.campaignId,
+    brandId: req.brandId,
+    workflowSlug: req.workflowSlug,
+    featureSlug: req.featureSlug,
+  }),
+}));
+
+import request from "supertest";
+import express from "express";
+import leadStatusRouter from "../../src/routes/lead-status.js";
+import { flattenStatus } from "../../src/routes/lead-status.js";
+
+function createApp() {
+  const app = express();
+  app.use((req: any, _res, next) => {
+    req.orgId = "org-1";
+    req.userId = "user-1";
+    req.runId = "run-1";
+    next();
+  });
+  app.use(leadStatusRouter);
+  return app;
+}
+
+describe("GET /leads/status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWhere.mockResolvedValue([]);
+    mockCheckDeliveryStatus.mockResolvedValue(null);
+  });
+
+  it("returns 400 when campaignId is missing", async () => {
+    const app = createApp();
+    const res = await request(app).get("/leads/status");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("campaignId");
+  });
+
+  it("returns empty statuses when no served leads exist", async () => {
+    mockWhere.mockResolvedValue([]);
+
+    const app = createApp();
+    const res = await request(app).get("/leads/status?campaignId=c1");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ statuses: [] });
+    expect(mockCheckDeliveryStatus).not.toHaveBeenCalled();
+  });
+
+  it("returns per-lead delivery status from email-gateway", async () => {
+    const servedRows = [
+      { leadId: "lead-1", email: "alice@acme.com", brandId: "b1" },
+      { leadId: "lead-2", email: "bob@acme.com", brandId: "b1" },
+    ];
+    mockWhere.mockResolvedValue(servedRows);
+
+    mockCheckDeliveryStatus.mockResolvedValue({
+      results: [
+        {
+          leadId: "lead-1",
+          email: "alice@acme.com",
+          broadcast: {
+            campaign: {
+              lead: { contacted: true, delivered: true, replied: false, lastDeliveredAt: null },
+              email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2026-03-29T10:00:00Z" },
+            },
+            brand: {
+              lead: { contacted: false, delivered: false, replied: false, lastDeliveredAt: null },
+              email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+            },
+            global: {
+              email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+            },
+          },
+        },
+        {
+          leadId: "lead-2",
+          email: "bob@acme.com",
+          broadcast: {
+            campaign: {
+              lead: { contacted: true, delivered: true, replied: false, lastDeliveredAt: null },
+              email: { contacted: true, delivered: false, bounced: true, unsubscribed: false, lastDeliveredAt: null },
+            },
+            brand: {
+              lead: { contacted: false, delivered: false, replied: false, lastDeliveredAt: null },
+              email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+            },
+            global: {
+              email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+            },
+          },
+        },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app).get("/leads/status?campaignId=c1");
+    expect(res.status).toBe(200);
+    expect(res.body.statuses).toHaveLength(2);
+
+    const alice = res.body.statuses.find((s: any) => s.email === "alice@acme.com");
+    expect(alice).toEqual({
+      leadId: "lead-1",
+      email: "alice@acme.com",
+      contacted: true,
+      delivered: true,
+      bounced: false,
+      replied: false,
+      lastDeliveredAt: "2026-03-29T10:00:00Z",
+    });
+
+    const bob = res.body.statuses.find((s: any) => s.email === "bob@acme.com");
+    expect(bob).toEqual({
+      leadId: "lead-2",
+      email: "bob@acme.com",
+      contacted: true,
+      delivered: false,
+      bounced: true,
+      replied: false,
+      lastDeliveredAt: null,
+    });
+
+    expect(mockCheckDeliveryStatus).toHaveBeenCalledWith(
+      "b1",
+      "c1",
+      [
+        { leadId: "lead-1", email: "alice@acme.com" },
+        { leadId: "lead-2", email: "bob@acme.com" },
+      ],
+      expect.objectContaining({ orgId: "org-1" }),
+    );
+  });
+
+  it("returns all-false status when email-gateway is unreachable", async () => {
+    mockWhere.mockResolvedValue([
+      { leadId: "lead-1", email: "alice@acme.com", brandId: "b1" },
+    ]);
+    mockCheckDeliveryStatus.mockResolvedValue(null);
+
+    const app = createApp();
+    const res = await request(app).get("/leads/status?campaignId=c1");
+    expect(res.status).toBe(200);
+    expect(res.body.statuses).toEqual([
+      {
+        leadId: "lead-1",
+        email: "alice@acme.com",
+        contacted: false,
+        delivered: false,
+        bounced: false,
+        replied: false,
+        lastDeliveredAt: null,
+      },
+    ]);
+  });
+
+  it("skips rows with null leadId", async () => {
+    mockWhere.mockResolvedValue([
+      { leadId: null, email: "orphan@acme.com", brandId: "b1" },
+      { leadId: "lead-1", email: "alice@acme.com", brandId: "b1" },
+    ]);
+    mockCheckDeliveryStatus.mockResolvedValue(null);
+
+    const app = createApp();
+    const res = await request(app).get("/leads/status?campaignId=c1");
+    expect(res.status).toBe(200);
+    expect(res.body.statuses).toHaveLength(1);
+    expect(res.body.statuses[0].leadId).toBe("lead-1");
+  });
+
+  it("groups email-gateway calls by brandId", async () => {
+    mockWhere.mockResolvedValue([
+      { leadId: "lead-1", email: "alice@acme.com", brandId: "b1" },
+      { leadId: "lead-2", email: "bob@other.com", brandId: "b2" },
+    ]);
+    mockCheckDeliveryStatus.mockResolvedValue({ results: [] });
+
+    const app = createApp();
+    await request(app).get("/leads/status?campaignId=c1");
+
+    expect(mockCheckDeliveryStatus).toHaveBeenCalledTimes(2);
+    expect(mockCheckDeliveryStatus).toHaveBeenCalledWith(
+      "b1", "c1",
+      [{ leadId: "lead-1", email: "alice@acme.com" }],
+      expect.any(Object),
+    );
+    expect(mockCheckDeliveryStatus).toHaveBeenCalledWith(
+      "b2", "c1",
+      [{ leadId: "lead-2", email: "bob@other.com" }],
+      expect.any(Object),
+    );
+  });
+
+  it("applies brandId filter when provided", async () => {
+    mockWhere.mockResolvedValue([]);
+
+    const app = createApp();
+    const res = await request(app).get("/leads/status?campaignId=c1&brandId=b1");
+    expect(res.status).toBe(200);
+    // Verify where was called (conditions include brandId filter)
+    expect(mockWhere).toHaveBeenCalled();
+  });
+});
+
+describe("flattenStatus", () => {
+  it("detects replied from broadcast campaign lead", () => {
+    const result = flattenStatus({
+      leadId: "l1",
+      email: "a@b.com",
+      broadcast: {
+        campaign: {
+          lead: { contacted: true, delivered: true, replied: true, lastDeliveredAt: null },
+          email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2026-03-29T10:00:00Z" },
+        },
+        brand: {
+          lead: { contacted: false, delivered: false, replied: false, lastDeliveredAt: null },
+          email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+        },
+        global: {
+          email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+        },
+      },
+    });
+
+    expect(result.replied).toBe(true);
+    expect(result.delivered).toBe(true);
+    expect(result.contacted).toBe(true);
+    expect(result.lastDeliveredAt).toBe("2026-03-29T10:00:00Z");
+  });
+
+  it("detects transactional delivery", () => {
+    const result = flattenStatus({
+      leadId: "l1",
+      email: "a@b.com",
+      transactional: {
+        campaign: {
+          lead: { contacted: true, delivered: false, replied: false, lastDeliveredAt: null },
+          email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2026-03-28T08:00:00Z" },
+        },
+        brand: {
+          lead: { contacted: false, delivered: false, replied: false, lastDeliveredAt: null },
+          email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+        },
+        global: {
+          email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+        },
+      },
+    });
+
+    expect(result.delivered).toBe(true);
+    expect(result.contacted).toBe(true);
+    expect(result.lastDeliveredAt).toBe("2026-03-28T08:00:00Z");
+  });
+
+  it("returns all false when no providers present", () => {
+    const result = flattenStatus({
+      leadId: "l1",
+      email: "a@b.com",
+    });
+    expect(result).toEqual({
+      contacted: false,
+      delivered: false,
+      bounced: false,
+      replied: false,
+      lastDeliveredAt: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /leads/status?campaignId=xxx` endpoint that returns per-lead delivery status (contacted, delivered, bounced, replied, lastDeliveredAt)
- Calls email-gateway internally — the frontend only needs to call lead-service
- Includes Zod schema, OpenAPI registration, and unit tests

## Test plan
- [x] Unit tests for route (400 on missing campaignId, empty results, per-lead status mapping, null leadId filtering, brandId grouping, email-gateway unreachable fallback)
- [x] Unit tests for `flattenStatus` helper (broadcast, transactional, no providers)
- [x] All 153 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)