### PR TITLE
Add pullNext outcome logs for lead fetch tracing

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -535,6 +535,7 @@ export async function pullNext(params: {
         continue; // Retry pulling from buffer
       }
 
+      console.log(`[lead-service] pullNext found=false campaign=${params.campaignId} source=${st}`);
       return { found: false };
     }
 
@@ -748,6 +749,7 @@ export async function pullNext(params: {
     const dataObj = finalData as Record<string, unknown>;
     const isJournalist = dataObj.sourceType === "journalist";
 
+    console.log(`[lead-service] pullNext found=true campaign=${params.campaignId} source=${params.sourceType} email=${email} leadId=${leadId}`);
     return {
       found: true,
       lead: {


### PR DESCRIPTION
## Summary
- Adds a `console.log` in `pullNext()` when a lead is found (`found=true` with email, leadId, source type) and when no lead is available (`found=false` with campaign and source)
- Makes it easy to trace lead serving outcomes in Railway logs

## Test plan
- [x] Build passes
- [x] Pre-existing test failures unchanged (cursor integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)