### PR TITLE
Batch email-gateway status requests to fix 413

### DIFF
--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -46,16 +46,43 @@ export interface DeliveryStatusResponse {
   results: StatusResult[];
 }
 
+const BATCH_SIZE = 100;
+
+async function checkDeliveryStatusBatch(
+  brandId: string,
+  campaignId: string | undefined,
+  items: DeliveryStatusItem[],
+  headers: Record<string, string>,
+): Promise<DeliveryStatusResponse | null> {
+  const body: Record<string, unknown> = { brandId, items };
+  if (campaignId) body.campaignId = campaignId;
+
+  const response = await fetch(`${EMAIL_GATEWAY_SERVICE_URL}/status`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    console.error(
+      `[email-gateway-client] Status check failed: ${response.status} - ${error}`
+    );
+    return null;
+  }
+
+  return (await response.json()) as DeliveryStatusResponse;
+}
+
 export async function checkDeliveryStatus(
   brandId: string,
   campaignId: string | undefined,
   items: DeliveryStatusItem[],
   context?: { orgId?: string; userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowSlug?: string; featureSlug?: string }
 ): Promise<DeliveryStatusResponse | null> {
-  try {
-    const body: Record<string, unknown> = { brandId, items };
-    if (campaignId) body.campaignId = campaignId;
+  if (items.length === 0) return { results: [] };
 
+  try {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       "X-API-Key": EMAIL_GATEWAY_SERVICE_API_KEY,
@@ -68,21 +95,26 @@ export async function checkDeliveryStatus(
     if (context?.workflowSlug) headers["x-workflow-slug"] = context.workflowSlug;
     if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
 
-    const response = await fetch(`${EMAIL_GATEWAY_SERVICE_URL}/status`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      const error = await response.text();
-      console.error(
-        `[email-gateway-client] Status check failed: ${response.status} - ${error}`
-      );
-      return null;
+    if (items.length <= BATCH_SIZE) {
+      return await checkDeliveryStatusBatch(brandId, campaignId, items, headers);
     }
 
-    return (await response.json()) as DeliveryStatusResponse;
+    const batches: DeliveryStatusItem[][] = [];
+    for (let i = 0; i < items.length; i += BATCH_SIZE) {
+      batches.push(items.slice(i, i + BATCH_SIZE));
+    }
+
+    const batchResults = await Promise.all(
+      batches.map((batch) => checkDeliveryStatusBatch(brandId, campaignId, batch, headers))
+    );
+
+    const allResults: StatusResult[] = [];
+    for (const result of batchResults) {
+      if (!result) return null;
+      allResults.push(...result.results);
+    }
+
+    return { results: allResults };
   } catch (error) {
     const isConnectionError =
       error instanceof TypeError && error.message === "fetch failed";

--- a/tests/unit/email-gateway-client.test.ts
+++ b/tests/unit/email-gateway-client.test.ts
@@ -115,6 +115,65 @@ describe("email-gateway-client", () => {
       errorSpy.mockRestore();
     });
 
+    it("returns empty results for empty items array", async () => {
+      const result = await checkDeliveryStatus("brand-1", "campaign-1", []);
+      expect(result).toEqual({ results: [] });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("batches items when exceeding batch size", async () => {
+      const items = Array.from({ length: 150 }, (_, i) => ({
+        leadId: `lead-${i}`,
+        email: `user${i}@acme.com`,
+      }));
+
+      mockFetch.mockImplementation(async (_url: string, opts: { body: string }) => {
+        const body = JSON.parse(opts.body);
+        return {
+          ok: true,
+          json: () => Promise.resolve({
+            results: body.items.map((item: { leadId: string; email: string }) => ({
+              leadId: item.leadId,
+              email: item.email,
+            })),
+          }),
+        };
+      });
+
+      const result = await checkDeliveryStatus("brand-1", "campaign-1", items);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const firstBatch = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const secondBatch = JSON.parse(mockFetch.mock.calls[1][1].body);
+      expect(firstBatch.items).toHaveLength(100);
+      expect(secondBatch.items).toHaveLength(50);
+      expect(result!.results).toHaveLength(150);
+    });
+
+    it("returns null if any batch fails", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      const items = Array.from({ length: 150 }, (_, i) => ({
+        leadId: `lead-${i}`,
+        email: `user${i}@acme.com`,
+      }));
+
+      let callCount = 0;
+      mockFetch.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 2) {
+          return { ok: false, status: 500, text: () => Promise.resolve("error") };
+        }
+        return {
+          ok: true,
+          json: () => Promise.resolve({ results: [] }),
+        };
+      });
+
+      const result = await checkDeliveryStatus("brand-1", "campaign-1", items);
+      expect(result).toBeNull();
+      vi.restoreAllMocks();
+    });
+
     it("returns null and logs error on unexpected errors", async () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- `checkDeliveryStatus` now splits large item arrays into batches of 100 before sending to email-gateway's `POST /status` endpoint
- Batches run in parallel and results are merged — if any batch fails, the whole call returns `null` (preserving existing error semantics)
- Fixes `413 PayloadTooLargeError` on campaigns with many served leads

## Test plan
- [x] Added unit test: batches 150 items into 100+50, verifies 2 fetch calls and merged results
- [x] Added unit test: returns null if any batch fails
- [x] Added unit test: empty items returns early without fetch
- [x] All 156 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)