### PR TITLE
Update CLAUDE.md — lead-service is now Apollo/sales-lead only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Project: lead-service
 
-Single source of truth for lead management — buffering, deduplication, enrichment caching, and lead retrieval.
+Apollo/sales-lead service — buffering, deduplication, enrichment caching, and lead retrieval. All journalist functionality has been moved to journalists-service.
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- Updates project description to reflect journalist features were removed in #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)