### PR TITLE
Fix Journalist interface to match actual API spec

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -359,16 +359,11 @@ async function fillBufferFromJournalists(params: {
 
         if (await isInBuffer(params.orgId, params.campaignId, externalId)) continue;
 
-        // Try email from buffer/next response first
-        let validEmail = journalist.emails
-          ?.filter(e => e.isValid)
-          ?.sort((a, b) => b.confidence - a.confidence)
-          ?.[0]?.email ?? null;
-
+        let validEmail: string | null = null;
         let enrichedData: Record<string, unknown> | null = null;
 
-        // No email — proactively match via Apollo Service
-        if (!validEmail && journalist.firstName && journalist.lastName && organizationDomain) {
+        // journalists-service does not return emails — match via Apollo Service
+        if (journalist.firstName && journalist.lastName && organizationDomain) {
           const matchResult = await apolloMatch(
             {
               firstName: journalist.firstName,

--- a/src/lib/journalist-client.ts
+++ b/src/lib/journalist-client.ts
@@ -1,21 +1,15 @@
 import { JOURNALISTS_SERVICE_URL, JOURNALISTS_SERVICE_API_KEY } from "../config.js";
 
-export interface JournalistEmail {
-  email: string;
-  isValid: boolean;
-  confidence: number;
-}
-
-export interface JournalistWithEmails {
+export interface Journalist {
   id: string;
   journalistName: string;
-  firstName: string | null;
-  lastName: string | null;
+  firstName: string;
+  lastName: string;
   entityType: "individual" | "organization";
   relevanceScore: number;
   whyRelevant: string;
   whyNotRelevant: string;
-  emails: JournalistEmail[];
+  articleUrls: string[];
 }
 
 export async function fetchNextJournalist(
@@ -31,7 +25,7 @@ export async function fetchNextJournalist(
     idempotencyKey?: string;
     maxArticles?: number;
   }
-): Promise<{ found: boolean; journalist?: JournalistWithEmails }> {
+): Promise<{ found: boolean; journalist?: Journalist }> {
   try {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -65,7 +59,7 @@ export async function fetchNextJournalist(
       return { found: false };
     }
 
-    const data = (await response.json()) as { found: boolean; journalist?: JournalistWithEmails };
+    const data = (await response.json()) as { found: boolean; journalist?: Journalist };
     return data;
   } catch (error) {
     console.error("[journalist-client] Error fetching next journalist:", error);

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -1097,10 +1097,22 @@ describe("buffer", () => {
             relevanceScore: 0.85,
             whyRelevant: "Covers tech",
             whyNotRelevant: "",
-            emails: [{ email: "jane@techcrunch.com", isValid: true, confidence: 0.95 }],
+            articleUrls: [],
           },
         })
         .mockResolvedValueOnce({ found: false });
+
+      // apolloMatch resolves the email (journalists no longer have emails directly)
+      vi.mocked(apolloMatch).mockResolvedValueOnce({
+        person: {
+          id: "apollo-jane",
+          email: "jane@techcrunch.com",
+          firstName: "Jane",
+          lastName: "Reporter",
+          organizationName: "TechCrunch",
+          organizationDomain: "techcrunch.com",
+        },
+      });
 
       vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
 
@@ -1316,10 +1328,22 @@ describe("buffer", () => {
             relevanceScore: 0.8,
             whyRelevant: "Covers tech",
             whyNotRelevant: "",
-            emails: [{ email: "discovered@outlet.com", isValid: true, confidence: 0.95 }],
+            articleUrls: [],
           },
         })
         .mockResolvedValueOnce({ found: false });
+
+      // apolloMatch resolves the email (journalists no longer have emails directly)
+      vi.mocked(apolloMatch).mockResolvedValueOnce({
+        person: {
+          id: "apollo-discovered",
+          email: "discovered@outlet.com",
+          firstName: "Jane",
+          lastName: "Reporter",
+          organizationName: "Discovered Outlet",
+          organizationDomain: "discovered-outlet.com",
+        },
+      });
 
       vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
 
@@ -1435,7 +1459,7 @@ describe("buffer", () => {
             relevanceScore: 0.8,
             whyRelevant: "Covers tech",
             whyNotRelevant: "",
-            emails: [],
+            articleUrls: [],
           },
         })
         .mockResolvedValueOnce({ found: false });
@@ -1506,7 +1530,7 @@ describe("buffer", () => {
             relevanceScore: 0.7,
             whyRelevant: "Writes about relocation",
             whyNotRelevant: "",
-            emails: [],
+            articleUrls: [],
           },
         })
         .mockResolvedValueOnce({ found: false });
@@ -1695,10 +1719,22 @@ describe("buffer", () => {
             lastName: "Doe",
             journalistName: "Jane Doe",
             entityType: "person",
-            emails: [{ email: "journalist@outlet.com", isValid: true, confidence: 0.9 }],
+            articleUrls: [],
           },
         } as never)
         .mockResolvedValueOnce({ found: false });
+
+      // apolloMatch resolves the email (journalists no longer have emails directly)
+      vi.mocked(apolloMatch).mockResolvedValueOnce({
+        person: {
+          id: "apollo-jane-doe",
+          email: "journalist@outlet.com",
+          firstName: "Jane",
+          lastName: "Doe",
+          organizationName: "TechCrunch",
+          organizationDomain: "techcrunch.com",
+        },
+      });
 
       vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
       vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
@@ -1723,8 +1759,11 @@ describe("buffer", () => {
         sourceType: "journalist",
       });
 
-      // The first insert call should be the buffer row with namespace="journalist"
-      const bufferInsert = insertValues[0] as Record<string, unknown>;
+      // Find the buffer row insert (has namespace field) — enrichment cache insert comes first
+      const bufferInsert = insertValues.find(
+        (v) => (v as Record<string, unknown>).namespace !== undefined
+      ) as Record<string, unknown>;
+      expect(bufferInsert).toBeDefined();
       expect(bufferInsert.namespace).toBe("journalist");
       expect(bufferInsert.namespace).not.toBe("campaign-uuid-456");
     });


### PR DESCRIPTION
## Summary
- **Removed dead `emails` field**: journalists-service's `/buffer/next` doesn't return emails — it returns `articleUrls`. Our `JournalistWithEmails` interface had an `emails` field that was always `undefined` at runtime, causing every journalist to silently fall through to apolloMatch (wasted API call if emails were ever added to the spec).
- **Renamed `JournalistWithEmails` → `Journalist`**, removed dead `JournalistEmail` interface.
- **Fixed `firstName`/`lastName` types** from `string | null` to `string` per the actual spec (required fields).
- **Removed dead code** in `fillBufferFromJournalists` that filtered `journalist.emails`.

## Test plan
- [x] Updated all 5 journalist mock objects in buffer tests to use `articleUrls: []`
- [x] Added apolloMatch mocks for tests that previously relied on `emails` field
- [x] All 190 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)