### PR TITLE
Adapt to email-gateway v2 POST /orgs/status response

### DIFF
--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -1,33 +1,29 @@
 import { EMAIL_GATEWAY_SERVICE_URL, EMAIL_GATEWAY_SERVICE_API_KEY } from "../config.js";
 
 export interface DeliveryStatusItem {
-  leadId: string;
+  leadId?: string;
   email: string;
 }
 
-export interface LeadDeliveryStatus {
+export interface ScopedStatus {
   contacted: boolean;
   delivered: boolean;
+  opened: boolean;
   replied: boolean;
   replyClassification: "positive" | "negative" | "neutral" | null;
-  lastDeliveredAt: string | null;
-}
-
-export interface EmailDeliveryStatus {
-  contacted: boolean;
-  delivered: boolean;
   bounced: boolean;
   unsubscribed: boolean;
   lastDeliveredAt: string | null;
 }
 
-export interface ScopedStatus {
-  lead: LeadDeliveryStatus;
-  email: EmailDeliveryStatus;
-}
-
 export interface GlobalStatus {
-  email: EmailDeliveryStatus;
+  email: {
+    contacted: boolean;
+    delivered: boolean;
+    bounced: boolean;
+    unsubscribed: boolean;
+    lastDeliveredAt: string | null;
+  };
 }
 
 export interface ProviderStatus {
@@ -37,7 +33,7 @@ export interface ProviderStatus {
 }
 
 export interface StatusResult {
-  leadId: string;
+  leadIds: string[];
   email: string;
   broadcast?: ProviderStatus;
   transactional?: ProviderStatus;
@@ -140,15 +136,11 @@ export function isContacted(result: StatusResult): boolean {
   const bc = result.broadcast;
   const tx = result.transactional;
   return !!(
-    bc?.campaign.lead.contacted ||
-    bc?.campaign.email.contacted ||
-    bc?.brand.lead.contacted ||
-    bc?.brand.email.contacted ||
+    bc?.campaign.contacted ||
+    bc?.brand.contacted ||
     bc?.global.email.contacted ||
-    tx?.campaign.lead.contacted ||
-    tx?.campaign.email.contacted ||
-    tx?.brand.lead.contacted ||
-    tx?.brand.email.contacted ||
+    tx?.campaign.contacted ||
+    tx?.brand.contacted ||
     tx?.global.email.contacted
   );
 }

--- a/src/routes/lead-status.ts
+++ b/src/routes/lead-status.ts
@@ -19,41 +19,37 @@ function flattenCampaignStatus(result: StatusResult) {
   const tx = result.transactional;
 
   const contacted = !!(
-    bc?.campaign.lead.contacted ||
-    bc?.campaign.email.contacted ||
-    bc?.brand.lead.contacted ||
-    bc?.brand.email.contacted ||
+    bc?.campaign.contacted ||
+    bc?.brand.contacted ||
     bc?.global.email.contacted ||
-    tx?.campaign.lead.contacted ||
-    tx?.campaign.email.contacted ||
-    tx?.brand.lead.contacted ||
-    tx?.brand.email.contacted ||
+    tx?.campaign.contacted ||
+    tx?.brand.contacted ||
     tx?.global.email.contacted
   );
 
   const delivered = !!(
-    bc?.campaign.email.delivered ||
-    tx?.campaign.email.delivered
+    bc?.campaign.delivered ||
+    tx?.campaign.delivered
   );
 
   const bounced = !!(
-    bc?.campaign.email.bounced ||
-    tx?.campaign.email.bounced
+    bc?.campaign.bounced ||
+    tx?.campaign.bounced
   );
 
   const replied = !!(
-    bc?.campaign.lead.replied ||
-    tx?.campaign.lead.replied
+    bc?.campaign.replied ||
+    tx?.campaign.replied
   );
 
   const replyClassification =
-    bc?.campaign.lead.replyClassification ??
-    tx?.campaign.lead.replyClassification ??
+    bc?.campaign.replyClassification ??
+    tx?.campaign.replyClassification ??
     null;
 
   const lastDeliveredAt =
-    bc?.campaign.email.lastDeliveredAt ??
-    tx?.campaign.email.lastDeliveredAt ??
+    bc?.campaign.lastDeliveredAt ??
+    tx?.campaign.lastDeliveredAt ??
     null;
 
   return { contacted, delivered, bounced, replied, replyClassification, lastDeliveredAt };
@@ -67,37 +63,35 @@ function flattenBrandStatus(result: StatusResult) {
   const tx = result.transactional;
 
   const contacted = !!(
-    bc?.brand.lead.contacted ||
-    bc?.brand.email.contacted ||
+    bc?.brand.contacted ||
     bc?.global.email.contacted ||
-    tx?.brand.lead.contacted ||
-    tx?.brand.email.contacted ||
+    tx?.brand.contacted ||
     tx?.global.email.contacted
   );
 
   const delivered = !!(
-    bc?.brand.email.delivered ||
-    tx?.brand.email.delivered
+    bc?.brand.delivered ||
+    tx?.brand.delivered
   );
 
   const bounced = !!(
-    bc?.brand.email.bounced ||
-    tx?.brand.email.bounced
+    bc?.brand.bounced ||
+    tx?.brand.bounced
   );
 
   const replied = !!(
-    bc?.brand.lead.replied ||
-    tx?.brand.lead.replied
+    bc?.brand.replied ||
+    tx?.brand.replied
   );
 
   const replyClassification =
-    bc?.brand.lead.replyClassification ??
-    tx?.brand.lead.replyClassification ??
+    bc?.brand.replyClassification ??
+    tx?.brand.replyClassification ??
     null;
 
   const lastDeliveredAt =
-    bc?.brand.email.lastDeliveredAt ??
-    tx?.brand.email.lastDeliveredAt ??
+    bc?.brand.lastDeliveredAt ??
+    tx?.brand.lastDeliveredAt ??
     null;
 
   return { contacted, delivered, bounced, replied, replyClassification, lastDeliveredAt };

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -184,7 +184,7 @@ async function countContacted(
         if (isContacted(result)) {
           // Find the leadId for this email
           const item = group.items.find((i) => i.email === result.email);
-          if (item) contactedLeadIds.add(item.leadId);
+          if (item?.leadId) contactedLeadIds.add(item.leadId);
         }
       }
     }),
@@ -252,7 +252,7 @@ async function countContactedGrouped(
             if (!contactedPerGroup.has(item.groupKey)) {
               contactedPerGroup.set(item.groupKey, new Set());
             }
-            contactedPerGroup.get(item.groupKey)!.add(item.leadId);
+            contactedPerGroup.get(item.groupKey)!.add(item.leadId!);
           }
         }
       }
@@ -322,7 +322,7 @@ async function countContactedGroupedByBrand(
               if (!contactedPerBrand.has(bid)) {
                 contactedPerBrand.set(bid, new Set());
               }
-              contactedPerBrand.get(bid)!.add(item.leadId);
+              contactedPerBrand.get(bid)!.add(item.leadId!);
             }
           }
         }

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -168,17 +168,11 @@ describe("API Integration Tests", () => {
       vi.mocked(checkDeliveryStatus)
         .mockResolvedValueOnce({
           results: [{
-            leadId: "any",
+            leadIds: [],
             email: "dedup@example.com",
             broadcast: {
-              campaign: {
-                lead: { contacted: true, delivered: true, replied: false, lastDeliveredAt: "2024-01-01" },
-                email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
-              },
-              brand: {
-                lead: { contacted: true, delivered: true, replied: false, lastDeliveredAt: "2024-01-01" },
-                email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
-              },
+              campaign: { contacted: true, delivered: true, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
+              brand: { contacted: true, delivered: true, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
               global: {
                 email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
               },

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -312,15 +312,10 @@ describe("buffer", () => {
       // First lead: delivered, second lead: not delivered
       vi.mocked(checkDeliveryStatus)
         .mockResolvedValueOnce({
-          results: [{ email: "alice@acme.com", broadcast: {
-            campaign: {
-              lead: { contacted: true, delivered: true, replied: false, lastDeliveredAt: "2024-01-01" },
-              email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
-            },
-            global: {
-              lead: { contacted: true, delivered: true, replied: false, lastDeliveredAt: "2024-01-01" },
-              email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
-            },
+          results: [{ leadIds: [], email: "alice@acme.com", broadcast: {
+            campaign: { contacted: true, delivered: true, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
+            brand: { contacted: false, delivered: false, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+            global: { email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" } },
           }}],
         })
         .mockResolvedValueOnce({ results: [] });

--- a/tests/unit/email-gateway-client.test.ts
+++ b/tests/unit/email-gateway-client.test.ts
@@ -4,6 +4,7 @@ import {
   isContacted,
   type StatusResult,
   type ProviderStatus,
+  type ScopedStatus,
 } from "../../src/lib/email-gateway-client.js";
 
 const mockFetch = vi.fn();
@@ -23,17 +24,11 @@ describe("email-gateway-client", () => {
       const responseBody = {
         results: [
           {
-            leadId: "lead-1",
+            leadIds: ["lead-1"],
             email: "alice@acme.com",
             broadcast: {
-              campaign: {
-                lead: { contacted: true, delivered: true, replied: false, lastDeliveredAt: "2024-01-01" },
-                email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
-              },
-              brand: {
-                lead: { contacted: true, delivered: true, replied: false, lastDeliveredAt: "2024-01-01" },
-                email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
-              },
+              campaign: { contacted: true, delivered: true, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
+              brand: { contacted: true, delivered: true, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
               global: {
                 email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
               },
@@ -194,9 +189,9 @@ describe("email-gateway-client", () => {
   });
 
   describe("isContacted", () => {
-    const emptyScoped = {
-      lead: { contacted: false, delivered: false, replied: false, lastDeliveredAt: null },
-      email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+    const emptyScoped: ScopedStatus = {
+      contacted: false, delivered: false, opened: false, replied: false,
+      replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null,
     };
 
     const emptyGlobal = {
@@ -211,7 +206,7 @@ describe("email-gateway-client", () => {
 
     it("returns false when nothing is contacted", () => {
       const result: StatusResult = {
-        leadId: "lead-1",
+        leadIds: ["lead-1"],
         email: "alice@acme.com",
         broadcast: emptyProvider,
         transactional: emptyProvider,
@@ -220,35 +215,29 @@ describe("email-gateway-client", () => {
     });
 
     it("returns false when no providers present", () => {
-      const result: StatusResult = { leadId: "lead-1", email: "alice@acme.com" };
+      const result: StatusResult = { leadIds: ["lead-1"], email: "alice@acme.com" };
       expect(isContacted(result)).toBe(false);
     });
 
-    it("returns true when broadcast campaign lead is contacted", () => {
+    it("returns true when broadcast campaign is contacted", () => {
       const result: StatusResult = {
-        leadId: "lead-1",
+        leadIds: ["lead-1"],
         email: "alice@acme.com",
         broadcast: {
           ...emptyProvider,
-          campaign: {
-            ...emptyScoped,
-            lead: { contacted: true, delivered: true, replied: false, lastDeliveredAt: "2024-01-01" },
-          },
+          campaign: { ...emptyScoped, contacted: true, delivered: true },
         },
       };
       expect(isContacted(result)).toBe(true);
     });
 
-    it("returns true when broadcast brand lead is contacted", () => {
+    it("returns true when broadcast brand is contacted", () => {
       const result: StatusResult = {
-        leadId: "lead-1",
+        leadIds: ["lead-1"],
         email: "alice@acme.com",
         broadcast: {
           ...emptyProvider,
-          brand: {
-            ...emptyScoped,
-            lead: { contacted: true, delivered: true, replied: false, lastDeliveredAt: "2024-01-01" },
-          },
+          brand: { ...emptyScoped, contacted: true, delivered: true },
         },
       };
       expect(isContacted(result)).toBe(true);
@@ -256,7 +245,7 @@ describe("email-gateway-client", () => {
 
     it("returns true when transactional global email is contacted", () => {
       const result: StatusResult = {
-        leadId: "lead-1",
+        leadIds: ["lead-1"],
         email: "alice@acme.com",
         transactional: {
           ...emptyProvider,
@@ -270,7 +259,7 @@ describe("email-gateway-client", () => {
 
     it("returns true when broadcast global email is contacted", () => {
       const result: StatusResult = {
-        leadId: "lead-1",
+        leadIds: ["lead-1"],
         email: "alice@acme.com",
         broadcast: {
           ...emptyProvider,

--- a/tests/unit/lead-status.test.ts
+++ b/tests/unit/lead-status.test.ts
@@ -58,20 +58,16 @@ function createApp() {
 }
 
 function makeBroadcastStatus(overrides: {
-  campaign?: { lead?: Record<string, unknown>; email?: Record<string, unknown> };
-  brand?: { lead?: Record<string, unknown>; email?: Record<string, unknown> };
+  campaign?: Record<string, unknown>;
+  brand?: Record<string, unknown>;
 }) {
-  const defaultLead = { contacted: false, delivered: false, replied: false, replyClassification: null, lastDeliveredAt: null };
-  const defaultEmail = { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null };
+  const defaultScoped = {
+    contacted: false, delivered: false, opened: false, replied: false,
+    replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null,
+  };
   return {
-    campaign: {
-      lead: { ...defaultLead, ...overrides.campaign?.lead },
-      email: { ...defaultEmail, ...overrides.campaign?.email },
-    },
-    brand: {
-      lead: { ...defaultLead, ...overrides.brand?.lead },
-      email: { ...defaultEmail, ...overrides.brand?.email },
-    },
+    campaign: { ...defaultScoped, ...overrides.campaign },
+    brand: { ...defaultScoped, ...overrides.brand },
     global: { email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null } },
   };
 }
@@ -112,23 +108,17 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadId: "lead-1",
+          leadIds: ["lead-1"],
           email: "alice@acme.com",
           broadcast: makeBroadcastStatus({
-            campaign: {
-              lead: { contacted: true, delivered: true },
-              email: { contacted: true, delivered: true, lastDeliveredAt: "2026-03-29T10:00:00Z" },
-            },
+            campaign: { contacted: true, delivered: true, lastDeliveredAt: "2026-03-29T10:00:00Z" },
           }),
         },
         {
-          leadId: "lead-2",
+          leadIds: ["lead-2"],
           email: "bob@acme.com",
           broadcast: makeBroadcastStatus({
-            campaign: {
-              lead: { contacted: true },
-              email: { contacted: true, bounced: true },
-            },
+            campaign: { contacted: true, bounced: true },
           }),
         },
       ],
@@ -183,13 +173,10 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadId: "lead-1",
+          leadIds: ["lead-1"],
           email: "alice@acme.com",
           broadcast: makeBroadcastStatus({
-            brand: {
-              lead: { contacted: true, delivered: true, replied: true },
-              email: { contacted: true, delivered: true, lastDeliveredAt: "2026-03-29T10:00:00Z" },
-            },
+            brand: { contacted: true, delivered: true, replied: true, lastDeliveredAt: "2026-03-29T10:00:00Z" },
           }),
         },
       ],
@@ -303,13 +290,10 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadId: "lead-1",
+          leadIds: ["lead-1"],
           email: "alice@acme.com",
           broadcast: makeBroadcastStatus({
-            campaign: {
-              lead: { contacted: true, delivered: true, replied: true, replyClassification: "positive" },
-              email: { contacted: true, delivered: true, lastDeliveredAt: "2026-04-01T12:00:00Z" },
-            },
+            campaign: { contacted: true, delivered: true, replied: true, replyClassification: "positive", lastDeliveredAt: "2026-04-01T12:00:00Z" },
           }),
         },
       ],
@@ -329,13 +313,10 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadId: "lead-1",
+          leadIds: ["lead-1"],
           email: "alice@acme.com",
           broadcast: makeBroadcastStatus({
-            brand: {
-              lead: { contacted: true, delivered: true, replied: true, replyClassification: "negative" },
-              email: { contacted: true, delivered: true, lastDeliveredAt: "2026-04-01T12:00:00Z" },
-            },
+            brand: { contacted: true, delivered: true, replied: true, replyClassification: "negative", lastDeliveredAt: "2026-04-01T12:00:00Z" },
           }),
         },
       ],
@@ -354,13 +335,10 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadId: "lead-1",
+          leadIds: ["lead-1"],
           email: "alice@acme.com",
           broadcast: makeBroadcastStatus({
-            campaign: {
-              lead: { contacted: true, delivered: true },
-              email: { contacted: true, delivered: true, lastDeliveredAt: "2026-04-01T12:00:00Z" },
-            },
+            campaign: { contacted: true, delivered: true, lastDeliveredAt: "2026-04-01T12:00:00Z" },
           }),
         },
       ],
@@ -375,15 +353,12 @@ describe("GET /leads/status", () => {
 });
 
 describe("flattenCampaignStatus", () => {
-  it("detects replied and replyClassification from broadcast campaign lead", () => {
+  it("detects replied and replyClassification from broadcast campaign", () => {
     const result = flattenCampaignStatus({
-      leadId: "l1",
+      leadIds: ["l1"],
       email: "a@b.com",
       broadcast: makeBroadcastStatus({
-        campaign: {
-          lead: { contacted: true, delivered: true, replied: true, replyClassification: "positive" },
-          email: { contacted: true, delivered: true, lastDeliveredAt: "2026-03-29T10:00:00Z" },
-        },
+        campaign: { contacted: true, delivered: true, replied: true, replyClassification: "positive", lastDeliveredAt: "2026-03-29T10:00:00Z" },
       }),
     });
 
@@ -395,18 +370,16 @@ describe("flattenCampaignStatus", () => {
   });
 
   it("detects transactional delivery", () => {
+    const defaultScoped = {
+      contacted: false, delivered: false, opened: false, replied: false,
+      replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null,
+    };
     const result = flattenCampaignStatus({
-      leadId: "l1",
+      leadIds: ["l1"],
       email: "a@b.com",
       transactional: {
-        campaign: {
-          lead: { contacted: true, delivered: false, replied: false, lastDeliveredAt: null },
-          email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2026-03-28T08:00:00Z" },
-        },
-        brand: {
-          lead: { contacted: false, delivered: false, replied: false, lastDeliveredAt: null },
-          email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
-        },
+        campaign: { ...defaultScoped, contacted: true, delivered: true, lastDeliveredAt: "2026-03-28T08:00:00Z" },
+        brand: defaultScoped,
         global: {
           email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
         },
@@ -419,7 +392,7 @@ describe("flattenCampaignStatus", () => {
   });
 
   it("returns all false when no providers present", () => {
-    const result = flattenCampaignStatus({ leadId: "l1", email: "a@b.com" });
+    const result = flattenCampaignStatus({ leadIds: ["l1"], email: "a@b.com" });
     expect(result).toEqual({
       contacted: false, delivered: false, bounced: false, replied: false, replyClassification: null, lastDeliveredAt: null,
     });
@@ -429,14 +402,10 @@ describe("flattenCampaignStatus", () => {
 describe("flattenBrandStatus", () => {
   it("uses brand scope for cross-campaign status", () => {
     const result = flattenBrandStatus({
-      leadId: "l1",
+      leadIds: ["l1"],
       email: "a@b.com",
       broadcast: makeBroadcastStatus({
-        campaign: { lead: {}, email: {} },
-        brand: {
-          lead: { contacted: true, delivered: true, replied: true },
-          email: { contacted: true, delivered: true, lastDeliveredAt: "2026-03-29T10:00:00Z" },
-        },
+        brand: { contacted: true, delivered: true, replied: true, lastDeliveredAt: "2026-03-29T10:00:00Z" },
       }),
     });
 
@@ -447,7 +416,7 @@ describe("flattenBrandStatus", () => {
   });
 
   it("returns all false when no providers present", () => {
-    const result = flattenBrandStatus({ leadId: "l1", email: "a@b.com" });
+    const result = flattenBrandStatus({ leadIds: ["l1"], email: "a@b.com" });
     expect(result).toEqual({
       contacted: false, delivered: false, bounced: false, replied: false, replyClassification: null, lastDeliveredAt: null,
     });

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -37,8 +37,8 @@ vi.mock("../../src/lib/apollo-client.js", () => ({
 const mockCheckDeliveryStatus = vi.fn();
 vi.mock("../../src/lib/email-gateway-client.js", () => ({
   checkDeliveryStatus: (...args: unknown[]) => mockCheckDeliveryStatus(...args),
-  isContacted: (result: { broadcast?: { campaign: { lead: { contacted: boolean } } } }) =>
-    !!(result.broadcast?.campaign.lead.contacted),
+  isContacted: (result: { broadcast?: { campaign: { contacted: boolean } } }) =>
+    !!(result.broadcast?.campaign.contacted),
 }));
 
 const mockResolveFeatureDynastySlugs = vi.fn();
@@ -177,20 +177,20 @@ describe("GET /stats", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadId: "lead-1",
+          leadIds: ["lead-1"],
           email: "alice@acme.com",
           broadcast: {
-            campaign: { lead: { contacted: true }, email: { contacted: true } },
-            brand: { lead: { contacted: false }, email: { contacted: false } },
+            campaign: { contacted: true },
+            brand: { contacted: false },
             global: { email: { contacted: false } },
           },
         },
         {
-          leadId: "lead-2",
+          leadIds: ["lead-2"],
           email: "bob@acme.com",
           broadcast: {
-            campaign: { lead: { contacted: false }, email: { contacted: false } },
-            brand: { lead: { contacted: false }, email: { contacted: false } },
+            campaign: { contacted: false },
+            brand: { contacted: false },
             global: { email: { contacted: false } },
           },
         },


### PR DESCRIPTION
## Summary
- Updates lead-service to handle email-gateway's new flat scoped status format (campaign/brand are now flat objects instead of nested `{ lead, email }`)
- Response field `leadId` → `leadIds` (array of all lead IDs found across providers)
- Request field `leadId` is now optional in `DeliveryStatusItem`
- Updates `isContacted`, `flattenCampaignStatus`, `flattenBrandStatus` to read from flat scope objects
- All 160 unit tests pass

## Test plan
- [x] All unit tests updated and passing (160/160)
- [x] TypeScript compiles cleanly
- [x] Build succeeds with regenerated openapi.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)