### PR TITLE
Fix email-gateway-client: /status → /orgs/status

### DIFF
--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -59,7 +59,7 @@ async function checkDeliveryStatusBatch(
   const body: Record<string, unknown> = { items };
   if (campaignId) body.campaignId = campaignId;
 
-  const response = await fetch(`${EMAIL_GATEWAY_SERVICE_URL}/status`, {
+  const response = await fetch(`${EMAIL_GATEWAY_SERVICE_URL}/orgs/status`, {
     method: "POST",
     headers,
     body: JSON.stringify(body),

--- a/tests/unit/email-gateway-client.test.ts
+++ b/tests/unit/email-gateway-client.test.ts
@@ -54,7 +54,7 @@ describe("email-gateway-client", () => {
       expect(result).toEqual(responseBody);
       expect(mockFetch).toHaveBeenCalledOnce();
       const [url, opts] = mockFetch.mock.calls[0];
-      expect(url).toContain("/status");
+      expect(url).toContain("/orgs/status");
       expect(opts.method).toBe("POST");
       expect(opts.headers["x-brand-id"]).toBe("brand-1");
       const body = JSON.parse(opts.body);


### PR DESCRIPTION
## Summary
- email-gateway-service migrated routes to standard prefixes (`/orgs/*`)
- Updated `POST /status` → `POST /orgs/status` in `email-gateway-client.ts`
- Updated test assertion to match new path

## Test plan
- [x] All 160 unit tests pass
- [x] Integration test failures are pre-existing (cursor endpoint, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)