### PR TITLE
Add OpenAPI examples for buffer/next typed IDs

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -64,15 +64,21 @@
               },
               "apolloPersonId": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "description": "Apollo person ID from enrichment. Present when the lead was sourced or enriched via Apollo.",
+                "example": "5f2a3b4c5d6e7f8a9b0c1d2e"
               },
               "journalistId": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "description": "Journalist ID from journalists-service. Present only when sourceType is 'journalist'.",
+                "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
               },
               "outletId": {
                 "type": "string",
-                "nullable": true
+                "nullable": true,
+                "description": "Outlet ID from outlets-service. Present only when sourceType is 'journalist'.",
+                "example": "f9e8d7c6-b5a4-3210-fedc-ba0987654321"
               }
             },
             "required": [
@@ -87,6 +93,61 @@
         },
         "required": [
           "found"
+        ],
+        "description": "Response from pulling the next lead. When found is true, lead contains the served lead with typed IDs.",
+        "examples": [
+          {
+            "summary": "Apollo lead",
+            "value": {
+              "found": true,
+              "lead": {
+                "leadId": "c1d2e3f4-a5b6-7890-abcd-ef1234567890",
+                "email": "jane.doe@acme.com",
+                "data": {
+                  "firstName": "Jane",
+                  "lastName": "Doe",
+                  "title": "VP of Marketing",
+                  "organizationName": "Acme Corp",
+                  "organizationDomain": "acme.com"
+                },
+                "brandId": "brand-uuid",
+                "orgId": "org-uuid",
+                "userId": "user-uuid",
+                "apolloPersonId": "5f2a3b4c5d6e7f8a9b0c1d2e",
+                "journalistId": null,
+                "outletId": null
+              }
+            }
+          },
+          {
+            "summary": "Journalist lead",
+            "value": {
+              "found": true,
+              "lead": {
+                "leadId": "d4e5f6a7-b8c9-0123-abcd-ef4567890123",
+                "email": "john.writer@techcrunch.com",
+                "data": {
+                  "firstName": "John",
+                  "lastName": "Writer",
+                  "organizationName": "TechCrunch",
+                  "organizationDomain": "techcrunch.com",
+                  "sourceType": "journalist"
+                },
+                "brandId": "brand-uuid",
+                "orgId": "org-uuid",
+                "userId": "user-uuid",
+                "apolloPersonId": "7a8b9c0d1e2f3a4b5c6d7e8f",
+                "journalistId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "outletId": "f9e8d7c6-b5a4-3210-fedc-ba0987654321"
+              }
+            }
+          },
+          {
+            "summary": "Buffer exhausted",
+            "value": {
+              "found": false
+            }
+          }
         ]
       },
       "ApolloPersonData": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -203,9 +203,33 @@ const ServedLeadSchema = z.object({
   brandId: z.string(),
   orgId: z.string().nullable(),
   userId: z.string().nullable(),
-  apolloPersonId: z.string().nullable().optional(),
-  journalistId: z.string().nullable().optional(),
-  outletId: z.string().nullable().optional(),
+  apolloPersonId: z
+    .string()
+    .nullable()
+    .optional()
+    .openapi({
+      description:
+        "Apollo person ID from enrichment. Present when the lead was sourced or enriched via Apollo.",
+      example: "5f2a3b4c5d6e7f8a9b0c1d2e",
+    }),
+  journalistId: z
+    .string()
+    .nullable()
+    .optional()
+    .openapi({
+      description:
+        "Journalist ID from journalists-service. Present only when sourceType is 'journalist'.",
+      example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    }),
+  outletId: z
+    .string()
+    .nullable()
+    .optional()
+    .openapi({
+      description:
+        "Outlet ID from outlets-service. Present only when sourceType is 'journalist'.",
+      example: "f9e8d7c6-b5a4-3210-fedc-ba0987654321",
+    }),
 });
 
 const BufferNextResponseSchema = z
@@ -213,7 +237,64 @@ const BufferNextResponseSchema = z
     found: z.boolean(),
     lead: ServedLeadSchema.optional(),
   })
-  .openapi("BufferNextResponse");
+  .openapi("BufferNextResponse", {
+    description:
+      "Response from pulling the next lead. When found is true, lead contains the served lead with typed IDs.",
+    examples: [
+      {
+        summary: "Apollo lead",
+        value: {
+          found: true,
+          lead: {
+            leadId: "c1d2e3f4-a5b6-7890-abcd-ef1234567890",
+            email: "jane.doe@acme.com",
+            data: {
+              firstName: "Jane",
+              lastName: "Doe",
+              title: "VP of Marketing",
+              organizationName: "Acme Corp",
+              organizationDomain: "acme.com",
+            },
+            brandId: "brand-uuid",
+            orgId: "org-uuid",
+            userId: "user-uuid",
+            apolloPersonId: "5f2a3b4c5d6e7f8a9b0c1d2e",
+            journalistId: null,
+            outletId: null,
+          },
+        },
+      },
+      {
+        summary: "Journalist lead",
+        value: {
+          found: true,
+          lead: {
+            leadId: "d4e5f6a7-b8c9-0123-abcd-ef4567890123",
+            email: "john.writer@techcrunch.com",
+            data: {
+              firstName: "John",
+              lastName: "Writer",
+              organizationName: "TechCrunch",
+              organizationDomain: "techcrunch.com",
+              sourceType: "journalist",
+            },
+            brandId: "brand-uuid",
+            orgId: "org-uuid",
+            userId: "user-uuid",
+            apolloPersonId: "7a8b9c0d1e2f3a4b5c6d7e8f",
+            journalistId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            outletId: "f9e8d7c6-b5a4-3210-fedc-ba0987654321",
+          },
+        },
+      },
+      {
+        summary: "Buffer exhausted",
+        value: {
+          found: false,
+        },
+      },
+    ],
+  });
 
 // --- Cursor ---
 


### PR DESCRIPTION
## Summary
- Added descriptions and example values for `apolloPersonId`, `journalistId`, `outletId` fields
- Added 3 response examples to `BufferNextResponse`: Apollo lead, journalist lead, buffer exhausted
- Makes the OpenAPI spec self-documenting for workflow builders

## Test plan
- [x] All 156 unit tests pass
- [x] Build + OpenAPI generation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)