### PR TITLE
Update brand-service client routes for /internal and /orgs prefixes

### DIFF
--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -29,7 +29,7 @@ export async function fetchBrand(
     if (context?.workflowSlug) headers["x-workflow-slug"] = context.workflowSlug;
     if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
 
-    const url = new URL(`${BRAND_SERVICE_URL}/brands/${brandId}`);
+    const url = new URL(`${BRAND_SERVICE_URL}/internal/brands/${brandId}`);
     if (orgId) url.searchParams.set("orgId", orgId);
 
     const response = await fetch(url.toString(), { headers, signal: AbortSignal.timeout(300_000) });
@@ -83,7 +83,7 @@ export async function extractBrandFields(
   context?: ServiceContext,
 ): Promise<ExtractedField[] | null> {
   try {
-    const response = await fetch(`${BRAND_SERVICE_URL}/brands/extract-fields`, {
+    const response = await fetch(`${BRAND_SERVICE_URL}/orgs/brands/extract-fields`, {
       method: "POST",
       headers: buildHeaders(orgId, context),
       body: JSON.stringify({ fields }),
@@ -99,8 +99,32 @@ export async function extractBrandFields(
       return null;
     }
 
-    const data = (await response.json()) as { results: ExtractedField[] };
-    return data.results;
+    const data = (await response.json()) as {
+      brands: Array<{ brandId: string; domain: string; name: string }>;
+      fields: Record<string, {
+        value: string | string[] | Record<string, unknown> | null;
+        byBrand: Record<string, {
+          value: string | string[] | Record<string, unknown> | null;
+          cached: boolean;
+          extractedAt: string;
+          expiresAt: string | null;
+          sourceUrls: string[] | null;
+        }>;
+      }>;
+    };
+
+    // Transform new response shape back to ExtractedField[] for consumers
+    return Object.entries(data.fields).map(([key, field]) => {
+      const firstBrand = Object.values(field.byBrand)[0];
+      return {
+        key,
+        value: field.value,
+        cached: firstBrand?.cached ?? false,
+        extractedAt: firstBrand?.extractedAt ?? new Date().toISOString(),
+        expiresAt: firstBrand?.expiresAt ?? null,
+        sourceUrls: firstBrand?.sourceUrls ?? null,
+      };
+    });
   } catch (error) {
     console.error("[brand-client] Error extracting brand fields:", error);
     throw error;
@@ -113,7 +137,7 @@ export async function fetchExtractedFields(
   context?: ServiceContext,
 ): Promise<ExtractedField[] | null> {
   try {
-    const response = await fetch(`${BRAND_SERVICE_URL}/brands/${brandId}/extracted-fields`, {
+    const response = await fetch(`${BRAND_SERVICE_URL}/internal/brands/${brandId}/extracted-fields`, {
       headers: buildHeaders(orgId, context),
       signal: AbortSignal.timeout(300_000),
     });

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -224,8 +224,8 @@ describe("service client headers", () => {
   });
 
   describe("brand-client extractBrandFields", () => {
-    it("calls POST /brands/extract-fields (no brandId in path) and sends correct headers", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ results: [] }));
+    it("calls POST /orgs/brands/extract-fields and sends correct headers", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ brands: [], fields: {} }));
 
       const { extractBrandFields } = await import("../../src/lib/brand-client.js");
       await extractBrandFields(
@@ -236,8 +236,7 @@ describe("service client headers", () => {
 
       expect(fetchSpy).toHaveBeenCalledOnce();
       const [url, opts] = fetchSpy.mock.calls[0];
-      expect(url).toContain("/brands/extract-fields");
-      expect(url).not.toContain("/brands/brand-");
+      expect(url).toContain("/orgs/brands/extract-fields");
       expect(opts.method).toBe("POST");
       expect(opts.headers["x-org-id"]).toBe("org-1");
       expect(opts.headers["x-user-id"]).toBe("user-1");
@@ -258,7 +257,7 @@ describe("service client headers", () => {
 
       expect(fetchSpy).toHaveBeenCalledOnce();
       const [url, opts] = fetchSpy.mock.calls[0];
-      expect(url).toContain("/brands/brand-123/extracted-fields");
+      expect(url).toContain("/internal/brands/brand-123/extracted-fields");
       expect(opts.headers["x-org-id"]).toBe("org-1");
       expect(opts.headers["x-user-id"]).toBe("user-1");
       expect(opts.headers["x-run-id"]).toBe("run-1");


### PR DESCRIPTION
## Summary
- Updates `brand-client.ts` to use brand-service's new tiered route prefixes (PR #129):
  - `GET /brands/{id}` → `GET /internal/brands/{id}`
  - `POST /brands/extract-fields` → `POST /orgs/brands/extract-fields`
  - `GET /brands/{brandId}/extracted-fields` → `GET /internal/brands/{brandId}/extracted-fields`
- Adapts `extractBrandFields` to transform the new response shape (`{ brands, fields }`) back to `ExtractedField[]` so `buffer.ts` consumers are unaffected
- Updates unit test assertions for the new URL paths and response mocks

## Test plan
- [x] All 154 unit tests pass
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)