### PR TITLE
Fix crash: handle missing scopes in email-gateway response

### DIFF
--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -27,9 +27,9 @@ export interface GlobalStatus {
 }
 
 export interface ProviderStatus {
-  campaign: ScopedStatus;
-  brand: ScopedStatus;
-  global: GlobalStatus;
+  campaign?: ScopedStatus;
+  brand?: ScopedStatus;
+  global?: GlobalStatus;
 }
 
 export interface StatusResult {
@@ -136,11 +136,11 @@ export function isContacted(result: StatusResult): boolean {
   const bc = result.broadcast;
   const tx = result.transactional;
   return !!(
-    bc?.campaign.contacted ||
-    bc?.brand.contacted ||
-    bc?.global.email.contacted ||
-    tx?.campaign.contacted ||
-    tx?.brand.contacted ||
-    tx?.global.email.contacted
+    bc?.campaign?.contacted ||
+    bc?.brand?.contacted ||
+    bc?.global?.email.contacted ||
+    tx?.campaign?.contacted ||
+    tx?.brand?.contacted ||
+    tx?.global?.email.contacted
   );
 }

--- a/src/routes/lead-status.ts
+++ b/src/routes/lead-status.ts
@@ -19,37 +19,37 @@ function flattenCampaignStatus(result: StatusResult) {
   const tx = result.transactional;
 
   const contacted = !!(
-    bc?.campaign.contacted ||
-    bc?.brand.contacted ||
-    bc?.global.email.contacted ||
-    tx?.campaign.contacted ||
-    tx?.brand.contacted ||
-    tx?.global.email.contacted
+    bc?.campaign?.contacted ||
+    bc?.brand?.contacted ||
+    bc?.global?.email.contacted ||
+    tx?.campaign?.contacted ||
+    tx?.brand?.contacted ||
+    tx?.global?.email.contacted
   );
 
   const delivered = !!(
-    bc?.campaign.delivered ||
-    tx?.campaign.delivered
+    bc?.campaign?.delivered ||
+    tx?.campaign?.delivered
   );
 
   const bounced = !!(
-    bc?.campaign.bounced ||
-    tx?.campaign.bounced
+    bc?.campaign?.bounced ||
+    tx?.campaign?.bounced
   );
 
   const replied = !!(
-    bc?.campaign.replied ||
-    tx?.campaign.replied
+    bc?.campaign?.replied ||
+    tx?.campaign?.replied
   );
 
   const replyClassification =
-    bc?.campaign.replyClassification ??
-    tx?.campaign.replyClassification ??
+    bc?.campaign?.replyClassification ??
+    tx?.campaign?.replyClassification ??
     null;
 
   const lastDeliveredAt =
-    bc?.campaign.lastDeliveredAt ??
-    tx?.campaign.lastDeliveredAt ??
+    bc?.campaign?.lastDeliveredAt ??
+    tx?.campaign?.lastDeliveredAt ??
     null;
 
   return { contacted, delivered, bounced, replied, replyClassification, lastDeliveredAt };
@@ -63,35 +63,35 @@ function flattenBrandStatus(result: StatusResult) {
   const tx = result.transactional;
 
   const contacted = !!(
-    bc?.brand.contacted ||
-    bc?.global.email.contacted ||
-    tx?.brand.contacted ||
-    tx?.global.email.contacted
+    bc?.brand?.contacted ||
+    bc?.global?.email.contacted ||
+    tx?.brand?.contacted ||
+    tx?.global?.email.contacted
   );
 
   const delivered = !!(
-    bc?.brand.delivered ||
-    tx?.brand.delivered
+    bc?.brand?.delivered ||
+    tx?.brand?.delivered
   );
 
   const bounced = !!(
-    bc?.brand.bounced ||
-    tx?.brand.bounced
+    bc?.brand?.bounced ||
+    tx?.brand?.bounced
   );
 
   const replied = !!(
-    bc?.brand.replied ||
-    tx?.brand.replied
+    bc?.brand?.replied ||
+    tx?.brand?.replied
   );
 
   const replyClassification =
-    bc?.brand.replyClassification ??
-    tx?.brand.replyClassification ??
+    bc?.brand?.replyClassification ??
+    tx?.brand?.replyClassification ??
     null;
 
   const lastDeliveredAt =
-    bc?.brand.lastDeliveredAt ??
-    tx?.brand.lastDeliveredAt ??
+    bc?.brand?.lastDeliveredAt ??
+    tx?.brand?.lastDeliveredAt ??
     null;
 
   return { contacted, delivered, bounced, replied, replyClassification, lastDeliveredAt };

--- a/tests/unit/lead-status.test.ts
+++ b/tests/unit/lead-status.test.ts
@@ -415,6 +415,16 @@ describe("flattenBrandStatus", () => {
     expect(result.lastDeliveredAt).toBe("2026-03-29T10:00:00Z");
   });
 
+  it("handles missing scopes in provider (partial response)", () => {
+    const result = flattenBrandStatus({
+      leadId: "l1",
+      email: "a@b.com",
+      broadcast: { global: { email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: null } } } as any,
+    });
+    expect(result.contacted).toBe(true);
+    expect(result.delivered).toBe(false);
+  });
+
   it("returns all false when no providers present", () => {
     const result = flattenBrandStatus({ leadId: "l1", email: "a@b.com" });
     expect(result).toEqual({


### PR DESCRIPTION
## Summary
- `ProviderStatus.campaign`, `.brand`, `.global` are now optional — email-gateway omits scopes with no data
- Added optional chaining (`?.`) on all scope accesses in `isContacted`, `flattenCampaignStatus`, `flattenBrandStatus`
- Fixes production 500s on `GET /leads/status?brandId=...`

## Test plan
- [x] 161 unit tests passing (1 new regression test for partial provider response)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)