### PR TITLE
Surface replyClassification from email-gateway in GET /leads/status

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -768,7 +768,18 @@
           },
           "replied": {
             "type": "boolean",
-            "description": "Whether the lead replied. Currently a raw boolean from email-gateway (any reply = true). Reply classification (positive/negative/other) will be added once email-gateway exposes it."
+            "description": "Whether the lead replied (any reply, regardless of sentiment)"
+          },
+          "replyClassification": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "positive",
+              "negative",
+              "neutral",
+              null
+            ],
+            "description": "Classification of the most recent reply from email-gateway. 'positive' = interested or willing to meet, 'negative' = not interested, 'neutral' = ambiguous or informational. null when no reply detected."
           },
           "lastDeliveredAt": {
             "type": "string",
@@ -784,6 +795,7 @@
           "delivered",
           "bounced",
           "replied",
+          "replyClassification",
           "lastDeliveredAt"
         ]
       }

--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -9,6 +9,7 @@ export interface LeadDeliveryStatus {
   contacted: boolean;
   delivered: boolean;
   replied: boolean;
+  replyClassification: "positive" | "negative" | "neutral" | null;
   lastDeliveredAt: string | null;
 }
 

--- a/src/routes/lead-status.ts
+++ b/src/routes/lead-status.ts
@@ -46,12 +46,17 @@ function flattenCampaignStatus(result: StatusResult) {
     tx?.campaign.lead.replied
   );
 
+  const replyClassification =
+    bc?.campaign.lead.replyClassification ??
+    tx?.campaign.lead.replyClassification ??
+    null;
+
   const lastDeliveredAt =
     bc?.campaign.email.lastDeliveredAt ??
     tx?.campaign.email.lastDeliveredAt ??
     null;
 
-  return { contacted, delivered, bounced, replied, lastDeliveredAt };
+  return { contacted, delivered, bounced, replied, replyClassification, lastDeliveredAt };
 }
 
 /**
@@ -85,15 +90,20 @@ function flattenBrandStatus(result: StatusResult) {
     tx?.brand.lead.replied
   );
 
+  const replyClassification =
+    bc?.brand.lead.replyClassification ??
+    tx?.brand.lead.replyClassification ??
+    null;
+
   const lastDeliveredAt =
     bc?.brand.email.lastDeliveredAt ??
     tx?.brand.email.lastDeliveredAt ??
     null;
 
-  return { contacted, delivered, bounced, replied, lastDeliveredAt };
+  return { contacted, delivered, bounced, replied, replyClassification, lastDeliveredAt };
 }
 
-const DEFAULT_FLAT = { contacted: false, delivered: false, bounced: false, replied: false, lastDeliveredAt: null };
+const DEFAULT_FLAT = { contacted: false, delivered: false, bounced: false, replied: false, replyClassification: null, lastDeliveredAt: null };
 
 router.get("/leads/status", authenticate, async (req: AuthenticatedRequest, res) => {
   try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -395,10 +395,17 @@ const LeadStatusItemSchema = z
     bounced: z.boolean(),
     replied: z
       .boolean()
+      .openapi({ description: "Whether the lead replied (any reply, regardless of sentiment)" }),
+    replyClassification: z
+      .enum(["positive", "negative", "neutral"])
+      .nullable()
       .openapi({
         description:
-          "Whether the lead replied. Currently a raw boolean from email-gateway (any reply = true). " +
-          "Reply classification (positive/negative/other) will be added once email-gateway exposes it.",
+          "Classification of the most recent reply from email-gateway. " +
+          "'positive' = interested or willing to meet, " +
+          "'negative' = not interested, " +
+          "'neutral' = ambiguous or informational. " +
+          "null when no reply detected.",
       }),
     lastDeliveredAt: z.string().nullable(),
   })

--- a/tests/unit/lead-status.test.ts
+++ b/tests/unit/lead-status.test.ts
@@ -61,7 +61,7 @@ function makeBroadcastStatus(overrides: {
   campaign?: { lead?: Record<string, unknown>; email?: Record<string, unknown> };
   brand?: { lead?: Record<string, unknown>; email?: Record<string, unknown> };
 }) {
-  const defaultLead = { contacted: false, delivered: false, replied: false, lastDeliveredAt: null };
+  const defaultLead = { contacted: false, delivered: false, replied: false, replyClassification: null, lastDeliveredAt: null };
   const defaultEmail = { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null };
   return {
     campaign: {
@@ -212,6 +212,7 @@ describe("GET /leads/status", () => {
       delivered: true,
       bounced: false,
       replied: true,
+      replyClassification: null,
       lastDeliveredAt: "2026-03-29T10:00:00Z",
     });
   });
@@ -258,6 +259,7 @@ describe("GET /leads/status", () => {
       delivered: false,
       bounced: false,
       replied: false,
+      replyClassification: null,
     });
   });
 
@@ -312,6 +314,83 @@ describe("GET /leads/status", () => {
     expect(res.body.statuses[0].outletId).toBe("o1");
   });
 
+  it("surfaces replyClassification from email-gateway (campaign-scoped)", async () => {
+    mockWhere.mockResolvedValue([
+      { leadId: "lead-1", email: "alice@acme.com", brandIds: ["b1"], metadata: null },
+    ]);
+
+    mockCheckDeliveryStatus.mockResolvedValue({
+      results: [
+        {
+          leadId: "lead-1",
+          email: "alice@acme.com",
+          broadcast: makeBroadcastStatus({
+            campaign: {
+              lead: { contacted: true, delivered: true, replied: true, replyClassification: "positive" },
+              email: { contacted: true, delivered: true, lastDeliveredAt: "2026-04-01T12:00:00Z" },
+            },
+          }),
+        },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app).get("/leads/status?campaignId=c1");
+    expect(res.body.statuses[0].replyClassification).toBe("positive");
+    expect(res.body.statuses[0].replied).toBe(true);
+  });
+
+  it("surfaces replyClassification from email-gateway (brand-scoped)", async () => {
+    mockWhere.mockResolvedValue([
+      { leadId: "lead-1", email: "alice@acme.com", brandIds: ["b1"], metadata: null },
+    ]);
+
+    mockCheckDeliveryStatus.mockResolvedValue({
+      results: [
+        {
+          leadId: "lead-1",
+          email: "alice@acme.com",
+          broadcast: makeBroadcastStatus({
+            brand: {
+              lead: { contacted: true, delivered: true, replied: true, replyClassification: "negative" },
+              email: { contacted: true, delivered: true, lastDeliveredAt: "2026-04-01T12:00:00Z" },
+            },
+          }),
+        },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app).get("/leads/status?brandId=b1");
+    expect(res.body.statuses[0].replyClassification).toBe("negative");
+  });
+
+  it("returns null replyClassification when no reply", async () => {
+    mockWhere.mockResolvedValue([
+      { leadId: "lead-1", email: "alice@acme.com", brandIds: ["b1"], metadata: null },
+    ]);
+
+    mockCheckDeliveryStatus.mockResolvedValue({
+      results: [
+        {
+          leadId: "lead-1",
+          email: "alice@acme.com",
+          broadcast: makeBroadcastStatus({
+            campaign: {
+              lead: { contacted: true, delivered: true },
+              email: { contacted: true, delivered: true, lastDeliveredAt: "2026-04-01T12:00:00Z" },
+            },
+          }),
+        },
+      ],
+    });
+
+    const app = createApp();
+    const res = await request(app).get("/leads/status?campaignId=c1");
+    expect(res.body.statuses[0].replyClassification).toBeNull();
+    expect(res.body.statuses[0].replied).toBe(false);
+  });
+
   it("returns null journalistId/outletId when metadata is null", async () => {
     mockWhere.mockResolvedValue([
       { leadId: "lead-1", email: "alice@acme.com", brandIds: ["b1"], metadata: null },
@@ -326,19 +405,20 @@ describe("GET /leads/status", () => {
 });
 
 describe("flattenCampaignStatus", () => {
-  it("detects replied from broadcast campaign lead", () => {
+  it("detects replied and replyClassification from broadcast campaign lead", () => {
     const result = flattenCampaignStatus({
       leadId: "l1",
       email: "a@b.com",
       broadcast: makeBroadcastStatus({
         campaign: {
-          lead: { contacted: true, delivered: true, replied: true },
+          lead: { contacted: true, delivered: true, replied: true, replyClassification: "positive" },
           email: { contacted: true, delivered: true, lastDeliveredAt: "2026-03-29T10:00:00Z" },
         },
       }),
     });
 
     expect(result.replied).toBe(true);
+    expect(result.replyClassification).toBe("positive");
     expect(result.delivered).toBe(true);
     expect(result.contacted).toBe(true);
     expect(result.lastDeliveredAt).toBe("2026-03-29T10:00:00Z");
@@ -371,7 +451,7 @@ describe("flattenCampaignStatus", () => {
   it("returns all false when no providers present", () => {
     const result = flattenCampaignStatus({ leadId: "l1", email: "a@b.com" });
     expect(result).toEqual({
-      contacted: false, delivered: false, bounced: false, replied: false, lastDeliveredAt: null,
+      contacted: false, delivered: false, bounced: false, replied: false, replyClassification: null, lastDeliveredAt: null,
     });
   });
 });
@@ -399,7 +479,7 @@ describe("flattenBrandStatus", () => {
   it("returns all false when no providers present", () => {
     const result = flattenBrandStatus({ leadId: "l1", email: "a@b.com" });
     expect(result).toEqual({
-      contacted: false, delivered: false, bounced: false, replied: false, lastDeliveredAt: null,
+      contacted: false, delivered: false, bounced: false, replied: false, replyClassification: null, lastDeliveredAt: null,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Consumes the new `replyClassification` field from email-gateway's `POST /status` response (their PR #63)
- Surfaces it in `GET /leads/status` response: `"positive"` | `"negative"` | `"neutral"` | `null`
- Works in both campaign-scoped and brand-scoped (cross-campaign) modes
- No new env vars or dependencies — just reading a new field from an existing response

## Test plan
- [x] 174 unit tests pass
- [x] Tests for replyClassification in campaign-scoped mode
- [x] Tests for replyClassification in brand-scoped mode
- [x] Tests for null replyClassification when no reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)