### PR TITLE
Handle journalists-service 502 by skipping to next outlet

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -275,16 +275,26 @@ async function fillBufferFromJournalists(params: {
 
     console.log(`[fillBufferFromJournalists] Got outlet "${outlet.outletName}" from outlets-service for campaign=${params.campaignId}`);
 
-    // Pull journalists from this outlet via journalists-service
+    // Pull journalists from this outlet via journalists-service.
+    // If journalists-service is temporarily unavailable (502/timeout), skip this outlet
+    // and try the next one instead of crashing the entire request.
     const MAX_JOURNALIST_PULLS = 50;
     let totalFilled = 0;
+    let outletFailed = false;
 
     for (let pull = 0; pull < MAX_JOURNALIST_PULLS; pull++) {
-      const result = await fetchNextJournalist(outlet.outletId, {
-        ...serviceContext,
-        campaignId: params.campaignId,
-        orgId: params.orgId,
-      });
+      let result: { found: boolean; journalist?: Awaited<ReturnType<typeof fetchNextJournalist>>["journalist"] };
+      try {
+        result = await fetchNextJournalist(outlet.outletId, {
+          ...serviceContext,
+          campaignId: params.campaignId,
+          orgId: params.orgId,
+        });
+      } catch (error) {
+        console.warn(`[fillBufferFromJournalists] journalists-service error for outlet "${outlet.outletName}" (${outlet.outletId}), skipping to next outlet:`, (error as Error).message);
+        outletFailed = true;
+        break;
+      }
 
       if (!result.found || !result.journalist) break;
 
@@ -373,6 +383,8 @@ async function fillBufferFromJournalists(params: {
       console.log(`[fillBufferFromJournalists] Buffered ${totalFilled} journalists from outlet ${outlet.outletName}`);
       return { filled: totalFilled };
     }
+
+    if (outletFailed) continue;
 
     // No journalists found for this outlet — ask outlets-service for the next one
     console.log(`[fillBufferFromJournalists] No usable journalists from outlet "${outlet.outletName}", requesting next outlet`);

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -1397,6 +1397,95 @@ describe("buffer", () => {
       );
     });
 
+    it("skips outlet and tries next when journalists-service returns 502 (regression)", async () => {
+      const journalistRow = toClaimedRow({
+        id: "buf-j-502",
+        namespace: "journalist",
+        campaignId: "campaign-1",
+        email: "fallback@outlet2.com",
+        externalId: "j-fallback",
+        data: {
+          firstName: "Jane",
+          lastName: "Fallback",
+          organizationName: "Outlet Two",
+          sourceType: "journalist",
+        },
+        brandIds: ["brand-1"],
+        orgId: "org-1",
+        userId: null,
+      });
+
+      pgSqlMock
+        .mockResolvedValueOnce([])              // pullNext: buffer empty
+        .mockResolvedValueOnce([journalistRow]); // pullNext retry: claimed journalist lead
+
+      // Outlet 1 returned, then outlet 2
+      vi.mocked(fetchNextOutlet)
+        .mockResolvedValueOnce({ found: true, outlet: {
+          outletId: "outlet-fail", outletName: "Failing Outlet", outletUrl: "https://failing.com", outletDomain: "failing.com", campaignId: "campaign-1", brandIds: ["brand-1"], relevanceScore: 90, whyRelevant: "Relevant", whyNotRelevant: "", overallRelevance: null, runId: null,
+        }})
+        .mockResolvedValueOnce({ found: true, outlet: {
+          outletId: "outlet-ok", outletName: "Outlet Two", outletUrl: "https://outlet2.com", outletDomain: "outlet2.com", campaignId: "campaign-1", brandIds: ["brand-1"], relevanceScore: 80, whyRelevant: "Also relevant", whyNotRelevant: "", overallRelevance: null, runId: null,
+        }});
+
+      // Outlet 1: journalists-service 502
+      vi.mocked(fetchNextJournalist)
+        .mockRejectedValueOnce(new Error("[journalist-client] buffer/next failed for outlet outlet-fail: 502"))
+        // Outlet 2: success
+        .mockResolvedValueOnce({
+          found: true,
+          journalist: {
+            id: "j-fallback",
+            journalistName: "Jane Fallback",
+            firstName: "Jane",
+            lastName: "Fallback",
+            entityType: "individual" as const,
+            relevanceScore: 0.8,
+            whyRelevant: "Covers topic",
+            whyNotRelevant: "",
+            articleUrls: [],
+          },
+        })
+        .mockResolvedValueOnce({ found: false });
+
+      vi.mocked(apolloMatch).mockResolvedValueOnce({
+        person: {
+          id: "apollo-fallback",
+          email: "fallback@outlet2.com",
+          firstName: "Jane",
+          lastName: "Fallback",
+          organizationName: "Outlet Two",
+          organizationDomain: "outlet2.com",
+        },
+      });
+
+      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
+
+      const returningMock = vi.fn().mockResolvedValue([{ id: "served-1" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandIds: ["brand-1"],
+        sourceType: "journalist",
+      });
+
+      // Should NOT crash — should skip the failing outlet and serve from outlet 2
+      expect(result.found).toBe(true);
+      expect(result.lead?.email).toBe("fallback@outlet2.com");
+      // Both outlets were requested
+      expect(vi.mocked(fetchNextOutlet)).toHaveBeenCalledTimes(2);
+    });
+
     it("uses apolloMatch proactively when resolve returns journalists without emails", async () => {
       const journalistRow = toClaimedRow({
         id: "buf-j-noemail",


### PR DESCRIPTION
## Summary
- **Bug**: When journalists-service returns 502 (articles-service timeout), lead-service crashed with 500 → 3 consecutive failures → campaign auto-stopped
- **Fix**: `fillBufferFromJournalists` now catches errors from `fetchNextJournalist` and skips to the next outlet instead of propagating the error
- Adds regression test for 502 resilience

## Test plan
- [x] All 191 unit tests pass (including new regression test)
- [x] Build compiles cleanly
- [ ] Deploy and verify campaigns survive transient journalists-service 502s

🤖 Generated with [Claude Code](https://claude.com/claude-code)