### PR TITLE
Fix global.email optional chaining + debug log

### DIFF
--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -138,9 +138,9 @@ export function isContacted(result: StatusResult): boolean {
   return !!(
     bc?.campaign?.contacted ||
     bc?.brand?.contacted ||
-    bc?.global?.email.contacted ||
+    bc?.global?.email?.contacted ||
     tx?.campaign?.contacted ||
     tx?.brand?.contacted ||
-    tx?.global?.email.contacted
+    tx?.global?.email?.contacted
   );
 }

--- a/src/routes/lead-status.ts
+++ b/src/routes/lead-status.ts
@@ -21,10 +21,10 @@ function flattenCampaignStatus(result: StatusResult) {
   const contacted = !!(
     bc?.campaign?.contacted ||
     bc?.brand?.contacted ||
-    bc?.global?.email.contacted ||
+    bc?.global?.email?.contacted ||
     tx?.campaign?.contacted ||
     tx?.brand?.contacted ||
-    tx?.global?.email.contacted
+    tx?.global?.email?.contacted
   );
 
   const delivered = !!(
@@ -64,9 +64,9 @@ function flattenBrandStatus(result: StatusResult) {
 
   const contacted = !!(
     bc?.brand?.contacted ||
-    bc?.global?.email.contacted ||
+    bc?.global?.email?.contacted ||
     tx?.brand?.contacted ||
-    tx?.global?.email.contacted
+    tx?.global?.email?.contacted
   );
 
   const delivered = !!(
@@ -175,6 +175,10 @@ router.get("/orgs/leads/status", apiKeyAuth, requireOrgId, async (req: Authentic
       seen.add(row.email);
 
       const result = statusMap.get(row.email);
+      if (result && !seen.has("__debug_logged__")) {
+        seen.add("__debug_logged__");
+        console.log("[lead-service] DEBUG email-gateway result sample:", JSON.stringify(result).slice(0, 500));
+      }
       const flat = result ? flatten(result) : DEFAULT_FLAT;
 
       statuses.push({


### PR DESCRIPTION
## Summary
- Added `?.` on `.email` in all `global?.email?.contacted` accesses — the crash was at this exact position in compiled JS
- Added a one-time debug log that dumps the first email-gateway result to see the actual response shape in production
- Will remove debug log once confirmed working

## Test plan
- [x] 161 unit tests passing
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)