### PR TITLE
Fix premature campaign auto-stop in journalist mode

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -311,127 +311,170 @@ async function fillBufferFromJournalists(params: {
   }
 
   let totalFilled = 0;
+  let oi = cursorState.outletIndex;
 
-  for (let oi = cursorState.outletIndex; oi < outlets.length; oi++) {
-    const outlet = outlets[oi];
-    const organizationDomain = outlet.outletDomain || extractDomain(outlet.outletUrl);
+  // Outer loop: iterate through known outlets, discovering more when exhausted.
+  // Keep going until outlet-service has no more outlets to offer.
+  const MAX_DISCOVERY_ROUNDS = 50;
+  let discoveryRounds = 0;
 
-    // Call journalists-service buffer/next in a loop for this outlet
-    // journalists-service manages its own internal buffer per (campaign, outlet)
-    const MAX_JOURNALIST_PULLS = 50;
-    for (let pull = 0; pull < MAX_JOURNALIST_PULLS; pull++) {
-      const result = await fetchNextJournalist(outlet.id, {
-        ...serviceContext,
-        campaignId: params.campaignId,
-        orgId: params.orgId,
-      });
+  while (true) {
+    // Inner loop: iterate through known outlets starting from cursor
+    for (; oi < outlets.length; oi++) {
+      const outlet = outlets[oi];
+      const organizationDomain = outlet.outletDomain || extractDomain(outlet.outletUrl);
 
-      if (!result.found || !result.journalist) {
-        // No more journalists for this outlet
-        break;
-      }
+      // Call journalists-service buffer/next in a loop for this outlet
+      // journalists-service manages its own internal buffer per (campaign, outlet)
+      const MAX_JOURNALIST_PULLS = 50;
+      for (let pull = 0; pull < MAX_JOURNALIST_PULLS; pull++) {
+        const result = await fetchNextJournalist(outlet.id, {
+          ...serviceContext,
+          campaignId: params.campaignId,
+          orgId: params.orgId,
+        });
 
-      const journalist = result.journalist;
-
-      // Skip organization-type entities (we need individual people)
-      if (journalist.entityType === "organization") continue;
-
-      const externalId = journalist.id;
-
-      if (await isInBuffer(params.orgId, params.campaignId, externalId)) continue;
-
-      // Try email from buffer/next response first
-      let validEmail = journalist.emails
-        ?.filter(e => e.isValid)
-        ?.sort((a, b) => b.confidence - a.confidence)
-        ?.[0]?.email ?? null;
-
-      let enrichedData: Record<string, unknown> | null = null;
-
-      // No email — proactively match via Apollo Service
-      if (!validEmail && journalist.firstName && journalist.lastName && organizationDomain) {
-        const matchResult = await apolloMatch(
-          {
-            firstName: journalist.firstName,
-            lastName: journalist.lastName,
-            organizationDomain,
-          },
-          {
-            runId: params.pushRunId,
-            orgId: params.orgId,
-            userId: params.userId,
-            brandId: brandIdCsv,
-            campaignId: params.campaignId,
-            workflowSlug: params.workflowSlug,
-            featureSlug: params.featureSlug,
-          }
-        );
-
-        if (matchResult?.person?.email) {
-          validEmail = matchResult.person.email;
-          enrichedData = matchResult.person;
-
-          // Cache enrichment for later lookups
-          await db.insert(enrichments).values({
-            email: validEmail,
-            apolloPersonId: matchResult.person.id ?? null,
-            firstName: matchResult.person.firstName ?? null,
-            lastName: matchResult.person.lastName ?? null,
-            title: matchResult.person.title ?? null,
-            linkedinUrl: matchResult.person.linkedinUrl ?? null,
-            organizationName: matchResult.person.organizationName ?? null,
-            organizationDomain: matchResult.person.organizationDomain ?? null,
-            organizationIndustry: matchResult.person.organizationIndustry ?? null,
-            organizationSize: matchResult.person.organizationSize ?? null,
-            responseRaw: matchResult.person,
-          }).onConflictDoNothing();
+        if (!result.found || !result.journalist) {
+          // No more journalists for this outlet
+          break;
         }
+
+        const journalist = result.journalist;
+
+        // Skip organization-type entities (we need individual people)
+        if (journalist.entityType === "organization") continue;
+
+        const externalId = journalist.id;
+
+        if (await isInBuffer(params.orgId, params.campaignId, externalId)) continue;
+
+        // Try email from buffer/next response first
+        let validEmail = journalist.emails
+          ?.filter(e => e.isValid)
+          ?.sort((a, b) => b.confidence - a.confidence)
+          ?.[0]?.email ?? null;
+
+        let enrichedData: Record<string, unknown> | null = null;
+
+        // No email — proactively match via Apollo Service
+        if (!validEmail && journalist.firstName && journalist.lastName && organizationDomain) {
+          const matchResult = await apolloMatch(
+            {
+              firstName: journalist.firstName,
+              lastName: journalist.lastName,
+              organizationDomain,
+            },
+            {
+              runId: params.pushRunId,
+              orgId: params.orgId,
+              userId: params.userId,
+              brandId: brandIdCsv,
+              campaignId: params.campaignId,
+              workflowSlug: params.workflowSlug,
+              featureSlug: params.featureSlug,
+            }
+          );
+
+          if (matchResult?.person?.email) {
+            validEmail = matchResult.person.email;
+            enrichedData = matchResult.person;
+
+            // Cache enrichment for later lookups
+            await db.insert(enrichments).values({
+              email: validEmail,
+              apolloPersonId: matchResult.person.id ?? null,
+              firstName: matchResult.person.firstName ?? null,
+              lastName: matchResult.person.lastName ?? null,
+              title: matchResult.person.title ?? null,
+              linkedinUrl: matchResult.person.linkedinUrl ?? null,
+              organizationName: matchResult.person.organizationName ?? null,
+              organizationDomain: matchResult.person.organizationDomain ?? null,
+              organizationIndustry: matchResult.person.organizationIndustry ?? null,
+              organizationSize: matchResult.person.organizationSize ?? null,
+              responseRaw: matchResult.person,
+            }).onConflictDoNothing();
+          }
+        }
+
+        // No email after all enrichment attempts — skip, can't serve without email
+        if (!validEmail) {
+          continue;
+        }
+
+        const data: Record<string, unknown> = {
+          firstName: journalist.firstName,
+          lastName: journalist.lastName,
+          journalistName: journalist.journalistName,
+          organizationDomain,
+          organizationName: outlet.outletName,
+          outletUrl: outlet.outletUrl,
+          outletId: outlet.id,
+          journalistId: journalist.id,
+          sourceType: "journalist",
+          ...(enrichedData ?? {}),
+        };
+
+        await db.insert(leadBuffer).values({
+          namespace: "journalist",
+          campaignId: params.campaignId,
+          email: validEmail,
+          externalId,
+          data,
+          status: "buffered",
+          pushRunId: params.pushRunId ?? null,
+          brandIds: params.brandIds,
+          orgId: params.orgId,
+          userId: params.userId ?? null,
+          workflowSlug: params.workflowSlug ?? null,
+          featureSlug: params.featureSlug ?? null,
+        });
+        totalFilled++;
       }
 
-      // No email after all enrichment attempts — skip, can't serve without email
-      if (!validEmail) {
-        continue;
+      // Save cursor after each outlet
+      if (totalFilled > 0) {
+        await saveCursor(params.orgId, cursorNamespace, { outletIndex: oi + 1 });
+        console.log(`[fillBufferFromJournalists] Buffered ${totalFilled} journalists from outlet ${outlet.outletName}`);
+        return { filled: totalFilled };
       }
-
-      const data: Record<string, unknown> = {
-        firstName: journalist.firstName,
-        lastName: journalist.lastName,
-        journalistName: journalist.journalistName,
-        organizationDomain,
-        organizationName: outlet.outletName,
-        outletUrl: outlet.outletUrl,
-        outletId: outlet.id,
-        journalistId: journalist.id,
-        sourceType: "journalist",
-        ...(enrichedData ?? {}),
-      };
-
-      await db.insert(leadBuffer).values({
-        namespace: "journalist",
-        campaignId: params.campaignId,
-        email: validEmail,
-        externalId,
-        data,
-        status: "buffered",
-        pushRunId: params.pushRunId ?? null,
-        brandIds: params.brandIds,
-        orgId: params.orgId,
-        userId: params.userId ?? null,
-        workflowSlug: params.workflowSlug ?? null,
-        featureSlug: params.featureSlug ?? null,
-      });
-      totalFilled++;
     }
 
-    // Save cursor after each outlet
-    if (totalFilled > 0) {
-      await saveCursor(params.orgId, cursorNamespace, { outletIndex: oi + 1 });
-      console.log(`[fillBufferFromJournalists] Buffered ${totalFilled} journalists from outlet ${outlet.outletName}`);
-      return { filled: totalFilled };
+    // All known outlets exhausted — ask outlet-service for more via buffer/next
+    discoveryRounds++;
+    if (discoveryRounds > MAX_DISCOVERY_ROUNDS) {
+      console.warn(`[fillBufferFromJournalists] Hit MAX_DISCOVERY_ROUNDS (${MAX_DISCOVERY_ROUNDS}), stopping`);
+      break;
     }
+
+    console.log(`[fillBufferFromJournalists] All ${outlets.length} known outlets exhausted for campaign=${params.campaignId}, discovering more...`);
+
+    const nextResult = await fetchNextOutlet({
+      orgId: params.orgId,
+      userId: params.userId ?? undefined,
+      runId: params.pushRunId ?? undefined,
+      campaignId: params.campaignId,
+      brandId: brandIdCsv,
+      workflowSlug: params.workflowSlug,
+      featureSlug: params.featureSlug,
+    });
+
+    if (!nextResult.found) {
+      console.log(`[fillBufferFromJournalists] Outlet-service has no more outlets for campaign=${params.campaignId}`);
+      break;
+    }
+
+    // Re-fetch outlets list now that discovery added new ones
+    const newOutlets = await fetchOutletsByCampaign(params.campaignId, params.orgId, serviceContext);
+    if (!newOutlets || newOutlets.length <= oi) {
+      console.warn(`[fillBufferFromJournalists] No new outlets after discovery for campaign=${params.campaignId}`);
+      break;
+    }
+
+    outlets = newOutlets;
+    // oi stays where it was — continue from the first new outlet
   }
 
-  // All outlets exhausted
+  // All outlets truly exhausted
   await saveCursor(params.orgId, cursorNamespace, { outletIndex: outlets.length });
   return { filled: totalFilled };
 }

--- a/src/lib/outlet-client.ts
+++ b/src/lib/outlet-client.ts
@@ -19,11 +19,12 @@ export interface BufferNextOutlet {
   outletUrl: string;
   outletDomain: string;
   campaignId: string;
-  brandId: string;
+  brandIds: string[];
   relevanceScore: number;
   whyRelevant: string;
   whyNotRelevant: string;
   overallRelevance: string | null;
+  runId: string | null;
 }
 
 function buildHeaders(context?: {
@@ -92,8 +93,9 @@ export async function fetchNextOutlet(context: {
         return { found: false };
       }
 
-      const data = (await response.json()) as { found: boolean; outlet?: BufferNextOutlet };
-      return data;
+      const data = (await response.json()) as { outlets: BufferNextOutlet[] };
+      const outlet = data.outlets?.[0];
+      return { found: !!outlet, outlet };
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
       console.warn(`[outlet-client] buffer/next attempt ${attempt + 1} failed for campaign ${context.campaignId}:`, lastError.message);

--- a/tests/unit/outlet-client.test.ts
+++ b/tests/unit/outlet-client.test.ts
@@ -24,16 +24,28 @@ describe("outlet-client", () => {
   });
 
   describe("fetchNextOutlet", () => {
-    it("returns outlet on first success", async () => {
-      const outlet = { outletId: "o-1", outletName: "Test Outlet", found: true };
+    it("parses outlets array response and returns first outlet as found", async () => {
+      const outlet = { outletId: "o-1", outletName: "Test Outlet", outletUrl: "https://test.com", outletDomain: "test.com", campaignId: "camp-1", brandIds: ["brand-1"], relevanceScore: 0.9, whyRelevant: "good", whyNotRelevant: "", overallRelevance: "high", runId: null };
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({ found: true, outlet }),
+        json: () => Promise.resolve({ outlets: [outlet] }),
       });
 
       const result = await fetchNextOutlet(baseContext);
       expect(result.found).toBe(true);
       expect(result.outlet).toEqual(outlet);
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it("returns found=false when outlets array is empty", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ outlets: [] }),
+      });
+
+      const result = await fetchNextOutlet(baseContext);
+      expect(result.found).toBe(false);
+      expect(result.outlet).toBeUndefined();
       expect(mockFetch).toHaveBeenCalledOnce();
     });
 
@@ -44,7 +56,7 @@ describe("outlet-client", () => {
         .mockResolvedValueOnce({ ok: false, status: 500 })
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve({ found: true, outlet }),
+          json: () => Promise.resolve({ outlets: [outlet] }),
         });
 
       const promise = fetchNextOutlet(baseContext);
@@ -63,7 +75,7 @@ describe("outlet-client", () => {
         .mockResolvedValueOnce({ ok: false, status: 500 })
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve({ found: true, outlet }),
+          json: () => Promise.resolve({ outlets: [outlet] }),
         });
 
       const promise = fetchNextOutlet(baseContext);
@@ -105,7 +117,7 @@ describe("outlet-client", () => {
         .mockImplementationOnce(() => Promise.reject(new Error("fetch failed")))
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve({ found: true, outlet }),
+          json: () => Promise.resolve({ outlets: [outlet] }),
         });
 
       // Capture eagerly so the initial rejection doesn't go unhandled during timer wait

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -323,7 +323,7 @@ describe("service client headers", () => {
     });
 
     it("sends POST to /buffer/next with headers and optional idempotencyKey", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ found: true, outlet: { outletId: "o1", outletName: "TechCrunch" } }));
+      fetchSpy.mockReturnValue(jsonResponse({ outlets: [{ outletId: "o1", outletName: "TechCrunch" }] }));
 
       const { fetchNextOutlet } = await import("../../src/lib/outlet-client.js");
       const result = await fetchNextOutlet({
@@ -348,7 +348,7 @@ describe("service client headers", () => {
     });
 
     it("sends empty body to /buffer/next when no idempotencyKey", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ found: false }));
+      fetchSpy.mockReturnValue(jsonResponse({ outlets: [] }));
 
       const { fetchNextOutlet } = await import("../../src/lib/outlet-client.js");
       const result = await fetchNextOutlet({
@@ -389,7 +389,7 @@ describe("service client headers", () => {
     });
 
     it("sends headers to /buffer/next for outlet discovery", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ found: true, outlet: { outletId: "o1" } }));
+      fetchSpy.mockReturnValue(jsonResponse({ outlets: [{ outletId: "o1" }] }));
 
       const { fetchNextOutlet } = await import("../../src/lib/outlet-client.js");
       await fetchNextOutlet({


### PR DESCRIPTION
## Summary
- **Fixed outlet-service response parsing**: `fetchNextOutlet` was reading `data.found` (which doesn't exist in outlet-service's response). The actual response format is `{ outlets: [...] }`. This caused every outlet discovery to return `found: false`, making journalist mode think there were no outlets.
- **Fixed outlet exhaustion loop**: When all known outlets had no journalists, `fillBufferFromJournalists` returned `filled: 0` without asking outlet-service for more outlets. Now it loops: exhaust known outlets → call `buffer/next` for more → continue until outlet-service is truly empty.
- **Updated `BufferNextOutlet` interface** to match the real outlet-service schema (`brandIds: string[]` instead of `brandId: string`, added `runId`).

## Test plan
- [x] Updated `outlet-client.test.ts`: tests now use real `{ outlets: [...] }` response format, added regression test for empty outlets array
- [x] Updated `service-clients-headers.test.ts`: mock responses aligned with real outlet-service format
- [x] All 190 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)