### PR TITLE
Adapt to email-gateway PR #75: leadIds → leadId

### DIFF
--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -33,7 +33,7 @@ export interface ProviderStatus {
 }
 
 export interface StatusResult {
-  leadIds: string[];
+  leadId: string | null;
   email: string;
   broadcast?: ProviderStatus;
   transactional?: ProviderStatus;

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -168,7 +168,7 @@ describe("API Integration Tests", () => {
       vi.mocked(checkDeliveryStatus)
         .mockResolvedValueOnce({
           results: [{
-            leadIds: [],
+            leadId: null,
             email: "dedup@example.com",
             broadcast: {
               campaign: { contacted: true, delivered: true, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -312,7 +312,7 @@ describe("buffer", () => {
       // First lead: delivered, second lead: not delivered
       vi.mocked(checkDeliveryStatus)
         .mockResolvedValueOnce({
-          results: [{ leadIds: [], email: "alice@acme.com", broadcast: {
+          results: [{ leadId: null, email: "alice@acme.com", broadcast: {
             campaign: { contacted: true, delivered: true, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
             brand: { contacted: false, delivered: false, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null },
             global: { email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" } },

--- a/tests/unit/email-gateway-client.test.ts
+++ b/tests/unit/email-gateway-client.test.ts
@@ -24,7 +24,7 @@ describe("email-gateway-client", () => {
       const responseBody = {
         results: [
           {
-            leadIds: ["lead-1"],
+            leadId: "lead-1",
             email: "alice@acme.com",
             broadcast: {
               campaign: { contacted: true, delivered: true, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
@@ -206,7 +206,7 @@ describe("email-gateway-client", () => {
 
     it("returns false when nothing is contacted", () => {
       const result: StatusResult = {
-        leadIds: ["lead-1"],
+        leadId: "lead-1",
         email: "alice@acme.com",
         broadcast: emptyProvider,
         transactional: emptyProvider,
@@ -215,13 +215,13 @@ describe("email-gateway-client", () => {
     });
 
     it("returns false when no providers present", () => {
-      const result: StatusResult = { leadIds: ["lead-1"], email: "alice@acme.com" };
+      const result: StatusResult = { leadId: "lead-1", email: "alice@acme.com" };
       expect(isContacted(result)).toBe(false);
     });
 
     it("returns true when broadcast campaign is contacted", () => {
       const result: StatusResult = {
-        leadIds: ["lead-1"],
+        leadId: "lead-1",
         email: "alice@acme.com",
         broadcast: {
           ...emptyProvider,
@@ -233,7 +233,7 @@ describe("email-gateway-client", () => {
 
     it("returns true when broadcast brand is contacted", () => {
       const result: StatusResult = {
-        leadIds: ["lead-1"],
+        leadId: "lead-1",
         email: "alice@acme.com",
         broadcast: {
           ...emptyProvider,
@@ -245,7 +245,7 @@ describe("email-gateway-client", () => {
 
     it("returns true when transactional global email is contacted", () => {
       const result: StatusResult = {
-        leadIds: ["lead-1"],
+        leadId: "lead-1",
         email: "alice@acme.com",
         transactional: {
           ...emptyProvider,
@@ -259,7 +259,7 @@ describe("email-gateway-client", () => {
 
     it("returns true when broadcast global email is contacted", () => {
       const result: StatusResult = {
-        leadIds: ["lead-1"],
+        leadId: "lead-1",
         email: "alice@acme.com",
         broadcast: {
           ...emptyProvider,

--- a/tests/unit/lead-status.test.ts
+++ b/tests/unit/lead-status.test.ts
@@ -108,14 +108,14 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadIds: ["lead-1"],
+          leadId: "lead-1",
           email: "alice@acme.com",
           broadcast: makeBroadcastStatus({
             campaign: { contacted: true, delivered: true, lastDeliveredAt: "2026-03-29T10:00:00Z" },
           }),
         },
         {
-          leadIds: ["lead-2"],
+          leadId: "lead-2",
           email: "bob@acme.com",
           broadcast: makeBroadcastStatus({
             campaign: { contacted: true, bounced: true },
@@ -173,7 +173,7 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadIds: ["lead-1"],
+          leadId: "lead-1",
           email: "alice@acme.com",
           broadcast: makeBroadcastStatus({
             brand: { contacted: true, delivered: true, replied: true, lastDeliveredAt: "2026-03-29T10:00:00Z" },
@@ -290,7 +290,7 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadIds: ["lead-1"],
+          leadId: "lead-1",
           email: "alice@acme.com",
           broadcast: makeBroadcastStatus({
             campaign: { contacted: true, delivered: true, replied: true, replyClassification: "positive", lastDeliveredAt: "2026-04-01T12:00:00Z" },
@@ -313,7 +313,7 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadIds: ["lead-1"],
+          leadId: "lead-1",
           email: "alice@acme.com",
           broadcast: makeBroadcastStatus({
             brand: { contacted: true, delivered: true, replied: true, replyClassification: "negative", lastDeliveredAt: "2026-04-01T12:00:00Z" },
@@ -335,7 +335,7 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadIds: ["lead-1"],
+          leadId: "lead-1",
           email: "alice@acme.com",
           broadcast: makeBroadcastStatus({
             campaign: { contacted: true, delivered: true, lastDeliveredAt: "2026-04-01T12:00:00Z" },
@@ -355,7 +355,7 @@ describe("GET /leads/status", () => {
 describe("flattenCampaignStatus", () => {
   it("detects replied and replyClassification from broadcast campaign", () => {
     const result = flattenCampaignStatus({
-      leadIds: ["l1"],
+      leadId: "l1",
       email: "a@b.com",
       broadcast: makeBroadcastStatus({
         campaign: { contacted: true, delivered: true, replied: true, replyClassification: "positive", lastDeliveredAt: "2026-03-29T10:00:00Z" },
@@ -375,7 +375,7 @@ describe("flattenCampaignStatus", () => {
       replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null,
     };
     const result = flattenCampaignStatus({
-      leadIds: ["l1"],
+      leadId: "l1",
       email: "a@b.com",
       transactional: {
         campaign: { ...defaultScoped, contacted: true, delivered: true, lastDeliveredAt: "2026-03-28T08:00:00Z" },
@@ -392,7 +392,7 @@ describe("flattenCampaignStatus", () => {
   });
 
   it("returns all false when no providers present", () => {
-    const result = flattenCampaignStatus({ leadIds: ["l1"], email: "a@b.com" });
+    const result = flattenCampaignStatus({ leadId: "l1", email: "a@b.com" });
     expect(result).toEqual({
       contacted: false, delivered: false, bounced: false, replied: false, replyClassification: null, lastDeliveredAt: null,
     });
@@ -402,7 +402,7 @@ describe("flattenCampaignStatus", () => {
 describe("flattenBrandStatus", () => {
   it("uses brand scope for cross-campaign status", () => {
     const result = flattenBrandStatus({
-      leadIds: ["l1"],
+      leadId: "l1",
       email: "a@b.com",
       broadcast: makeBroadcastStatus({
         brand: { contacted: true, delivered: true, replied: true, lastDeliveredAt: "2026-03-29T10:00:00Z" },
@@ -416,7 +416,7 @@ describe("flattenBrandStatus", () => {
   });
 
   it("returns all false when no providers present", () => {
-    const result = flattenBrandStatus({ leadIds: ["l1"], email: "a@b.com" });
+    const result = flattenBrandStatus({ leadId: "l1", email: "a@b.com" });
     expect(result).toEqual({
       contacted: false, delivered: false, bounced: false, replied: false, replyClassification: null, lastDeliveredAt: null,
     });

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -177,7 +177,7 @@ describe("GET /stats", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadIds: ["lead-1"],
+          leadId: "lead-1",
           email: "alice@acme.com",
           broadcast: {
             campaign: { contacted: true },
@@ -186,7 +186,7 @@ describe("GET /stats", () => {
           },
         },
         {
-          leadIds: ["lead-2"],
+          leadId: "lead-2",
           email: "bob@acme.com",
           broadcast: {
             campaign: { contacted: false },


### PR DESCRIPTION
## Summary
- `StatusResult.leadIds: string[]` → `StatusResult.leadId: string | null` to match email-gateway PR #75
- All test mocks updated accordingly

## Test plan
- [x] 160 unit tests passing
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)