### PR TITLE
Fix infinite loop when journalists have no email

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -388,6 +388,11 @@ async function fillBufferFromJournalists(params: {
         }
       }
 
+      // No email after all enrichment attempts — skip, can't serve without email
+      if (!validEmail) {
+        continue;
+      }
+
       const data: Record<string, unknown> = {
         firstName: journalist.firstName,
         lastName: journalist.lastName,
@@ -404,7 +409,7 @@ async function fillBufferFromJournalists(params: {
       await db.insert(leadBuffer).values({
         namespace: params.campaignId,
         campaignId: params.campaignId,
-        email: validEmail ?? "",
+        email: validEmail,
         externalId,
         data,
         status: "buffered",

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -1488,6 +1488,72 @@ describe("buffer", () => {
       expect(result.lead?.email).toBe("found@techcrunch.com");
     });
 
+    it("does not buffer journalist when no email found after apolloMatch — prevents infinite loop", async () => {
+      // Regression: when a journalist has no email and apolloMatch fails,
+      // fillBufferFromJournalists should NOT buffer the journalist. Otherwise
+      // pullNext claims it, skips it (no email), calls fillBuffer again, and
+      // the cycle repeats for every outlet — causing an infinite loop of service calls.
+      pgSqlMock.mockResolvedValue([]); // buffer always empty
+
+      vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
+
+      vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([
+        { id: "outlet-1", outletName: "Expat Focus", outletUrl: "https://expatfocus.com", outletDomain: "expatfocus.com", relevanceScore: 80, outletStatus: "open", campaignId: "campaign-1" },
+      ]);
+
+      // Journalist has no valid emails
+      vi.mocked(fetchNextJournalist)
+        .mockResolvedValueOnce({
+          found: true,
+          journalist: {
+            id: "j-noemail-1",
+            journalistName: "Ghost Writer",
+            firstName: "Ghost",
+            lastName: "Writer",
+            entityType: "individual" as const,
+            relevanceScore: 0.7,
+            whyRelevant: "Writes about relocation",
+            whyNotRelevant: "",
+            emails: [],
+          },
+        })
+        .mockResolvedValueOnce({ found: false });
+
+      // apolloMatch fails — no email found
+      vi.mocked(apolloMatch).mockResolvedValueOnce({
+        enrichmentId: null,
+        person: null,
+        cached: false,
+      });
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      const valuesMock = vi.fn().mockReturnValue({
+        onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandIds: ["brand-1"],
+        sourceType: "journalist",
+      });
+
+      expect(result.found).toBe(false);
+      // apolloMatch was tried during fillBufferFromJournalists
+      expect(vi.mocked(apolloMatch)).toHaveBeenCalledOnce();
+      // Crucially: db.insert should only be called for the cursor save, NOT for a buffer row
+      // (the journalist was not buffered because no email was found)
+      const { leadBuffer } = await import("../../src/db/schema.js");
+      const insertCalls = vi.mocked(db.insert).mock.calls;
+      const bufferInserts = insertCalls.filter(([table]) => table === leadBuffer);
+      expect(bufferInserts).toHaveLength(0);
+    });
+
     it("skips lead when markServed returns inserted: false (race condition dedup)", async () => {
       // Regression test: two concurrent pullNext calls claim different rows
       // but both have the same email. The second call's markServed returns


### PR DESCRIPTION
## Summary
- `fillBufferFromJournalists` was buffering journalists even when no email was found (neither from journalists-service nor apolloMatch)
- `pullNext` would claim the row, fail to enrich, skip it, and call `fillBuffer` again — cascading through every outlet and triggering expensive discovery calls (google-service, articles-service, brand-service) in a loop
- Now journalists without email are skipped at buffer time, breaking the cycle

## Test plan
- [x] Added regression test: "does not buffer journalist when no email found after apolloMatch — prevents infinite loop"
- [x] All 176 unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)