### PR TITLE
Add retry logic to fetchNextOutlet for transient 500s

### DIFF
--- a/src/lib/outlet-client.ts
+++ b/src/lib/outlet-client.ts
@@ -49,6 +49,8 @@ function buildHeaders(context?: {
   return headers;
 }
 
+const RETRY_DELAYS_MS = [5_000, 15_000];
+
 export async function fetchNextOutlet(context: {
   orgId: string;
   userId?: string;
@@ -59,34 +61,48 @@ export async function fetchNextOutlet(context: {
   featureSlug?: string;
   idempotencyKey?: string;
 }): Promise<{ found: boolean; outlet?: BufferNextOutlet }> {
-  try {
-    const headers = buildHeaders(context);
+  const headers = buildHeaders(context);
+  const body: Record<string, unknown> = {};
+  if (context.idempotencyKey) body.idempotencyKey = context.idempotencyKey;
 
-    const body: Record<string, unknown> = {};
-    if (context.idempotencyKey) body.idempotencyKey = context.idempotencyKey;
+  let lastError: Error | null = null;
 
-    const response = await fetch(`${OUTLETS_SERVICE_URL}/buffer/next`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(body),
-      signal: AbortSignal.timeout(300_000),
-    });
-
-    if (!response.ok) {
-      const msg = `[outlet-client] buffer/next failed for campaign ${context.campaignId}: ${response.status}`;
-      if (response.status >= 500) {
-        throw new Error(msg);
-      }
-      console.warn(msg);
-      return { found: false };
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    if (attempt > 0) {
+      const delay = RETRY_DELAYS_MS[attempt - 1];
+      console.log(`[outlet-client] Retrying buffer/next for campaign ${context.campaignId} in ${delay}ms (attempt ${attempt + 1}/${RETRY_DELAYS_MS.length + 1})`);
+      await new Promise((r) => setTimeout(r, delay));
     }
 
-    const data = (await response.json()) as { found: boolean; outlet?: BufferNextOutlet };
-    return data;
-  } catch (error) {
-    console.error("[outlet-client] Error fetching next outlet:", error);
-    throw error;
+    try {
+      const response = await fetch(`${OUTLETS_SERVICE_URL}/buffer/next`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(300_000),
+      });
+
+      if (!response.ok) {
+        const msg = `[outlet-client] buffer/next failed for campaign ${context.campaignId}: ${response.status}`;
+        if (response.status >= 500) {
+          lastError = new Error(msg);
+          continue;
+        }
+        console.warn(msg);
+        return { found: false };
+      }
+
+      const data = (await response.json()) as { found: boolean; outlet?: BufferNextOutlet };
+      return data;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      console.warn(`[outlet-client] buffer/next attempt ${attempt + 1} failed for campaign ${context.campaignId}:`, lastError.message);
+      continue;
+    }
   }
+
+  console.error(`[outlet-client] buffer/next exhausted all ${RETRY_DELAYS_MS.length + 1} attempts for campaign ${context.campaignId}`);
+  throw lastError!;
 }
 
 export async function fetchOutletsByCampaign(

--- a/tests/unit/outlet-client.test.ts
+++ b/tests/unit/outlet-client.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchNextOutlet, fetchOutletsByCampaign } from "../../src/lib/outlet-client.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const baseContext = {
+  orgId: "org-1",
+  userId: "user-1",
+  runId: "run-1",
+  campaignId: "camp-1",
+  brandId: "brand-1",
+};
+
+describe("outlet-client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("fetchNextOutlet", () => {
+    it("returns outlet on first success", async () => {
+      const outlet = { outletId: "o-1", outletName: "Test Outlet", found: true };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ found: true, outlet }),
+      });
+
+      const result = await fetchNextOutlet(baseContext);
+      expect(result.found).toBe(true);
+      expect(result.outlet).toEqual(outlet);
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it("retries on 500 and succeeds on second attempt", async () => {
+      const outlet = { outletId: "o-1", outletName: "Test Outlet" };
+
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ found: true, outlet }),
+        });
+
+      const promise = fetchNextOutlet(baseContext);
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      const result = await promise;
+      expect(result.found).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries twice on consecutive 500s and succeeds on third attempt", async () => {
+      const outlet = { outletId: "o-1", outletName: "Test Outlet" };
+
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ found: true, outlet }),
+        });
+
+      const promise = fetchNextOutlet(baseContext);
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      const result = await promise;
+      expect(result.found).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("throws after exhausting all retries on 500", async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({ ok: false, status: 500 });
+
+      // Capture rejection eagerly to avoid unhandled rejection warnings
+      const promise = fetchNextOutlet(baseContext).catch((e: Error) => e);
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      const error = await promise;
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("buffer/next failed");
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not retry on 4xx errors", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 400 });
+
+      const result = await fetchNextOutlet(baseContext);
+      expect(result.found).toBe(false);
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it("retries on network errors (fetch throws)", async () => {
+      const outlet = { outletId: "o-1", outletName: "Test Outlet" };
+
+      mockFetch
+        .mockImplementationOnce(() => Promise.reject(new Error("fetch failed")))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ found: true, outlet }),
+        });
+
+      // Capture eagerly so the initial rejection doesn't go unhandled during timer wait
+      let resolved: { found: boolean; outlet?: unknown } | Error | undefined;
+      const promise = fetchNextOutlet(baseContext).then(
+        (v) => { resolved = v; },
+        (e) => { resolved = e; },
+      );
+      await vi.advanceTimersByTimeAsync(5_000);
+      await promise;
+
+      expect(resolved).not.toBeInstanceOf(Error);
+      expect((resolved as { found: boolean }).found).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws after exhausting retries on network errors", async () => {
+      mockFetch
+        .mockImplementationOnce(() => Promise.reject(new Error("connection refused")))
+        .mockImplementationOnce(() => Promise.reject(new Error("connection refused")))
+        .mockImplementationOnce(() => Promise.reject(new Error("connection refused")));
+
+      const promise = fetchNextOutlet(baseContext).catch((e: Error) => e);
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      const error = await promise;
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("connection refused");
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("fetchOutletsByCampaign", () => {
+    it("returns outlets on success", async () => {
+      const outlets = [{ id: "o-1", outletName: "Test" }];
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ outlets }),
+      });
+
+      const result = await fetchOutletsByCampaign("camp-1", "org-1");
+      expect(result).toEqual(outlets);
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it("throws on 500", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+      await expect(fetchOutletsByCampaign("camp-1", "org-1")).rejects.toThrow(
+        "Failed to fetch outlets"
+      );
+    });
+
+    it("returns null on 4xx", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+      const result = await fetchOutletsByCampaign("camp-1", "org-1");
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -362,12 +362,19 @@ describe("service client headers", () => {
     });
 
     it("throws on /buffer/next 5xx error", async () => {
+      vi.useFakeTimers();
       fetchSpy.mockReturnValue(jsonResponse({ error: "fail" }, 502));
 
       const { fetchNextOutlet } = await import("../../src/lib/outlet-client.js");
-      await expect(fetchNextOutlet({
+      const promise = fetchNextOutlet({
         orgId: "org-1", campaignId: "camp-1", brandId: "brand-1",
-      })).rejects.toThrow("502");
+      }).catch((e: Error) => e);
+
+      await vi.advanceTimersByTimeAsync(20_000);
+      const error = await promise;
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("502");
+      vi.useRealTimers();
     });
 
     it("returns found: false on /buffer/next 4xx error", async () => {


### PR DESCRIPTION
## Summary
- Adds retry with backoff (3 attempts: 0s, 5s, 15s) to `fetchNextOutlet` for transient 500 errors and network failures
- 4xx errors still return `{ found: false }` immediately (no retry)
- After exhausting retries, throws the last error (fail loud preserved)
- Fixes campaign auto-stop caused by transient brand-service timeouts in outlets-service

## Test plan
- [x] 10 new unit tests covering: success, retry on 500, retry on network error, exhaustion, no retry on 4xx
- [x] Updated existing `service-clients-headers` test for retry-aware assertion
- [x] All 189 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)