### PR TITLE
Add journalistId, outletId, apolloPersonId to buffer/next

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -48,10 +48,6 @@
               "email": {
                 "type": "string"
               },
-              "externalId": {
-                "type": "string",
-                "nullable": true
-              },
               "data": {
                 "$ref": "#/components/schemas/ApolloPersonData"
               },
@@ -65,12 +61,23 @@
               "userId": {
                 "type": "string",
                 "nullable": true
+              },
+              "apolloPersonId": {
+                "type": "string",
+                "nullable": true
+              },
+              "journalistId": {
+                "type": "string",
+                "nullable": true
+              },
+              "outletId": {
+                "type": "string",
+                "nullable": true
               }
             },
             "required": [
               "leadId",
               "email",
-              "externalId",
               "data",
               "brandId",
               "orgId",

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -332,7 +332,7 @@ async function fillBufferFromJournalists(params: {
       // Skip organization-type entities (we need individual people)
       if (journalist.entityType === "organization") continue;
 
-      const externalId = `journalist:${journalist.id}`;
+      const externalId = journalist.id;
 
       if (await isInBuffer(params.orgId, params.campaignId, externalId)) continue;
 
@@ -441,11 +441,13 @@ export async function pullNext(params: {
   lead?: {
     leadId: string;
     email: string;
-    externalId: string | null;
     data: unknown;
     brandId: string;
     orgId: string | null;
     userId: string | null;
+    apolloPersonId: string | null;
+    journalistId: string | null;
+    outletId: string | null;
   };
 }> {
   const MAX_ITERATIONS = 100;
@@ -732,17 +734,22 @@ export async function pullNext(params: {
         ? { ...(enrichedData as Record<string, unknown>), email }
         : { email };
 
+    // Extract typed IDs from the data blob
+    const dataObj = finalData as Record<string, unknown>;
+    const isJournalist = dataObj.sourceType === "journalist";
 
     return {
       found: true,
       lead: {
         leadId,
         email,
-        externalId: row.externalId,
         data: finalData,
         brandId: params.brandId,
         orgId: row.orgId,
         userId: row.userId,
+        apolloPersonId: (dataObj.id as string) ?? null,
+        journalistId: isJournalist ? ((dataObj.journalistId as string) ?? null) : null,
+        outletId: isJournalist ? ((dataObj.outletId as string) ?? null) : null,
       },
     };
   }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -199,11 +199,13 @@ export const BufferNextRequestSchema = z
 const ServedLeadSchema = z.object({
   leadId: z.string().uuid(),
   email: z.string(),
-  externalId: z.string().nullable(),
   data: ApolloPersonDataSchema.nullable(),
   brandId: z.string(),
   orgId: z.string().nullable(),
   userId: z.string().nullable(),
+  apolloPersonId: z.string().nullable().optional(),
+  journalistId: z.string().nullable().optional(),
+  outletId: z.string().nullable().optional(),
 });
 
 const BufferNextResponseSchema = z

--- a/tests/unit/buffer-route.test.ts
+++ b/tests/unit/buffer-route.test.ts
@@ -87,7 +87,7 @@ describe("POST /buffer/next run status", () => {
   it("marks run as completed when pullNext returns found: true", async () => {
     mockPullNext.mockResolvedValue({
       found: true,
-      lead: { leadId: "lid", email: "a@b.com", externalId: null, data: {}, brandId: "b1", orgId: "test-org", userId: null },
+      lead: { leadId: "lid", email: "a@b.com", data: {}, brandId: "b1", orgId: "test-org", userId: null, apolloPersonId: null, journalistId: null, outletId: null },
     });
 
     const app = createApp();

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -248,7 +248,7 @@ describe("buffer", () => {
       expect(result.found).toBe(true);
       expect(result.lead?.leadId).toBe("lead-abc");
       expect(result.lead?.email).toBe("alice@acme.com");
-      expect(result.lead?.externalId).toBe("e-1");
+      expect(result.lead?.apolloPersonId).toBeNull();
       expect(result.lead?.data).toEqual({ name: "Alice", email: "alice@acme.com" });
     });
 
@@ -1057,7 +1057,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "jane@techcrunch.com",
-        externalId: "journalist:j-uuid-1",
+        externalId: "j-uuid-1",
         data: {
           firstName: "Jane",
           lastName: "Reporter",
@@ -1138,7 +1138,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "",
-        externalId: "journalist:j-uuid-2",
+        externalId: "j-uuid-2",
         data: {
           firstName: "John",
           lastName: "Writer",
@@ -1200,7 +1200,7 @@ describe("buffer", () => {
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "",
-          externalId: "journalist:j-uuid-3",
+          externalId: "j-uuid-3",
           data: {
             firstName: "Ghost",
             lastName: "Journalist",
@@ -1269,7 +1269,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "discovered@outlet.com",
-        externalId: "journalist:j-discovered",
+        externalId: "j-discovered",
         data: {
           firstName: "Jane",
           lastName: "Reporter",
@@ -1406,7 +1406,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "found@techcrunch.com",
-        externalId: "journalist:j-noemail",
+        externalId: "j-noemail",
         data: {
           firstName: "Bob",
           lastName: "Writer",


### PR DESCRIPTION
## Summary
- Replaced opaque `externalId` (with confusing `journalist:` prefix) with clear top-level fields: `apolloPersonId`, `journalistId`, `outletId` on the `ServedLead` response schema
- Removed `externalId` from the API response — it was internal-only and confusing for callers
- Removed `journalist:` prefix from internal buffer `externalId` storage (raw IDs, dedup still works)
- Workflows can now read `lead.journalistId` and `lead.outletId` directly instead of parsing `lead.data`

## Test plan
- [x] All 156 unit tests pass
- [x] Build + OpenAPI generation succeeds
- [ ] Verify workflow can read `journalistId`/`outletId` from buffer/next response

🤖 Generated with [Claude Code](https://claude.com/claude-code)