### PR TITLE
Remove noisy error logging in journalist-client

### DIFF
--- a/src/lib/journalist-client.ts
+++ b/src/lib/journalist-client.ts
@@ -26,43 +26,38 @@ export async function fetchNextJournalist(
     maxArticles?: number;
   }
 ): Promise<{ found: boolean; journalist?: Journalist }> {
-  try {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      "X-API-Key": JOURNALISTS_SERVICE_API_KEY,
-    };
-    if (options?.orgId) headers["x-org-id"] = options.orgId;
-    if (options?.userId) headers["x-user-id"] = options.userId;
-    if (options?.runId) headers["x-run-id"] = options.runId;
-    if (options?.campaignId) headers["x-campaign-id"] = options.campaignId;
-    if (options?.brandId) headers["x-brand-id"] = options.brandId;
-    if (options?.workflowSlug) headers["x-workflow-slug"] = options.workflowSlug;
-    if (options?.featureSlug) headers["x-feature-slug"] = options.featureSlug;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-API-Key": JOURNALISTS_SERVICE_API_KEY,
+  };
+  if (options?.orgId) headers["x-org-id"] = options.orgId;
+  if (options?.userId) headers["x-user-id"] = options.userId;
+  if (options?.runId) headers["x-run-id"] = options.runId;
+  if (options?.campaignId) headers["x-campaign-id"] = options.campaignId;
+  if (options?.brandId) headers["x-brand-id"] = options.brandId;
+  if (options?.workflowSlug) headers["x-workflow-slug"] = options.workflowSlug;
+  if (options?.featureSlug) headers["x-feature-slug"] = options.featureSlug;
 
-    const body: Record<string, unknown> = { outletId };
-    if (options?.idempotencyKey) body.idempotencyKey = options.idempotencyKey;
-    if (options?.maxArticles != null) body.maxArticles = options.maxArticles;
+  const body: Record<string, unknown> = { outletId };
+  if (options?.idempotencyKey) body.idempotencyKey = options.idempotencyKey;
+  if (options?.maxArticles != null) body.maxArticles = options.maxArticles;
 
-    const response = await fetch(`${JOURNALISTS_SERVICE_URL}/buffer/next`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(body),
-      signal: AbortSignal.timeout(300_000),
-    });
+  const response = await fetch(`${JOURNALISTS_SERVICE_URL}/buffer/next`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(300_000),
+  });
 
-    if (!response.ok) {
-      const msg = `[journalist-client] buffer/next failed for outlet ${outletId}: ${response.status}`;
-      if (response.status >= 500) {
-        throw new Error(msg);
-      }
-      console.warn(msg);
-      return { found: false };
+  if (!response.ok) {
+    const msg = `[journalist-client] buffer/next failed for outlet ${outletId}: ${response.status}`;
+    if (response.status >= 500) {
+      throw new Error(msg);
     }
-
-    const data = (await response.json()) as { found: boolean; journalist?: Journalist };
-    return data;
-  } catch (error) {
-    console.error("[journalist-client] Error fetching next journalist:", error);
-    throw error;
+    console.warn(msg);
+    return { found: false };
   }
+
+  const data = (await response.json()) as { found: boolean; journalist?: Journalist };
+  return data;
 }

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -1492,6 +1492,94 @@ describe("buffer", () => {
       expect(vi.mocked(fetchNextOutlet)).toHaveBeenCalledTimes(2);
     });
 
+    it("skips outlet and tries next when journalists-service socket closes mid-request (regression)", async () => {
+      const journalistRow = toClaimedRow({
+        id: "buf-j-socket",
+        namespace: "journalist",
+        campaignId: "campaign-1",
+        email: "fallback@outlet2.com",
+        externalId: "j-fallback-socket",
+        data: {
+          firstName: "Jane",
+          lastName: "Fallback",
+          organizationName: "Outlet Two",
+          sourceType: "journalist",
+        },
+        brandIds: ["brand-1"],
+        orgId: "org-1",
+        userId: null,
+      });
+
+      pgSqlMock
+        .mockResolvedValueOnce([])              // pullNext: buffer empty
+        .mockResolvedValueOnce([journalistRow]); // pullNext retry: claimed journalist lead
+
+      vi.mocked(fetchNextOutlet)
+        .mockResolvedValueOnce({ found: true, outlet: {
+          outletId: "outlet-socket-fail", outletName: "Restarting Outlet", outletUrl: "https://restarting.com", outletDomain: "restarting.com", campaignId: "campaign-1", brandIds: ["brand-1"], relevanceScore: 90, whyRelevant: "Relevant", whyNotRelevant: "", overallRelevance: null, runId: null,
+        }})
+        .mockResolvedValueOnce({ found: true, outlet: {
+          outletId: "outlet-ok-2", outletName: "Outlet Two", outletUrl: "https://outlet2.com", outletDomain: "outlet2.com", campaignId: "campaign-1", brandIds: ["brand-1"], relevanceScore: 80, whyRelevant: "Also relevant", whyNotRelevant: "", overallRelevance: null, runId: null,
+        }});
+
+      // Outlet 1: socket error (container restart / "other side closed")
+      const socketError = new TypeError("fetch failed");
+      (socketError as unknown as { cause: Error }).cause = new Error("other side closed");
+      vi.mocked(fetchNextJournalist)
+        .mockRejectedValueOnce(socketError)
+        // Outlet 2: success
+        .mockResolvedValueOnce({
+          found: true,
+          journalist: {
+            id: "j-fallback-socket",
+            journalistName: "Jane Fallback",
+            firstName: "Jane",
+            lastName: "Fallback",
+            entityType: "individual" as const,
+            relevanceScore: 0.8,
+            whyRelevant: "Covers topic",
+            whyNotRelevant: "",
+            articleUrls: [],
+          },
+        });
+
+      vi.mocked(apolloMatch).mockResolvedValueOnce({
+        person: {
+          id: "apollo-fallback-socket",
+          email: "fallback@outlet2.com",
+          firstName: "Jane",
+          lastName: "Fallback",
+          organizationName: "Outlet Two",
+          organizationDomain: "outlet2.com",
+        },
+      });
+
+      vi.mocked(db.query.leadBuffer.findFirst).mockResolvedValueOnce(undefined);
+      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
+
+      const returningMock = vi.fn().mockResolvedValue([{ id: "served-socket" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandIds: ["brand-1"],
+        sourceType: "journalist",
+      });
+
+      // Should NOT crash — should skip the socket-error outlet and serve from outlet 2
+      expect(result.found).toBe(true);
+      expect(result.lead?.email).toBe("fallback@outlet2.com");
+      expect(vi.mocked(fetchNextOutlet)).toHaveBeenCalledTimes(2);
+    });
+
     it("uses apolloMatch proactively when resolve returns journalists without emails", async () => {
       const journalistRow = toClaimedRow({
         id: "buf-j-noemail",


### PR DESCRIPTION
## Summary
- Removed redundant `console.error` + re-throw try/catch in `fetchNextJournalist` — the caller (`fillBufferFromJournalists`) already catches and logs a concise warning, so the full stack trace dump was just noise during normal container restarts.
- Added regression test for `TypeError: fetch failed` (socket close) errors to verify the skip-to-next-outlet path works for connection-level failures, not just HTTP 502s.

## Test plan
- [x] New unit test: "skips outlet and tries next when journalists-service socket closes mid-request"
- [x] All 192 unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)