### PR TITLE
Stop pulling more journalists after buffering one

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -377,6 +377,11 @@ async function fillBufferFromJournalists(params: {
         featureSlug: params.featureSlug ?? null,
       });
       totalFilled++;
+
+      // Got one — stop pulling from this outlet immediately.
+      // pullNext only needs a single buffered row; extra pulls waste time
+      // and trigger "outlet blocked" responses from journalists-service.
+      break;
     }
 
     if (totalFilled > 0) {

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -106,11 +106,17 @@ function toClaimedRow(row: {
 
 describe("buffer", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    // Reset default mocks
+    vi.resetAllMocks();
+    // Restore default mocks (resetAllMocks clears factory defaults too)
     pgSqlMock.mockResolvedValue([]);
     vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
     vi.mocked(resolveOrCreateLead).mockResolvedValue({ leadId: "lead-uuid-1", isNew: true });
+    vi.mocked(fetchNextOutlet).mockResolvedValue({ found: false });
+    vi.mocked(fetchNextJournalist).mockResolvedValue({ found: false });
+    vi.mocked(fetchCampaign).mockResolvedValue(null);
+    vi.mocked(extractBrandFields).mockResolvedValue(null);
+    vi.mocked(apolloSearchParams).mockResolvedValue({ searchParams: {} });
+    vi.mocked(apolloSearchNext).mockResolvedValue({ people: [], done: true });
   });
 
   describe("pullNext", () => {
@@ -1092,8 +1098,7 @@ describe("buffer", () => {
             whyNotRelevant: "",
             articleUrls: [],
           },
-        })
-        .mockResolvedValueOnce({ found: false });
+        });
 
       // apolloMatch resolves the email (journalists no longer have emails directly)
       vi.mocked(apolloMatch).mockResolvedValueOnce({
@@ -1134,6 +1139,9 @@ describe("buffer", () => {
       expect(vi.mocked(fetchNextJournalist)).toHaveBeenCalledWith(
         "outlet-1", expect.objectContaining({ campaignId: "campaign-1" })
       );
+      // After buffering one journalist, should NOT call fetchNextJournalist again
+      // for the same outlet (regression: extra call caused "outlet blocked" + timeouts)
+      expect(vi.mocked(fetchNextJournalist)).toHaveBeenCalledTimes(1);
     });
 
     it("uses apolloMatch for journalist leads without email", async () => {
@@ -1315,8 +1323,7 @@ describe("buffer", () => {
             whyNotRelevant: "",
             articleUrls: [],
           },
-        })
-        .mockResolvedValueOnce({ found: false });
+        });
 
       // apolloMatch resolves the email (journalists no longer have emails directly)
       vi.mocked(apolloMatch).mockResolvedValueOnce({
@@ -1445,8 +1452,7 @@ describe("buffer", () => {
             whyNotRelevant: "",
             articleUrls: [],
           },
-        })
-        .mockResolvedValueOnce({ found: false });
+        });
 
       vi.mocked(apolloMatch).mockResolvedValueOnce({
         person: {
@@ -1531,8 +1537,7 @@ describe("buffer", () => {
             whyNotRelevant: "",
             articleUrls: [],
           },
-        })
-        .mockResolvedValueOnce({ found: false });
+        });
 
       // apolloMatch finds the email
       vi.mocked(apolloMatch).mockResolvedValueOnce({
@@ -1792,8 +1797,7 @@ describe("buffer", () => {
             entityType: "person",
             articleUrls: [],
           },
-        } as never)
-        .mockResolvedValueOnce({ found: false });
+        } as never);
 
       // apolloMatch resolves the email (journalists no longer have emails directly)
       vi.mocked(apolloMatch).mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- `fillBufferFromJournalists` now breaks out of the inner journalist loop immediately after buffering one journalist, instead of continuing to call `fetchNextJournalist` (which triggers "outlet blocked" responses and adds latency)
- This matches `fillBufferFromSearch`'s existing behavior of stopping as soon as new leads are buffered
- Fixed test mock isolation (`vi.resetAllMocks` instead of `vi.clearAllMocks`) to prevent mock leakage between tests

## Root cause
The inner loop in `fillBufferFromJournalists` kept calling `fetchNextJournalist` after successfully buffering a journalist. journalists-service would respond with "outlet blocked", wasting time. The accumulated latency caused the DAG's `fetch_lead` step to timeout, even though the lead was eventually found.

## Test plan
- [x] All 191 unit tests pass
- [x] New assertion verifies `fetchNextJournalist` is called exactly once per outlet when a journalist is buffered
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)