### PR TITLE
Add missing indexes on lead_buffer to fix 18K sequential scans

### DIFF
--- a/drizzle/0013_fix_buffer_indexes.sql
+++ b/drizzle/0013_fix_buffer_indexes.sql
@@ -1,0 +1,9 @@
+-- Replace suboptimal composite index with one matching pullNext WHERE clause
+-- Old: (org_id, namespace, status) — skips campaign_id, forcing heap lookups
+-- New: (org_id, campaign_id, namespace, status) — exact match for pullNext query
+DROP INDEX IF EXISTS "idx_buffer_org_ns_status";
+--> statement-breakpoint
+CREATE INDEX "idx_buffer_org_campaign_ns_status" ON "lead_buffer" USING btree ("org_id","campaign_id","namespace","status");
+--> statement-breakpoint
+-- Cover isInBuffer(orgId, campaignId, externalId) which had zero index support
+CREATE INDEX "idx_buffer_org_campaign_extid" ON "lead_buffer" USING btree ("org_id","campaign_id","external_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1775116800000,
       "tag": "0012_multi_brand_ids",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1775376000000,
+      "tag": "0013_fix_buffer_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -80,7 +80,8 @@ export const leadBuffer = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    index("idx_buffer_org_ns_status").on(table.orgId, table.namespace, table.status),
+    index("idx_buffer_org_campaign_ns_status").on(table.orgId, table.campaignId, table.namespace, table.status),
+    index("idx_buffer_org_campaign_extid").on(table.orgId, table.campaignId, table.externalId),
   ]
 );
 

--- a/tests/unit/db-indexes.test.ts
+++ b/tests/unit/db-indexes.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { leadBuffer, servedLeads } from "../../src/db/schema.js";
+
+describe("lead_buffer indexes", () => {
+  const config = getTableConfig(leadBuffer);
+  const indexes = config.indexes.map((i) => ({
+    name: (i as any).config.name as string,
+    columns: (i as any).config.columns.map((c: any) => c.name) as string[],
+  }));
+  const indexNames = indexes.map((i) => i.name);
+
+  it("has index covering pullNext query (org_id, campaign_id, namespace, status)", () => {
+    expect(indexNames).toContain("idx_buffer_org_campaign_ns_status");
+    const idx = indexes.find((i) => i.name === "idx_buffer_org_campaign_ns_status")!;
+    expect(idx.columns).toEqual(["org_id", "campaign_id", "namespace", "status"]);
+  });
+
+  it("has index covering isInBuffer query (org_id, campaign_id, external_id)", () => {
+    expect(indexNames).toContain("idx_buffer_org_campaign_extid");
+    const idx = indexes.find((i) => i.name === "idx_buffer_org_campaign_extid")!;
+    expect(idx.columns).toEqual(["org_id", "campaign_id", "external_id"]);
+  });
+
+  it("does NOT have the old suboptimal index (org_id, namespace, status)", () => {
+    expect(indexNames).not.toContain("idx_buffer_org_ns_status");
+  });
+});
+
+describe("served_leads indexes", () => {
+  const config = getTableConfig(servedLeads);
+  const indexNames = config.indexes.map((i) => (i as any).config.name as string);
+
+  it("has unique index on (org_id, campaign_id, email)", () => {
+    expect(indexNames).toContain("idx_served_org_campaign_email");
+  });
+
+  it("has single-column index on org_id", () => {
+    expect(indexNames).toContain("idx_served_org_id");
+  });
+
+  it("has single-column index on campaign_id", () => {
+    expect(indexNames).toContain("idx_served_campaign");
+  });
+});


### PR DESCRIPTION
## Summary
- **Root cause**: `isInBuffer()` queries by `(org_id, campaign_id, external_id)` had zero index support — full table scan every call. `pullNext` subquery filters on `(org_id, campaign_id, namespace, status)` but existing index `(org_id, namespace, status)` skips `campaign_id`.
- **Fix**: Replace `idx_buffer_org_ns_status` with `idx_buffer_org_campaign_ns_status` (exact match for pullNext WHERE clause), add `idx_buffer_org_campaign_extid` for isInBuffer lookups.
- Stats queries also benefit via the `org_id` prefix on the new composite index.
- `served_leads` seq scans (3,654 on 2.4K rows) are normal small-table behavior — Postgres prefers seq scan over index scan at that size.

## Test plan
- [x] New `db-indexes.test.ts` verifies correct index definitions and absence of old index
- [x] All 198 unit tests pass
- [ ] After deploy: verify via `pg_stat_user_indexes` that the new indexes show scans and `pg_stat_user_tables.seq_scan` count on `lead_buffer` stops climbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)