### PR TITLE
Remove .passthrough() from ApolloPersonDataSchema

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -493,10 +493,7 @@
           "lastName",
           "organizationName"
         ],
-        "additionalProperties": {
-          "nullable": true
-        },
-        "description": "Apollo person + organization data in flat camelCase format. Organization fields are prefixed with 'organization' (e.g. organizationDomain, organizationName) — there is NO nested 'organization' object. Additional fields from Apollo may be present."
+        "description": "Apollo person + organization data in flat camelCase format. Organization fields are prefixed with 'organization' (e.g. organizationDomain, organizationName) — there is NO nested 'organization' object."
       },
       "ErrorResponse": {
         "type": "object",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -180,12 +180,11 @@ export const ApolloPersonDataSchema = z
     organizationRetailLocationCount: z.number().nullable().optional(),
     organizationAlexaRanking: z.number().nullable().optional(),
   })
-  .passthrough()
   .openapi("ApolloPersonData", {
     description:
       "Apollo person + organization data in flat camelCase format. " +
       "Organization fields are prefixed with 'organization' (e.g. organizationDomain, organizationName) — " +
-      "there is NO nested 'organization' object. Additional fields from Apollo may be present.",
+      "there is NO nested 'organization' object.",
   });
 
 // --- Buffer Next ---


### PR DESCRIPTION
## Summary
- Removes `.passthrough()` from `ApolloPersonDataSchema`, which was generating `additionalProperties: true` in the OpenAPI spec
- Apollo-service already filters to explicit fields only — the passthrough on the consumer side was misleading downstream services into thinking arbitrary fields (like `leadBeat`) might be present
- Regenerated `openapi.json` to reflect the strict schema

## Test plan
- [x] `npm run build` passes (TypeScript + OpenAPI generation)
- [x] Tests: same 194/210 pass rate as main (16 pre-existing failures in cursor integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)