### PR TITLE
Remove temporary debug log

### DIFF
--- a/src/routes/lead-status.ts
+++ b/src/routes/lead-status.ts
@@ -175,10 +175,6 @@ router.get("/orgs/leads/status", apiKeyAuth, requireOrgId, async (req: Authentic
       seen.add(row.email);
 
       const result = statusMap.get(row.email);
-      if (result && !seen.has("__debug_logged__")) {
-        seen.add("__debug_logged__");
-        console.log("[lead-service] DEBUG email-gateway result sample:", JSON.stringify(result).slice(0, 500));
-      }
       const flat = result ? flatten(result) : DEFAULT_FLAT;
 
       statuses.push({


### PR DESCRIPTION
## Summary
Removes the one-time debug log added in #169 — confirmed the email-gateway response shape, crash is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)