### PR TITLE
Fix namespace column storing campaignId instead of sourceType

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -13,7 +13,7 @@ async function isInBuffer(orgId: string, campaignId: string, externalId: string)
   const row = await db.query.leadBuffer.findFirst({
     where: and(
       eq(leadBuffer.orgId, orgId),
-      eq(leadBuffer.namespace, campaignId),
+      eq(leadBuffer.campaignId, campaignId),
       eq(leadBuffer.externalId, externalId)
     ),
   });
@@ -193,7 +193,7 @@ async function fillBufferFromSearch(params: {
       if (email && contactedMap.get(email)) continue;
 
       await db.insert(leadBuffer).values({
-        namespace: params.campaignId,
+        namespace: "apollo",
         campaignId: params.campaignId,
         email: email ?? "",
         externalId: externalId,
@@ -407,7 +407,7 @@ async function fillBufferFromJournalists(params: {
       };
 
       await db.insert(leadBuffer).values({
-        namespace: params.campaignId,
+        namespace: "journalist",
         campaignId: params.campaignId,
         email: validEmail,
         externalId,
@@ -477,7 +477,8 @@ export async function pullNext(params: {
       WHERE id = (
         SELECT id FROM lead_buffer
         WHERE org_id = ${params.orgId}
-          AND namespace = ${params.campaignId}
+          AND campaign_id = ${params.campaignId}
+          AND namespace = ${params.sourceType}
           AND status = 'buffered'
         ORDER BY CASE WHEN email != '' THEN 0 ELSE 1 END
         LIMIT 1
@@ -710,7 +711,7 @@ export async function pullNext(params: {
 
     const { inserted } = await markServed({
       orgId: params.orgId,
-      namespace: params.campaignId,
+      namespace: params.sourceType,
       brandIds: params.brandIds,
       campaignId: params.campaignId,
       email,

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -1619,5 +1619,166 @@ describe("buffer", () => {
       expect(result.lead?.email).toBe("unique@other.com");
       expect(result.lead?.leadId).toBe("lead-next");
     });
+
+    it("sets namespace to 'apollo' (not campaignId) when filling buffer from Apollo search (regression)", async () => {
+      // First call: buffer empty → triggers fillBufferFromSearch
+      // Second call: buffer has the lead
+      pgSqlMock
+        .mockResolvedValueOnce([])  // buffer empty
+        .mockResolvedValueOnce([toClaimedRow({
+          id: "buf-ns-1",
+          namespace: "apollo",
+          campaignId: "campaign-uuid-123",
+          email: "ns-test@example.com",
+          externalId: "apollo-ns-1",
+          data: { firstName: "NsTest" },
+          brandIds: ["brand-1"],
+          orgId: "org-1",
+          userId: null,
+        })]);
+
+      vi.mocked(apolloSearchParams).mockResolvedValue({
+        searchParams: { personTitles: ["CEO"] },
+        totalResults: 1,
+        attempts: 1,
+      });
+      vi.mocked(apolloSearchNext).mockResolvedValue({
+        people: [{ id: "apollo-ns-1", email: "ns-test@example.com", firstName: "NsTest" }],
+        done: true,
+        totalEntries: 1,
+      });
+      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
+
+      const insertValues: unknown[] = [];
+      const valuesMock = vi.fn().mockImplementation((vals) => {
+        insertValues.push(vals);
+        return { onConflictDoNothing: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: "served-ns-1" }]) }) };
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-uuid-123",
+        brandIds: ["brand-1"],
+        sourceType: "apollo",
+      });
+
+      // The first insert call should be the buffer row with namespace="apollo"
+      const bufferInsert = insertValues[0] as Record<string, unknown>;
+      expect(bufferInsert.namespace).toBe("apollo");
+      expect(bufferInsert.namespace).not.toBe("campaign-uuid-123");
+    });
+
+    it("sets namespace to 'journalist' (not campaignId) when filling buffer from journalists (regression)", async () => {
+      pgSqlMock
+        .mockResolvedValueOnce([])  // buffer empty
+        .mockResolvedValueOnce([toClaimedRow({
+          id: "buf-jns-1",
+          namespace: "journalist",
+          campaignId: "campaign-uuid-456",
+          email: "journalist@outlet.com",
+          externalId: "journalist-id-1",
+          data: { firstName: "Jane", lastName: "Doe", sourceType: "journalist", journalistId: "journalist-id-1" },
+          brandIds: ["brand-1"],
+          orgId: "org-1",
+          userId: null,
+        })]);
+
+      // Setup outlets
+      vi.mocked(fetchOutletsByCampaign).mockResolvedValueOnce([
+        { id: "outlet-1", outletName: "TechCrunch", outletUrl: "https://techcrunch.com", outletDomain: "techcrunch.com" },
+      ] as never);
+
+      // Setup journalist
+      vi.mocked(fetchNextJournalist)
+        .mockResolvedValueOnce({
+          found: true,
+          journalist: {
+            id: "journalist-id-1",
+            firstName: "Jane",
+            lastName: "Doe",
+            journalistName: "Jane Doe",
+            entityType: "person",
+            emails: [{ email: "journalist@outlet.com", isValid: true, confidence: 0.9 }],
+          },
+        } as never)
+        .mockResolvedValueOnce({ found: false });
+
+      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
+
+      const insertValues: unknown[] = [];
+      const valuesMock = vi.fn().mockImplementation((vals) => {
+        insertValues.push(vals);
+        return { onConflictDoNothing: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: "served-jns-1" }]) }) };
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      // Mock cursor
+      vi.mocked(db.query.cursors.findFirst).mockResolvedValueOnce(undefined);
+
+      await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-uuid-456",
+        brandIds: ["brand-1"],
+        sourceType: "journalist",
+      });
+
+      // The first insert call should be the buffer row with namespace="journalist"
+      const bufferInsert = insertValues[0] as Record<string, unknown>;
+      expect(bufferInsert.namespace).toBe("journalist");
+      expect(bufferInsert.namespace).not.toBe("campaign-uuid-456");
+    });
+
+    it("passes sourceType as namespace to markServed (not campaignId) (regression)", async () => {
+      pgSqlMock.mockResolvedValue([toClaimedRow({
+        id: "buf-ms-1",
+        namespace: "apollo",
+        campaignId: "campaign-uuid-789",
+        email: "served@example.com",
+        externalId: "e-ms-1",
+        data: { name: "Served" },
+        brandIds: ["brand-1"],
+        orgId: "org-1",
+        userId: null,
+      })]);
+
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
+      vi.mocked(resolveOrCreateLead).mockResolvedValue({ leadId: "lead-ms-1", isNew: true });
+
+      const insertValues: unknown[] = [];
+      const returningMock = vi.fn().mockResolvedValue([{ id: "served-ms-1" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockImplementation((vals) => {
+        insertValues.push(vals);
+        return { onConflictDoNothing: onConflictMock };
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-uuid-789",
+        brandIds: ["brand-1"],
+        sourceType: "apollo",
+      });
+
+      // markServed inserts into servedLeads — find the insert that has namespace
+      const servedInsert = insertValues.find(
+        (v) => (v as Record<string, unknown>).namespace !== undefined
+      ) as Record<string, unknown>;
+      expect(servedInsert).toBeDefined();
+      expect(servedInsert.namespace).toBe("apollo");
+      expect(servedInsert.namespace).not.toBe("campaign-uuid-789");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Fixed `namespace` column in `lead_buffer` and `served_leads` being set to campaign UUID instead of source type (`"apollo"` or `"journalist"`)
- Updated all buffer insertion points, the `pullNext` SQL query, and the `markServed` call to use the correct source type
- This was causing `journalistsFound` stat to always show 0 (features-service queries by `namespace = 'journalist'`) and lead source display to be wrong in the dashboard

## Test plan
- [x] Added 3 regression tests verifying namespace is set to source type, not campaignId
- [x] All 179 unit tests pass
- [x] Build succeeds
- [ ] **Prod backfill needed**: existing rows have UUID as namespace — need SQL migration to fix (see below)

## Prod backfill (required after deploy)
```sql
-- Fix lead_buffer namespace
UPDATE lead_buffer
SET namespace = CASE
  WHEN (data->>'sourceType') = 'journalist' THEN 'journalist'
  ELSE 'apollo'
END
WHERE namespace NOT IN ('apollo', 'journalist');

-- Fix served_leads namespace
UPDATE served_leads
SET namespace = CASE
  WHEN (metadata->>'journalistId') IS NOT NULL THEN 'journalist'
  ELSE 'apollo'
END
WHERE namespace NOT IN ('apollo', 'journalist');
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)