### PR TITLE
Throw on 5xx from downstream services instead of silent fallbacks

### DIFF
--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -170,7 +170,7 @@ export async function apolloSearch(
     return result;
   } catch (error) {
     console.error("[apollo-client] Search failed:", error);
-    return null;
+    throw error;
   }
 }
 
@@ -212,7 +212,7 @@ export async function apolloSearchNext(options: {
     });
   } catch (error) {
     console.error("[apollo-client] SearchNext failed:", error);
-    return null;
+    throw error;
   }
 }
 
@@ -328,7 +328,7 @@ export async function apolloMatch(
     });
   } catch (error) {
     console.error(`[apollo-client] Match failed for ${params.firstName} ${params.lastName} @ ${params.organizationDomain}:`, error);
-    return null;
+    throw error;
   }
 }
 
@@ -359,6 +359,6 @@ export async function apolloEnrich(
     return result;
   } catch (error) {
     console.error(`[apollo-client] Enrich failed for personId=${personId}:`, error);
-    return null;
+    throw error;
   }
 }

--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -35,7 +35,11 @@ export async function fetchBrand(
     const response = await fetch(url.toString(), { headers });
 
     if (!response.ok) {
-      console.warn(`[brand-client] Failed to fetch brand ${brandId}: ${response.status}`);
+      const msg = `[brand-client] Failed to fetch brand ${brandId}: ${response.status}`;
+      if (response.status >= 500) {
+        throw new Error(msg);
+      }
+      console.warn(msg);
       return null;
     }
 
@@ -43,7 +47,7 @@ export async function fetchBrand(
     return data.brand;
   } catch (error) {
     console.error("[brand-client] Error fetching brand:", error);
-    return null;
+    throw error;
   }
 }
 
@@ -86,7 +90,11 @@ export async function extractBrandFields(
     });
 
     if (!response.ok) {
-      console.warn(`[brand-client] extract-fields failed: ${response.status}`);
+      const msg = `[brand-client] extract-fields failed: ${response.status}`;
+      if (response.status >= 500) {
+        throw new Error(msg);
+      }
+      console.warn(msg);
       return null;
     }
 
@@ -94,7 +102,7 @@ export async function extractBrandFields(
     return data.results;
   } catch (error) {
     console.error("[brand-client] Error extracting brand fields:", error);
-    return null;
+    throw error;
   }
 }
 
@@ -109,7 +117,11 @@ export async function fetchExtractedFields(
     });
 
     if (!response.ok) {
-      console.warn(`[brand-client] fetch extracted-fields failed for brand ${brandId}: ${response.status}`);
+      const msg = `[brand-client] fetch extracted-fields failed for brand ${brandId}: ${response.status}`;
+      if (response.status >= 500) {
+        throw new Error(msg);
+      }
+      console.warn(msg);
       return null;
     }
 
@@ -117,6 +129,6 @@ export async function fetchExtractedFields(
     return data.fields;
   } catch (error) {
     console.error("[brand-client] Error fetching extracted fields:", error);
-    return null;
+    throw error;
   }
 }

--- a/src/lib/campaign-client.ts
+++ b/src/lib/campaign-client.ts
@@ -32,7 +32,11 @@ export async function fetchCampaign(
     });
 
     if (!response.ok) {
-      console.warn(`[campaign-client] Failed to fetch campaign ${campaignId}: ${response.status}`);
+      const msg = `[campaign-client] Failed to fetch campaign ${campaignId}: ${response.status}`;
+      if (response.status >= 500) {
+        throw new Error(msg);
+      }
+      console.warn(msg);
       return null;
     }
 
@@ -40,6 +44,6 @@ export async function fetchCampaign(
     return data.campaign;
   } catch (error) {
     console.error("[campaign-client] Error fetching campaign:", error);
-    return null;
+    throw error;
   }
 }

--- a/src/lib/journalist-client.ts
+++ b/src/lib/journalist-client.ts
@@ -56,7 +56,11 @@ export async function fetchNextJournalist(
     });
 
     if (!response.ok) {
-      console.warn(`[journalist-client] buffer/next failed for outlet ${outletId}: ${response.status}`);
+      const msg = `[journalist-client] buffer/next failed for outlet ${outletId}: ${response.status}`;
+      if (response.status >= 500) {
+        throw new Error(msg);
+      }
+      console.warn(msg);
       return { found: false };
     }
 
@@ -64,6 +68,6 @@ export async function fetchNextJournalist(
     return data;
   } catch (error) {
     console.error("[journalist-client] Error fetching next journalist:", error);
-    return { found: false };
+    throw error;
   }
 }

--- a/src/lib/outlet-client.ts
+++ b/src/lib/outlet-client.ts
@@ -72,7 +72,11 @@ export async function fetchNextOutlet(context: {
     });
 
     if (!response.ok) {
-      console.warn(`[outlet-client] buffer/next failed for campaign ${context.campaignId}: ${response.status}`);
+      const msg = `[outlet-client] buffer/next failed for campaign ${context.campaignId}: ${response.status}`;
+      if (response.status >= 500) {
+        throw new Error(msg);
+      }
+      console.warn(msg);
       return { found: false };
     }
 
@@ -80,7 +84,7 @@ export async function fetchNextOutlet(context: {
     return data;
   } catch (error) {
     console.error("[outlet-client] Error fetching next outlet:", error);
-    return { found: false };
+    throw error;
   }
 }
 
@@ -106,7 +110,11 @@ export async function fetchOutletsByCampaign(
     );
 
     if (!response.ok) {
-      console.warn(`[outlet-client] Failed to fetch outlets for campaign ${campaignId}: ${response.status}`);
+      const msg = `[outlet-client] Failed to fetch outlets for campaign ${campaignId}: ${response.status}`;
+      if (response.status >= 500) {
+        throw new Error(msg);
+      }
+      console.warn(msg);
       return null;
     }
 
@@ -114,6 +122,6 @@ export async function fetchOutletsByCampaign(
     return data.outlets;
   } catch (error) {
     console.error("[outlet-client] Error fetching outlets:", error);
-    return null;
+    throw error;
   }
 }

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -206,6 +206,23 @@ describe("service client headers", () => {
     });
   });
 
+  describe("brand-client fetchBrand", () => {
+    it("throws on 5xx error", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ error: "internal" }, 500));
+
+      const { fetchBrand } = await import("../../src/lib/brand-client.js");
+      await expect(fetchBrand("brand-1", "org-1")).rejects.toThrow("500");
+    });
+
+    it("returns null on 4xx error", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ error: "not found" }, 404));
+
+      const { fetchBrand } = await import("../../src/lib/brand-client.js");
+      const result = await fetchBrand("brand-1", "org-1");
+      expect(result).toBeNull();
+    });
+  });
+
   describe("brand-client extractBrandFields", () => {
     it("calls POST /brands/extract-fields (no brandId in path) and sends correct headers", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ results: [] }));
@@ -344,8 +361,17 @@ describe("service client headers", () => {
       expect(body).toEqual({});
     });
 
-    it("returns found: false on /buffer/next error", async () => {
+    it("throws on /buffer/next 5xx error", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ error: "fail" }, 502));
+
+      const { fetchNextOutlet } = await import("../../src/lib/outlet-client.js");
+      await expect(fetchNextOutlet({
+        orgId: "org-1", campaignId: "camp-1", brandId: "brand-1",
+      })).rejects.toThrow("502");
+    });
+
+    it("returns found: false on /buffer/next 4xx error", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ error: "not found" }, 404));
 
       const { fetchNextOutlet } = await import("../../src/lib/outlet-client.js");
       const result = await fetchNextOutlet({
@@ -423,13 +449,20 @@ describe("service client headers", () => {
       expect(body).toEqual({ outletId: "outlet-uuid-1" });
     });
 
-    it("returns found: false on error", async () => {
+    it("returns found: false on 4xx error", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ error: "not found" }, 404));
 
       const { fetchNextJournalist } = await import("../../src/lib/journalist-client.js");
       const result = await fetchNextJournalist("bad-outlet");
 
       expect(result).toEqual({ found: false });
+    });
+
+    it("throws on 5xx error", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ error: "downstream failure" }, 502));
+
+      const { fetchNextJournalist } = await import("../../src/lib/journalist-client.js");
+      await expect(fetchNextJournalist("bad-outlet")).rejects.toThrow("502");
     });
   });
 


### PR DESCRIPTION
## Summary
- All service clients (journalist, outlet, brand, campaign, apollo) were silently swallowing 5xx errors from downstream services and returning `null` or `{ found: false }`
- This made downstream outages (e.g. journalists-service returning 502 because brand-service was down) look like "no results found" — masking the real problem
- Now 5xx errors throw and propagate as 500 to the caller, while 4xx errors still return gracefully

## Test plan
- [x] Updated existing unit tests that expected `{ found: false }` on 502 → now expect throws
- [x] Added new tests for 5xx throw behavior on journalist-client, outlet-client, brand-client
- [x] Added tests confirming 4xx still returns null/found:false gracefully
- [x] All 163 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)