### PR TITLE
Move brandId from /status body to x-brand-id header

### DIFF
--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -12,8 +12,7 @@ import {
  * Falls back to all-false if email-gateway is unreachable —
  * the downstream /send endpoint has its own idempotency.
  *
- * With multi-brand, checks against the first brand ID (email-gateway
- * body param expects a single brandId; the full CSV is forwarded via header).
+ * With multi-brand, checks against the first brand ID via x-brand-id header.
  */
 export async function checkContacted(
   brandIds: string[],

--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -54,7 +54,8 @@ async function checkDeliveryStatusBatch(
   items: DeliveryStatusItem[],
   headers: Record<string, string>,
 ): Promise<DeliveryStatusResponse | null> {
-  const body: Record<string, unknown> = { brandId, items };
+  headers["x-brand-id"] = brandId;
+  const body: Record<string, unknown> = { items };
   if (campaignId) body.campaignId = campaignId;
 
   const response = await fetch(`${EMAIL_GATEWAY_SERVICE_URL}/status`, {

--- a/tests/unit/email-gateway-client.test.ts
+++ b/tests/unit/email-gateway-client.test.ts
@@ -56,13 +56,14 @@ describe("email-gateway-client", () => {
       const [url, opts] = mockFetch.mock.calls[0];
       expect(url).toContain("/status");
       expect(opts.method).toBe("POST");
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
       const body = JSON.parse(opts.body);
-      expect(body.brandId).toBe("brand-1");
+      expect(body.brandId).toBeUndefined();
       expect(body.campaignId).toBe("campaign-1");
       expect(body.items).toEqual([{ leadId: "lead-1", email: "alice@acme.com" }]);
     });
 
-    it("sends brandId without campaignId when campaignId is undefined", async () => {
+    it("sends brandId via x-brand-id header, not in body, when campaignId is undefined", async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({ results: [] }),
@@ -72,15 +73,12 @@ describe("email-gateway-client", () => {
         { leadId: "lead-1", email: "alice@acme.com" },
       ]);
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          body: JSON.stringify({
-            brandId: "brand-1",
-            items: [{ leadId: "lead-1", email: "alice@acme.com" }],
-          }),
-        })
-      );
+      const [, opts] = mockFetch.mock.calls[0];
+      expect(opts.headers["x-brand-id"]).toBe("brand-1");
+      const body = JSON.parse(opts.body);
+      expect(body.brandId).toBeUndefined();
+      expect(body.campaignId).toBeUndefined();
+      expect(body.items).toEqual([{ leadId: "lead-1", email: "alice@acme.com" }]);
     });
 
     it("returns null on non-200 response", async () => {


### PR DESCRIPTION
## Summary
- Removed `brandId` from `POST /status` request body in email-gateway client
- Brand scope now sent exclusively via `x-brand-id` header (already being set from context)
- Updated unit tests to assert header-based brand passing

Adapts to email-gateway-service breaking change: brandIds removed from /status body.

## Test plan
- [x] All 159 unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)