### PR TITLE
Fix OutletDetails import in buffer.ts

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -6,7 +6,7 @@ import { resolveOrCreateLead, findLeadByApolloPersonId } from "./leads-registry.
 import { apolloSearchNext, apolloEnrich, apolloMatch, apolloSearchParams } from "./apollo-client.js";
 import { fetchCampaign } from "./campaign-client.js";
 import { extractBrandFields } from "./brand-client.js";
-import { fetchOutletsByCampaign, fetchNextOutlet } from "./outlet-client.js";
+import { fetchOutletsByCampaign, fetchNextOutlet, type OutletDetails } from "./outlet-client.js";
 import { fetchNextJournalist } from "./journalist-client.js";
 
 async function isInBuffer(orgId: string, campaignId: string, externalId: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Adds missing `OutletDetails` type import in `buffer.ts` — the `discoverNextOutlet` helper references this type but it wasn't imported, causing the build to fail.

## Test plan
- [x] `npm run build` passes
- [x] All 190 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)