### PR TITLE
Adopt /orgs/* route convention, split auth middlewares

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -763,7 +763,7 @@
         }
       }
     },
-    "/buffer/next": {
+    "/orgs/buffer/next": {
       "post": {
         "summary": "Pull the next lead from the buffer",
         "parameters": [
@@ -876,7 +876,7 @@
         }
       }
     },
-    "/cursor/{namespace}": {
+    "/orgs/cursor/{namespace}": {
       "get": {
         "summary": "Get cursor state for a namespace",
         "parameters": [
@@ -1097,7 +1097,7 @@
         }
       }
     },
-    "/leads": {
+    "/orgs/leads": {
       "get": {
         "summary": "List served leads with enrichment data",
         "parameters": [
@@ -1223,7 +1223,7 @@
         }
       }
     },
-    "/stats": {
+    "/orgs/stats": {
       "get": {
         "summary": "Get lead stats by status",
         "description": "Returns counts of leads by status: served (delivered with verified email), contacted (unique leads with at least one successful email send), buffered (awaiting enrichment), and skipped (no email found).",
@@ -1447,7 +1447,7 @@
         }
       }
     },
-    "/leads/status": {
+    "/orgs/leads/status": {
       "get": {
         "summary": "Get per-lead delivery and reply status",
         "description": "Returns delivery status (contacted, delivered, bounced, replied, replyClassification) for served leads. With campaignId: campaign-scoped status. Without campaignId: cross-campaign brand-scoped status (requires brandId). At least one of campaignId or brandId must be provided. Calls email-gateway internally.",

--- a/src/lib/register-providers.ts
+++ b/src/lib/register-providers.ts
@@ -7,7 +7,7 @@ const ENDPOINT_MAPPING: Array<{
   downstream: Array<{ service: string; method: string; path: string }>;
 }> = [
   {
-    lead: { method: "POST", path: "/buffer/next" },
+    lead: { method: "POST", path: "/orgs/buffer/next" },
     downstream: [
       { service: "apollo", method: "POST", path: "/search" },
       { service: "apollo", method: "POST", path: "/search/next" },
@@ -16,7 +16,7 @@ const ENDPOINT_MAPPING: Array<{
     ],
   },
   {
-    lead: { method: "GET", path: "/stats" },
+    lead: { method: "GET", path: "/orgs/stats" },
     downstream: [
       { service: "apollo", method: "POST", path: "/stats" },
     ],

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -42,46 +42,56 @@ function parseBrandIds(header: string | undefined): string[] {
   return String(header).split(",").map(s => s.trim()).filter(Boolean);
 }
 
-export async function authenticate(
+/**
+ * Validates x-api-key header. Used on /public/*, /internal/*, and /orgs/* tiers.
+ */
+export function apiKeyAuth(
   req: AuthenticatedRequest,
   res: Response,
   next: NextFunction
 ) {
-  try {
-    const apiKey = req.headers["x-api-key"] as string;
-    if (!apiKey || apiKey !== LEAD_SERVICE_API_KEY) {
-      return res.status(401).json({ error: "Invalid API key" });
-    }
-
-    const orgId = req.headers["x-org-id"] as string;
-    const userId = req.headers["x-user-id"] as string;
-    const runId = req.headers["x-run-id"] as string;
-
-    if (!orgId || !userId || !runId) {
-      return res.status(400).json({ error: "x-org-id, x-user-id, and x-run-id headers required" });
-    }
-
-    const campaignId = req.headers["x-campaign-id"] as string | undefined;
-    const brandIdRaw = req.headers["x-brand-id"] as string | undefined;
-    const workflowSlug = req.headers["x-workflow-slug"] as string | undefined;
-    const featureSlug = req.headers["x-feature-slug"] as string | undefined;
-
-    req.orgId = orgId;
-    req.userId = userId;
-    req.runId = runId;
-    if (campaignId) req.campaignId = campaignId;
-    if (brandIdRaw) {
-      req.brandId = brandIdRaw;
-      req.brandIds = parseBrandIds(brandIdRaw);
-    } else {
-      req.brandIds = [];
-    }
-    if (workflowSlug) req.workflowSlug = workflowSlug;
-    if (featureSlug) req.featureSlug = featureSlug;
-
-    next();
-  } catch (error) {
-    console.error("[auth] Error:", error);
-    return res.status(401).json({ error: "Authentication failed" });
+  const apiKey = req.headers["x-api-key"] as string;
+  if (!apiKey || apiKey !== LEAD_SERVICE_API_KEY) {
+    res.status(401).json({ error: "Invalid API key" });
+    return;
   }
+  next();
+}
+
+/**
+ * Parses all 7 identity headers, requires only x-org-id.
+ * Must be used after apiKeyAuth. Used on /orgs/* tier.
+ */
+export function requireOrgId(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+) {
+  const orgId = req.headers["x-org-id"] as string;
+  if (!orgId) {
+    res.status(400).json({ error: "x-org-id header required" });
+    return;
+  }
+
+  const userId = req.headers["x-user-id"] as string | undefined;
+  const runId = req.headers["x-run-id"] as string | undefined;
+  const campaignId = req.headers["x-campaign-id"] as string | undefined;
+  const brandIdRaw = req.headers["x-brand-id"] as string | undefined;
+  const workflowSlug = req.headers["x-workflow-slug"] as string | undefined;
+  const featureSlug = req.headers["x-feature-slug"] as string | undefined;
+
+  req.orgId = orgId;
+  if (userId) req.userId = userId;
+  if (runId) req.runId = runId;
+  if (campaignId) req.campaignId = campaignId;
+  if (brandIdRaw) {
+    req.brandId = brandIdRaw;
+    req.brandIds = parseBrandIds(brandIdRaw);
+  } else {
+    req.brandIds = [];
+  }
+  if (workflowSlug) req.workflowSlug = workflowSlug;
+  if (featureSlug) req.featureSlug = featureSlug;
+
+  next();
 }

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { eq, lt } from "drizzle-orm";
-import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
+import { type AuthenticatedRequest, apiKeyAuth, requireOrgId } from "../middleware/auth.js";
 import { pullNext } from "../lib/buffer.js";
 import { createRun, updateRun } from "../lib/runs-client.js";
 import { BufferNextRequestSchema } from "../schemas.js";
@@ -25,7 +25,7 @@ function pruneExpiredIdempotencyCache(): void {
     });
 }
 
-router.post("/buffer/next", authenticate, async (req: AuthenticatedRequest, res) => {
+router.post("/orgs/buffer/next", apiKeyAuth, requireOrgId, async (req: AuthenticatedRequest, res) => {
   const parsed = BufferNextRequestSchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });

--- a/src/routes/cursor.ts
+++ b/src/routes/cursor.ts
@@ -1,13 +1,13 @@
 import { Router } from "express";
 import { eq, and } from "drizzle-orm";
-import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
+import { type AuthenticatedRequest, apiKeyAuth, requireOrgId } from "../middleware/auth.js";
 import { db } from "../db/index.js";
 import { cursors } from "../db/schema.js";
 import { CursorSetRequestSchema } from "../schemas.js";
 
 const router = Router();
 
-router.get("/cursor/:namespace", authenticate, async (req: AuthenticatedRequest, res) => {
+router.get("/orgs/cursor/:namespace", apiKeyAuth, requireOrgId, async (req: AuthenticatedRequest, res) => {
   try {
     const { namespace } = req.params;
 
@@ -25,7 +25,7 @@ router.get("/cursor/:namespace", authenticate, async (req: AuthenticatedRequest,
   }
 });
 
-router.put("/cursor/:namespace", authenticate, async (req: AuthenticatedRequest, res) => {
+router.put("/orgs/cursor/:namespace", apiKeyAuth, requireOrgId, async (req: AuthenticatedRequest, res) => {
   const parsed = CursorSetRequestSchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ error: "Invalid request", details: parsed.error.flatten() });

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -2,10 +2,6 @@ import { Router } from "express";
 
 const router = Router();
 
-router.get("/", (req, res) => {
-  res.json({ status: "ok", service: "lead-service" });
-});
-
 router.get("/health", (req, res) => {
   res.json({ status: "ok", service: "lead-service" });
 });

--- a/src/routes/lead-status.ts
+++ b/src/routes/lead-status.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { eq, and, sql, type SQL } from "drizzle-orm";
-import { type AuthenticatedRequest, authenticate, getServiceContext } from "../middleware/auth.js";
+import { type AuthenticatedRequest, apiKeyAuth, requireOrgId, getServiceContext } from "../middleware/auth.js";
 import { db } from "../db/index.js";
 import { servedLeads } from "../db/schema.js";
 import {
@@ -99,7 +99,7 @@ function flattenBrandStatus(result: StatusResult) {
 
 const DEFAULT_FLAT = { contacted: false, delivered: false, bounced: false, replied: false, replyClassification: null, lastDeliveredAt: null };
 
-router.get("/leads/status", authenticate, async (req: AuthenticatedRequest, res) => {
+router.get("/orgs/leads/status", apiKeyAuth, requireOrgId, async (req: AuthenticatedRequest, res) => {
   try {
     const campaignId = typeof req.query.campaignId === "string" ? req.query.campaignId : undefined;
     const brandId = typeof req.query.brandId === "string" ? req.query.brandId : undefined;

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { eq, and, sql, type SQL } from "drizzle-orm";
-import { type AuthenticatedRequest, authenticate } from "../middleware/auth.js";
+import { type AuthenticatedRequest, apiKeyAuth, requireOrgId } from "../middleware/auth.js";
 import { db } from "../db/index.js";
 import { servedLeads } from "../db/schema.js";
 
@@ -15,7 +15,7 @@ export function extractEnrichment(metadata: unknown): Record<string, unknown> | 
   return { ...m };
 }
 
-router.get("/leads", authenticate, async (req: AuthenticatedRequest, res) => {
+router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedRequest, res) => {
   try {
     const { brandId, campaignId, orgId, userId } = req.query;
 

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { eq, and, count, inArray, or, sql, type SQL } from "drizzle-orm";
-import { type AuthenticatedRequest, type ServiceContext, authenticate, getServiceContext } from "../middleware/auth.js";
+import { type AuthenticatedRequest, type ServiceContext, apiKeyAuth, requireOrgId, getServiceContext } from "../middleware/auth.js";
 import { db } from "../db/index.js";
 import { servedLeads, leadBuffer } from "../db/schema.js";
 import { fetchApolloStats } from "../lib/apollo-client.js";
@@ -339,7 +339,7 @@ async function countContactedGroupedByBrand(
 
 const ZERO_STATS = { groups: [] };
 
-router.get("/stats", authenticate, async (req: AuthenticatedRequest, res) => {
+router.get("/orgs/stats", apiKeyAuth, requireOrgId, async (req: AuthenticatedRequest, res) => {
   try {
     const groupByParam =
       typeof req.query.groupBy === "string" ? req.query.groupBy : undefined;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -379,7 +379,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/buffer/next",
+  path: "/orgs/buffer/next",
   summary: "Pull the next lead from the buffer",
   request: {
     params: z.object({}),
@@ -403,7 +403,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/cursor/{namespace}",
+  path: "/orgs/cursor/{namespace}",
   summary: "Get cursor state for a namespace",
   request: {
     params: z.object({ namespace: z.string() }),
@@ -420,7 +420,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "put",
-  path: "/cursor/{namespace}",
+  path: "/orgs/cursor/{namespace}",
   summary: "Set cursor state for a namespace",
   request: {
     params: z.object({ namespace: z.string() }),
@@ -444,7 +444,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/leads",
+  path: "/orgs/leads",
   summary: "List served leads with enrichment data",
   parameters: [
     ...AuthHeaders,
@@ -484,7 +484,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/stats",
+  path: "/orgs/stats",
   summary: "Get lead stats by status",
   description:
     "Returns counts of leads by status: served (delivered with verified email), contacted (unique leads with at least one successful email send), buffered (awaiting enrichment), and skipped (no email found).",
@@ -606,7 +606,7 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
-  path: "/leads/status",
+  path: "/orgs/leads/status",
   summary: "Get per-lead delivery and reply status",
   description:
     "Returns delivery status (contacted, delivered, bounced, replied, replyClassification) for served leads. " +

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -34,12 +34,6 @@ describe("API Integration Tests", () => {
   });
 
   describe("Health check", () => {
-    it("GET / returns 200 with service status", async () => {
-      const res = await request(app).get("/");
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual({ status: "ok", service: "lead-service" });
-    });
-
     it("GET /health returns 200 with service status", async () => {
       const res = await request(app).get("/health");
       expect(res.status).toBe(200);
@@ -50,7 +44,7 @@ describe("API Integration Tests", () => {
   describe("Authentication", () => {
     it("rejects requests without API key", async () => {
       const res = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .send({ campaignId: "c1", brandId: "b1" });
 
       expect(res.status).toBe(401);
@@ -58,33 +52,18 @@ describe("API Integration Tests", () => {
 
     it("rejects requests with invalid API key", async () => {
       const res = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set("x-api-key", "wrong-key")
         .set("x-org-id", "test")
-        .set("x-user-id", "test")
-        .set("x-run-id", "test")
         .send({ campaignId: "c1", brandId: "b1" });
 
       expect(res.status).toBe(401);
     });
 
-    it("rejects requests without x-user-id header", async () => {
+    it("rejects requests without x-org-id header", async () => {
       const res = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set("x-api-key", TEST_API_KEY)
-        .set("x-org-id", "test")
-        .set("x-run-id", "test")
-        .send({ campaignId: "c1", brandId: "b1" });
-
-      expect(res.status).toBe(400);
-    });
-
-    it("rejects requests without x-run-id header", async () => {
-      const res = await request(app)
-        .post("/buffer/next")
-        .set("x-api-key", TEST_API_KEY)
-        .set("x-org-id", "test")
-        .set("x-user-id", "test")
         .send({ campaignId: "c1", brandId: "b1" });
 
       expect(res.status).toBe(400);
@@ -100,7 +79,7 @@ describe("API Integration Tests", () => {
       });
 
       const res = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({ campaignId: "campaign-b", brandId: "brand-b" });
 
@@ -112,7 +91,7 @@ describe("API Integration Tests", () => {
 
     it("returns found: false when buffer empty", async () => {
       const res = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({ campaignId: "campaign-empty", brandId: "brand-empty" });
 
@@ -122,7 +101,7 @@ describe("API Integration Tests", () => {
 
     it("returns 400 when brandId is empty string", async () => {
       const res = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({ campaignId: "campaign-x", brandId: "" });
 
@@ -140,7 +119,7 @@ describe("API Integration Tests", () => {
       vi.mocked(createRun).mockClear();
 
       await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({
           campaignId: "campaign-wf-next",
@@ -186,7 +165,7 @@ describe("API Integration Tests", () => {
         .mockReturnValue(false);
 
       const res = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({ campaignId: "campaign-c", brandId: "brand-c" });
 
@@ -209,7 +188,7 @@ describe("API Integration Tests", () => {
 
       // First pull with idempotencyKey
       const first = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({
           campaignId: "campaign-idem-1",
@@ -224,7 +203,7 @@ describe("API Integration Tests", () => {
 
       // Retry with same idempotencyKey — should return cached result
       const retry = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({
           campaignId: "campaign-idem-1",
@@ -249,7 +228,7 @@ describe("API Integration Tests", () => {
 
       // Pull with idempotencyKey
       const first = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({
           campaignId: "campaign-idem-2",
@@ -262,7 +241,7 @@ describe("API Integration Tests", () => {
 
       // Retry with same key — should NOT consume second lead
       await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({
           campaignId: "campaign-idem-2",
@@ -272,7 +251,7 @@ describe("API Integration Tests", () => {
 
       // Pull with different key — should get the other lead
       const second = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({
           campaignId: "campaign-idem-2",
@@ -287,7 +266,7 @@ describe("API Integration Tests", () => {
     it("caches found: false responses too", async () => {
       // Pull from empty buffer with idempotencyKey
       const first = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({
           campaignId: "campaign-idem-empty",
@@ -306,7 +285,7 @@ describe("API Integration Tests", () => {
 
       // Retry with same key — should still return cached found: false
       const retry = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({
           campaignId: "campaign-idem-empty",
@@ -325,7 +304,7 @@ describe("API Integration Tests", () => {
       });
 
       const res = await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({
           campaignId: "campaign-idem-compat",
@@ -370,13 +349,13 @@ describe("API Integration Tests", () => {
 
       // Pull it to move to served_leads
       await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({ campaignId: "campaign-leads", brandId: "brand-leads" });
 
       // Query GET /leads
       const res = await request(app)
-        .get("/leads?brandId=brand-leads&campaignId=campaign-leads")
+        .get("/orgs/leads?brandId=brand-leads&campaignId=campaign-leads")
         .set(getAuthHeaders());
 
       expect(res.status).toBe(200);
@@ -410,12 +389,12 @@ describe("API Integration Tests", () => {
       });
 
       await request(app)
-        .post("/buffer/next")
+        .post("/orgs/buffer/next")
         .set(getAuthHeaders())
         .send({ campaignId: "campaign-leads-empty", brandId: "brand-leads-empty" });
 
       const res = await request(app)
-        .get("/leads?brandId=brand-leads-empty&campaignId=campaign-leads-empty")
+        .get("/orgs/leads?brandId=brand-leads-empty&campaignId=campaign-leads-empty")
         .set(getAuthHeaders());
 
       expect(res.status).toBe(200);
@@ -428,7 +407,7 @@ describe("API Integration Tests", () => {
   describe("Cursor endpoints", () => {
     it("GET returns null for non-existent cursor", async () => {
       const res = await request(app)
-        .get("/cursor/new-namespace")
+        .get("/orgs/cursor/new-namespace")
         .set(getAuthHeaders());
 
       expect(res.status).toBe(200);
@@ -439,7 +418,7 @@ describe("API Integration Tests", () => {
       const state = { page: 5, lastId: "abc123" };
 
       const putRes = await request(app)
-        .put("/cursor/my-namespace")
+        .put("/orgs/cursor/my-namespace")
         .set(getAuthHeaders())
         .send({ state });
 
@@ -447,7 +426,7 @@ describe("API Integration Tests", () => {
       expect(putRes.body.ok).toBe(true);
 
       const getRes = await request(app)
-        .get("/cursor/my-namespace")
+        .get("/orgs/cursor/my-namespace")
         .set(getAuthHeaders());
 
       expect(getRes.status).toBe(200);
@@ -456,17 +435,17 @@ describe("API Integration Tests", () => {
 
     it("PUT updates existing cursor", async () => {
       await request(app)
-        .put("/cursor/update-test")
+        .put("/orgs/cursor/update-test")
         .set(getAuthHeaders())
         .send({ state: { v: 1 } });
 
       await request(app)
-        .put("/cursor/update-test")
+        .put("/orgs/cursor/update-test")
         .set(getAuthHeaders())
         .send({ state: { v: 2 } });
 
       const res = await request(app)
-        .get("/cursor/update-test")
+        .get("/orgs/cursor/update-test")
         .set(getAuthHeaders());
 
       expect(res.body.state).toEqual({ v: 2 });

--- a/tests/unit/buffer-route.test.ts
+++ b/tests/unit/buffer-route.test.ts
@@ -34,7 +34,8 @@ vi.mock("../../src/db/index.js", () => ({
 }));
 
 vi.mock("../../src/middleware/auth.js", () => ({
-  authenticate: (_req: any, _res: any, next: any) => {
+  apiKeyAuth: (_req: any, _res: any, next: any) => next(),
+  requireOrgId: (_req: any, _res: any, next: any) => {
     _req.orgId = "test-org";
     _req.userId = "test-user";
     _req.runId = "parent-run";
@@ -72,7 +73,7 @@ describe("POST /buffer/next run status", () => {
 
     const app = createApp();
     const res = await request(app)
-      .post("/buffer/next")
+      .post("/orgs/buffer/next")
       .set("x-campaign-id", "c1")
       .set("x-brand-id", "b1")
       .send({});
@@ -94,7 +95,7 @@ describe("POST /buffer/next run status", () => {
 
     const app = createApp();
     const res = await request(app)
-      .post("/buffer/next")
+      .post("/orgs/buffer/next")
       .set("x-campaign-id", "c1")
       .set("x-brand-id", "b1")
       .send({});
@@ -113,7 +114,7 @@ describe("POST /buffer/next run status", () => {
 
     const app = createApp();
     const res = await request(app)
-      .post("/buffer/next")
+      .post("/orgs/buffer/next")
       .set("x-campaign-id", "c1")
       .set("x-brand-id", "b1")
       .send({});

--- a/tests/unit/lead-status.test.ts
+++ b/tests/unit/lead-status.test.ts
@@ -28,7 +28,8 @@ vi.mock("../../src/lib/email-gateway-client.js", () => ({
 }));
 
 vi.mock("../../src/middleware/auth.js", () => ({
-  authenticate: (_req: unknown, _res: unknown, next: () => void) => next(),
+  apiKeyAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+  requireOrgId: (_req: unknown, _res: unknown, next: () => void) => next(),
   getServiceContext: (req: any) => ({
     orgId: req.orgId,
     userId: req.userId,
@@ -81,7 +82,7 @@ describe("GET /leads/status", () => {
 
   it("returns 400 when neither campaignId nor brandId is provided", async () => {
     const app = createApp();
-    const res = await request(app).get("/leads/status");
+    const res = await request(app).get("/orgs/leads/status");
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("campaignId or brandId");
   });
@@ -90,7 +91,7 @@ describe("GET /leads/status", () => {
     mockWhere.mockResolvedValue([]);
 
     const app = createApp();
-    const res = await request(app).get("/leads/status?campaignId=c1");
+    const res = await request(app).get("/orgs/leads/status?campaignId=c1");
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ statuses: [] });
     expect(mockCheckDeliveryStatus).not.toHaveBeenCalled();
@@ -125,7 +126,7 @@ describe("GET /leads/status", () => {
     });
 
     const app = createApp();
-    const res = await request(app).get("/leads/status?campaignId=c1");
+    const res = await request(app).get("/orgs/leads/status?campaignId=c1");
     expect(res.status).toBe(200);
     expect(res.body.statuses).toHaveLength(2);
 
@@ -152,7 +153,7 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({ results: [] });
 
     const app = createApp();
-    await request(app).get("/leads/status?campaignId=c1");
+    await request(app).get("/orgs/leads/status?campaignId=c1");
 
     expect(mockCheckDeliveryStatus).toHaveBeenCalledWith(
       "b1", "c1", expect.any(Array), expect.any(Object),
@@ -183,7 +184,7 @@ describe("GET /leads/status", () => {
     });
 
     const app = createApp();
-    const res = await request(app).get("/leads/status?brandId=b1");
+    const res = await request(app).get("/orgs/leads/status?brandId=b1");
     expect(res.status).toBe(200);
     expect(res.body.statuses).toHaveLength(1);
 
@@ -207,7 +208,7 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({ results: [] });
 
     const app = createApp();
-    await request(app).get("/leads/status?brandId=b1");
+    await request(app).get("/orgs/leads/status?brandId=b1");
 
     expect(mockCheckDeliveryStatus).toHaveBeenCalledWith(
       "b1", undefined, expect.any(Array), expect.any(Object),
@@ -222,7 +223,7 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({ results: [] });
 
     const app = createApp();
-    const res = await request(app).get("/leads/status?brandId=b1");
+    const res = await request(app).get("/orgs/leads/status?brandId=b1");
     expect(res.body.statuses).toHaveLength(1);
   });
 
@@ -235,7 +236,7 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue(null);
 
     const app = createApp();
-    const res = await request(app).get("/leads/status?campaignId=c1");
+    const res = await request(app).get("/orgs/leads/status?campaignId=c1");
     expect(res.status).toBe(200);
     expect(res.body.statuses[0]).toMatchObject({
       contacted: false,
@@ -254,7 +255,7 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue(null);
 
     const app = createApp();
-    const res = await request(app).get("/leads/status?campaignId=c1");
+    const res = await request(app).get("/orgs/leads/status?campaignId=c1");
     expect(res.body.statuses).toHaveLength(1);
     expect(res.body.statuses[0].leadId).toBe("lead-1");
   });
@@ -267,7 +268,7 @@ describe("GET /leads/status", () => {
     mockCheckDeliveryStatus.mockResolvedValue({ results: [] });
 
     const app = createApp();
-    await request(app).get("/leads/status?campaignId=c1");
+    await request(app).get("/orgs/leads/status?campaignId=c1");
 
     expect(mockCheckDeliveryStatus).toHaveBeenCalledTimes(2);
     expect(mockCheckDeliveryStatus).toHaveBeenCalledWith("b1", "c1", expect.any(Array), expect.any(Object));
@@ -278,7 +279,7 @@ describe("GET /leads/status", () => {
     mockWhere.mockResolvedValue([]);
 
     const app = createApp();
-    const res = await request(app).get("/leads/status?campaignId=c1&brandId=b1");
+    const res = await request(app).get("/orgs/leads/status?campaignId=c1&brandId=b1");
     expect(res.status).toBe(200);
   });
 
@@ -300,7 +301,7 @@ describe("GET /leads/status", () => {
     });
 
     const app = createApp();
-    const res = await request(app).get("/leads/status?campaignId=c1");
+    const res = await request(app).get("/orgs/leads/status?campaignId=c1");
     expect(res.body.statuses[0].replyClassification).toBe("positive");
     expect(res.body.statuses[0].replied).toBe(true);
   });
@@ -323,7 +324,7 @@ describe("GET /leads/status", () => {
     });
 
     const app = createApp();
-    const res = await request(app).get("/leads/status?brandId=b1");
+    const res = await request(app).get("/orgs/leads/status?brandId=b1");
     expect(res.body.statuses[0].replyClassification).toBe("negative");
   });
 
@@ -345,7 +346,7 @@ describe("GET /leads/status", () => {
     });
 
     const app = createApp();
-    const res = await request(app).get("/leads/status?campaignId=c1");
+    const res = await request(app).get("/orgs/leads/status?campaignId=c1");
     expect(res.body.statuses[0].replyClassification).toBeNull();
     expect(res.body.statuses[0].replied).toBe(false);
   });

--- a/tests/unit/register-providers.test.ts
+++ b/tests/unit/register-providers.test.ts
@@ -65,7 +65,7 @@ describe("key-service-client", () => {
         json: () => Promise.resolve({ provider: "apollo", key: "ak_123" }),
       });
 
-      await registerProviderRequirement("apollo", "lead", "POST", "/buffer/next");
+      await registerProviderRequirement("apollo", "lead", "POST", "/orgs/buffer/next");
 
       expect(mockFetch).toHaveBeenCalledOnce();
       const [url, opts] = mockFetch.mock.calls[0];
@@ -73,7 +73,7 @@ describe("key-service-client", () => {
       expect(opts.method).toBe("GET");
       expect(opts.headers["x-caller-service"]).toBe("lead");
       expect(opts.headers["x-caller-method"]).toBe("POST");
-      expect(opts.headers["x-caller-path"]).toBe("/buffer/next");
+      expect(opts.headers["x-caller-path"]).toBe("/orgs/buffer/next");
     });
 
     it("tolerates 404 (key not configured)", async () => {
@@ -84,7 +84,7 @@ describe("key-service-client", () => {
       });
 
       await expect(
-        registerProviderRequirement("apollo", "lead", "POST", "/buffer/next")
+        registerProviderRequirement("apollo", "lead", "POST", "/orgs/buffer/next")
       ).resolves.toBeUndefined();
     });
 
@@ -96,7 +96,7 @@ describe("key-service-client", () => {
       });
 
       await expect(
-        registerProviderRequirement("apollo", "lead", "POST", "/buffer/next")
+        registerProviderRequirement("apollo", "lead", "POST", "/orgs/buffer/next")
       ).rejects.toThrow("Key service registration failed: 500");
     });
   });
@@ -161,8 +161,8 @@ describe("registerProviders", () => {
       service: opts.headers["x-caller-service"],
     }));
 
-    expect(registeredPairs).toContainEqual({ provider: "apollo", method: "POST", path: "/buffer/next", service: "lead" });
-    expect(registeredPairs).toContainEqual({ provider: "anthropic", method: "POST", path: "/buffer/next", service: "lead" });
+    expect(registeredPairs).toContainEqual({ provider: "apollo", method: "POST", path: "/orgs/buffer/next", service: "lead" });
+    expect(registeredPairs).toContainEqual({ provider: "anthropic", method: "POST", path: "/orgs/buffer/next", service: "lead" });
 
     logSpy.mockRestore();
   });
@@ -215,7 +215,7 @@ describe("registerProviders", () => {
     // 1 query + 2 registration attempts
     expect(mockFetch).toHaveBeenCalledTimes(3);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to register lead POST /buffer/next"),
+      expect.stringContaining("Failed to register lead POST /orgs/buffer/next"),
       expect.any(Error)
     );
 

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -54,7 +54,8 @@ vi.mock("../../src/lib/dynasty-client.js", () => ({
 }));
 
 vi.mock("../../src/middleware/auth.js", () => ({
-  authenticate: (_req: unknown, _res: unknown, next: () => void) => next(),
+  apiKeyAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+  requireOrgId: (_req: unknown, _res: unknown, next: () => void) => next(),
   getServiceContext: (req: any) => ({
     orgId: req.orgId,
     userId: req.userId,
@@ -106,14 +107,14 @@ describe("GET /stats", () => {
 
   it("returns 400 for invalid groupBy value", async () => {
     const app = createApp();
-    const res = await request(app).get("/stats?groupBy=invalid");
+    const res = await request(app).get("/orgs/stats?groupBy=invalid");
     expect(res.status).toBe(400);
     expect(res.body.error).toContain("Invalid groupBy");
   });
 
   it("accepts groupBy=campaignId", async () => {
     const app = createApp();
-    const res = await request(app).get("/stats?groupBy=campaignId");
+    const res = await request(app).get("/orgs/stats?groupBy=campaignId");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
     expect(Array.isArray(res.body.groups)).toBe(true);
@@ -121,28 +122,28 @@ describe("GET /stats", () => {
 
   it("accepts groupBy=brandId", async () => {
     const app = createApp();
-    const res = await request(app).get("/stats?groupBy=brandId");
+    const res = await request(app).get("/orgs/stats?groupBy=brandId");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
   });
 
   it("accepts groupBy=workflowSlug", async () => {
     const app = createApp();
-    const res = await request(app).get("/stats?groupBy=workflowSlug");
+    const res = await request(app).get("/orgs/stats?groupBy=workflowSlug");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
   });
 
   it("accepts groupBy=featureSlug", async () => {
     const app = createApp();
-    const res = await request(app).get("/stats?groupBy=featureSlug");
+    const res = await request(app).get("/orgs/stats?groupBy=featureSlug");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
   });
 
   it("returns flat response without groupBy including contacted=0", async () => {
     const app = createApp();
-    const res = await request(app).get("/stats");
+    const res = await request(app).get("/orgs/stats");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("served");
     expect(res.body).toHaveProperty("contacted");
@@ -197,7 +198,7 @@ describe("GET /stats", () => {
       ],
     });
 
-    const res = await request(app).get("/stats");
+    const res = await request(app).get("/orgs/stats");
     expect(res.status).toBe(200);
     expect(res.body.served).toBe(2);
     expect(res.body.contacted).toBe(1);
@@ -225,7 +226,7 @@ describe("GET /stats", () => {
 
     mockCheckDeliveryStatus.mockResolvedValue(null);
 
-    const res = await request(app).get("/stats");
+    const res = await request(app).get("/orgs/stats");
     expect(res.status).toBe(200);
     expect(res.body.served).toBe(1);
     expect(res.body.contacted).toBe(0);
@@ -235,7 +236,7 @@ describe("GET /stats", () => {
 
   it("filters by workflowSlug query param", async () => {
     const app = createApp();
-    const res = await request(app).get("/stats?workflowSlug=cold-email-v2");
+    const res = await request(app).get("/orgs/stats?workflowSlug=cold-email-v2");
     expect(res.status).toBe(200);
     // Verify dynasty resolver was NOT called (exact slug, not dynasty)
     expect(mockResolveWorkflowDynastySlugs).not.toHaveBeenCalled();
@@ -243,7 +244,7 @@ describe("GET /stats", () => {
 
   it("filters by featureSlug query param", async () => {
     const app = createApp();
-    const res = await request(app).get("/stats?featureSlug=feat-alpha");
+    const res = await request(app).get("/orgs/stats?featureSlug=feat-alpha");
     expect(res.status).toBe(200);
     expect(mockResolveFeatureDynastySlugs).not.toHaveBeenCalled();
   });
@@ -252,7 +253,7 @@ describe("GET /stats", () => {
     mockResolveWorkflowDynastySlugs.mockResolvedValue(["cold-email", "cold-email-v2"]);
 
     const app = createApp();
-    const res = await request(app).get("/stats?workflowDynastySlug=cold-email");
+    const res = await request(app).get("/orgs/stats?workflowDynastySlug=cold-email");
     expect(res.status).toBe(200);
     expect(mockResolveWorkflowDynastySlugs).toHaveBeenCalledWith("cold-email", expect.any(Object));
   });
@@ -261,7 +262,7 @@ describe("GET /stats", () => {
     mockResolveFeatureDynastySlugs.mockResolvedValue(["feat-alpha", "feat-alpha-v2"]);
 
     const app = createApp();
-    const res = await request(app).get("/stats?featureDynastySlug=feat-alpha");
+    const res = await request(app).get("/orgs/stats?featureDynastySlug=feat-alpha");
     expect(res.status).toBe(200);
     expect(mockResolveFeatureDynastySlugs).toHaveBeenCalledWith("feat-alpha", expect.any(Object));
   });
@@ -270,7 +271,7 @@ describe("GET /stats", () => {
     mockResolveWorkflowDynastySlugs.mockResolvedValue([]);
 
     const app = createApp();
-    const res = await request(app).get("/stats?workflowDynastySlug=nonexistent");
+    const res = await request(app).get("/orgs/stats?workflowDynastySlug=nonexistent");
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       served: 0,
@@ -287,7 +288,7 @@ describe("GET /stats", () => {
     mockResolveFeatureDynastySlugs.mockResolvedValue([]);
 
     const app = createApp();
-    const res = await request(app).get("/stats?featureDynastySlug=nonexistent");
+    const res = await request(app).get("/orgs/stats?featureDynastySlug=nonexistent");
     expect(res.status).toBe(200);
     expect(res.body.served).toBe(0);
     expect(mockWhere).not.toHaveBeenCalled();
@@ -297,7 +298,7 @@ describe("GET /stats", () => {
     mockResolveWorkflowDynastySlugs.mockResolvedValue([]);
 
     const app = createApp();
-    const res = await request(app).get("/stats?workflowDynastySlug=nonexistent&groupBy=campaignId");
+    const res = await request(app).get("/orgs/stats?workflowDynastySlug=nonexistent&groupBy=campaignId");
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ groups: [] });
   });
@@ -306,7 +307,7 @@ describe("GET /stats", () => {
 
   it("filters by comma-separated workflowSlugs", async () => {
     const app = createApp();
-    const res = await request(app).get("/stats?workflowSlugs=cold-email-v1,cold-email-v2");
+    const res = await request(app).get("/orgs/stats?workflowSlugs=cold-email-v1,cold-email-v2");
     expect(res.status).toBe(200);
     // Dynasty resolver should NOT be called
     expect(mockResolveWorkflowDynastySlugs).not.toHaveBeenCalled();
@@ -314,14 +315,14 @@ describe("GET /stats", () => {
 
   it("filters by comma-separated featureSlugs", async () => {
     const app = createApp();
-    const res = await request(app).get("/stats?featureSlugs=feat-a,feat-b");
+    const res = await request(app).get("/orgs/stats?featureSlugs=feat-a,feat-b");
     expect(res.status).toBe(200);
     expect(mockResolveFeatureDynastySlugs).not.toHaveBeenCalled();
   });
 
   it("workflowSlugs takes priority over workflowSlug", async () => {
     const app = createApp();
-    const res = await request(app).get("/stats?workflowSlugs=v1,v2&workflowSlug=v3");
+    const res = await request(app).get("/orgs/stats?workflowSlugs=v1,v2&workflowSlug=v3");
     expect(res.status).toBe(200);
     // Should use the plural param, not the singular
     expect(mockResolveWorkflowDynastySlugs).not.toHaveBeenCalled();
@@ -331,14 +332,14 @@ describe("GET /stats", () => {
     mockResolveWorkflowDynastySlugs.mockResolvedValue(["cold-email", "cold-email-v2"]);
 
     const app = createApp();
-    const res = await request(app).get("/stats?workflowDynastySlug=cold-email&workflowSlugs=v1,v2");
+    const res = await request(app).get("/orgs/stats?workflowDynastySlug=cold-email&workflowSlugs=v1,v2");
     expect(res.status).toBe(200);
     expect(mockResolveWorkflowDynastySlugs).toHaveBeenCalledWith("cold-email", expect.any(Object));
   });
 
   it("groupBy=workflowSlug with workflowSlugs filter returns grouped stats", async () => {
     const app = createApp();
-    const res = await request(app).get("/stats?groupBy=workflowSlug&workflowSlugs=slug1,slug2");
+    const res = await request(app).get("/orgs/stats?groupBy=workflowSlug&workflowSlugs=slug1,slug2");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
   });
@@ -347,7 +348,7 @@ describe("GET /stats", () => {
     mockResolveWorkflowDynastySlugs.mockResolvedValue(["cold-email", "cold-email-v2"]);
 
     const app = createApp();
-    const res = await request(app).get("/stats?workflowDynastySlug=cold-email&workflowSlug=cold-email-v2");
+    const res = await request(app).get("/orgs/stats?workflowDynastySlug=cold-email&workflowSlug=cold-email-v2");
     expect(res.status).toBe(200);
     // Dynasty resolver should be called (takes priority)
     expect(mockResolveWorkflowDynastySlugs).toHaveBeenCalledWith("cold-email", expect.any(Object));
@@ -364,7 +365,7 @@ describe("GET /stats", () => {
     );
 
     const app = createApp();
-    const res = await request(app).get("/stats?groupBy=workflowDynastySlug");
+    const res = await request(app).get("/orgs/stats?groupBy=workflowDynastySlug");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
     expect(mockFetchWorkflowDynastyMap).toHaveBeenCalled();
@@ -379,7 +380,7 @@ describe("GET /stats", () => {
     );
 
     const app = createApp();
-    const res = await request(app).get("/stats?groupBy=featureDynastySlug");
+    const res = await request(app).get("/orgs/stats?groupBy=featureDynastySlug");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
     expect(mockFetchFeatureDynastyMap).toHaveBeenCalled();
@@ -389,7 +390,7 @@ describe("GET /stats", () => {
     mockResolveWorkflowDynastySlugs.mockResolvedValue(["cold-email", "cold-email-v2"]);
 
     const app = createApp();
-    const res = await request(app).get("/stats?workflowDynastySlug=cold-email&brandId=b1&campaignId=c1");
+    const res = await request(app).get("/orgs/stats?workflowDynastySlug=cold-email&brandId=b1&campaignId=c1");
     expect(res.status).toBe(200);
     expect(mockResolveWorkflowDynastySlugs).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- **BREAKING**: All org-scoped routes now prefixed with `/orgs/*` per platform convention
- Split `authenticate` middleware into `apiKeyAuth` + `requireOrgId` (two-tier auth per convention)
- `x-user-id` and `x-run-id` are now optional — only `x-org-id` is required on `/orgs/*` routes
- Removed duplicate `GET /` health route (`GET /health` remains)
- Updated OpenAPI spec, register-providers, and all tests

### Route changes
| Before | After |
|--------|-------|
| `POST /buffer/next` | `POST /orgs/buffer/next` |
| `GET /leads` | `GET /orgs/leads` |
| `GET /leads/status` | `GET /orgs/leads/status` |
| `GET /stats` | `GET /orgs/stats` |
| `GET /cursor/:ns` | `GET /orgs/cursor/:ns` |
| `PUT /cursor/:ns` | `PUT /orgs/cursor/:ns` |

## Test plan
- [x] 161 unit tests passing
- [x] TypeScript compiles cleanly
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)