### PR TITLE
Adapt email-gateway client to POST /orgs/status refacto

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -170,7 +170,7 @@ async function fillBufferFromSearch(params: {
     // Batch contacted check for candidates with emails and leadIds
     const itemsWithEmails = candidates
       .filter((c): c is typeof c & { email: string; leadId: string } => !!c.email && !!c.leadId)
-      .map((c) => ({ email: c.email, leadId: c.leadId }));
+      .map((c) => ({ email: c.email }));
 
     const contactedMap =
       itemsWithEmails.length > 0
@@ -409,7 +409,7 @@ export async function pullNext(params: {
 
     // Check contacted status via email-gateway
     const contactedMap = await checkContacted(params.brandIds, params.campaignId, [
-      { leadId, email },
+      { email },
     ], {
       orgId: params.orgId,
       userId: params.userId ?? undefined,

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -12,7 +12,7 @@ import {
  * Falls back to all-false if email-gateway is unreachable —
  * the downstream /send endpoint has its own idempotency.
  *
- * With multi-brand, checks against the first brand ID via x-brand-id header.
+ * With multi-brand, checks against the first brand ID via brandId body field.
  */
 export async function checkContacted(
   brandIds: string[],

--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -1,7 +1,6 @@
 import { EMAIL_GATEWAY_SERVICE_URL, EMAIL_GATEWAY_SERVICE_API_KEY } from "../config.js";
 
 export interface DeliveryStatusItem {
-  leadId?: string;
   email: string;
 }
 
@@ -27,13 +26,13 @@ export interface GlobalStatus {
 }
 
 export interface ProviderStatus {
-  campaign?: ScopedStatus;
-  brand?: ScopedStatus;
+  campaign?: ScopedStatus | null;
+  brand?: ScopedStatus | null;
+  byCampaign?: Record<string, ScopedStatus> | null;
   global?: GlobalStatus;
 }
 
 export interface StatusResult {
-  leadId: string | null;
   email: string;
   broadcast?: ProviderStatus;
   transactional?: ProviderStatus;
@@ -51,8 +50,7 @@ async function checkDeliveryStatusBatch(
   items: DeliveryStatusItem[],
   headers: Record<string, string>,
 ): Promise<DeliveryStatusResponse | null> {
-  headers["x-brand-id"] = brandId;
-  const body: Record<string, unknown> = { items };
+  const body: Record<string, unknown> = { brandId, items };
   if (campaignId) body.campaignId = campaignId;
 
   const response = await fetch(`${EMAIL_GATEWAY_SERVICE_URL}/orgs/status`, {
@@ -135,12 +133,24 @@ export async function checkDeliveryStatus(
 export function isContacted(result: StatusResult): boolean {
   const bc = result.broadcast;
   const tx = result.transactional;
-  return !!(
+
+  if (
     bc?.campaign?.contacted ||
     bc?.brand?.contacted ||
     bc?.global?.email?.contacted ||
     tx?.campaign?.contacted ||
     tx?.brand?.contacted ||
     tx?.global?.email?.contacted
-  );
+  ) return true;
+
+  // Check byCampaign breakdown (populated in brand-only mode)
+  for (const provider of [bc, tx]) {
+    if (provider?.byCampaign) {
+      for (const status of Object.values(provider.byCampaign)) {
+        if (status.contacted) return true;
+      }
+    }
+  }
+
+  return false;
 }

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -151,7 +151,7 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
         if (!groups.has(primaryBrandId)) {
           groups.set(primaryBrandId, { brandId: primaryBrandId, items: [] });
         }
-        groups.get(primaryBrandId)!.items.push({ leadId: row.leadId, email: row.email });
+        groups.get(primaryBrandId)!.items.push({ email: row.email });
       }
 
       await Promise.all(

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -7,7 +7,6 @@ import { fetchApolloStats } from "../lib/apollo-client.js";
 import {
   checkDeliveryStatus,
   isContacted,
-  type DeliveryStatusItem,
 } from "../lib/email-gateway-client.js";
 import {
   resolveFeatureDynastySlugs,
@@ -158,7 +157,7 @@ async function countContacted(
   if (rows.length === 0) return 0;
 
   // Group by first brandId + campaignId since email-gateway scopes status per brand/campaign
-  const groups = new Map<string, { brandId: string; campaignId: string; items: DeliveryStatusItem[] }>();
+  const groups = new Map<string, { brandId: string; campaignId: string; items: { leadId: string; email: string }[] }>();
   for (const row of rows) {
     if (!row.leadId) continue;
     const primaryBrandId = row.brandIds[0] ?? "unknown";
@@ -176,7 +175,7 @@ async function countContacted(
       const response = await checkDeliveryStatus(
         group.brandId,
         group.campaignId,
-        group.items,
+        group.items.map((i) => ({ email: i.email })),
         context,
       );
       if (!response) return;
@@ -218,7 +217,7 @@ async function countContactedGrouped(
   if (rows.length === 0) return new Map();
 
   // Group by first brandId + campaignId for email-gateway calls
-  const callGroups = new Map<string, { brandId: string; campaignId: string; items: (DeliveryStatusItem & { groupKey: string })[] }>();
+  const callGroups = new Map<string, { brandId: string; campaignId: string; items: { leadId: string; email: string; groupKey: string }[] }>();
   for (const row of rows) {
     if (!row.leadId) continue;
     const primaryBrandId = row.brandIds[0] ?? "unknown";
@@ -241,7 +240,7 @@ async function countContactedGrouped(
       const response = await checkDeliveryStatus(
         group.brandId,
         group.campaignId,
-        group.items,
+        group.items.map((i) => ({ email: i.email })),
         context,
       );
       if (!response) return;
@@ -252,7 +251,7 @@ async function countContactedGrouped(
             if (!contactedPerGroup.has(item.groupKey)) {
               contactedPerGroup.set(item.groupKey, new Set());
             }
-            contactedPerGroup.get(item.groupKey)!.add(item.leadId!);
+            contactedPerGroup.get(item.groupKey)!.add(item.leadId);
           }
         }
       }
@@ -286,7 +285,7 @@ async function countContactedGroupedByBrand(
   if (rows.length === 0) return new Map();
 
   // Group by first brandId + campaignId for email-gateway calls
-  const callGroups = new Map<string, { brandId: string; campaignId: string; items: (DeliveryStatusItem & { brandIds: string[] })[] }>();
+  const callGroups = new Map<string, { brandId: string; campaignId: string; items: { leadId: string; email: string; brandIds: string[] }[] }>();
   for (const row of rows) {
     if (!row.leadId) continue;
     const primaryBrandId = row.brandIds[0] ?? "unknown";
@@ -309,7 +308,7 @@ async function countContactedGroupedByBrand(
       const response = await checkDeliveryStatus(
         group.brandId,
         group.campaignId,
-        group.items,
+        group.items.map((i) => ({ email: i.email })),
         context,
       );
       if (!response) return;
@@ -322,7 +321,7 @@ async function countContactedGroupedByBrand(
               if (!contactedPerBrand.has(bid)) {
                 contactedPerBrand.set(bid, new Set());
               }
-              contactedPerBrand.get(bid)!.add(item.leadId!);
+              contactedPerBrand.get(bid)!.add(item.leadId);
             }
           }
         }

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -312,7 +312,7 @@ describe("buffer", () => {
       // First lead: delivered, second lead: not delivered
       vi.mocked(checkDeliveryStatus)
         .mockResolvedValueOnce({
-          results: [{ leadId: null, email: "alice@acme.com", broadcast: {
+          results: [{ email: "alice@acme.com", broadcast: {
             campaign: { contacted: true, delivered: true, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
             brand: { contacted: false, delivered: false, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null },
             global: { email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" } },

--- a/tests/unit/dedup.test.ts
+++ b/tests/unit/dedup.test.ts
@@ -29,31 +29,31 @@ describe("dedup", () => {
     it("returns contacted=true for emails that email-gateway reports as contacted", async () => {
       vi.mocked(checkDeliveryStatus).mockResolvedValue({
         results: [
-          { leadId: "lead-1", email: "alice@acme.com" } as never,
+          { email: "alice@acme.com" } as never,
         ],
       });
       vi.mocked(isContacted).mockReturnValue(true);
 
       const result = await checkContacted(["brand-1"], "campaign-1", [
-        { leadId: "lead-1", email: "alice@acme.com" },
+        { email: "alice@acme.com" },
       ]);
 
       expect(result.get("alice@acme.com")).toBe(true);
       expect(checkDeliveryStatus).toHaveBeenCalledWith("brand-1", "campaign-1", [
-        { leadId: "lead-1", email: "alice@acme.com" },
+        { email: "alice@acme.com" },
       ], undefined);
     });
 
     it("returns contacted=false for emails not yet contacted", async () => {
       vi.mocked(checkDeliveryStatus).mockResolvedValue({
         results: [
-          { leadId: "lead-1", email: "bob@acme.com" } as never,
+          { email: "bob@acme.com" } as never,
         ],
       });
       vi.mocked(isContacted).mockReturnValue(false);
 
       const result = await checkContacted(["brand-1"], "campaign-1", [
-        { leadId: "lead-1", email: "bob@acme.com" },
+        { email: "bob@acme.com" },
       ]);
 
       expect(result.get("bob@acme.com")).toBe(false);
@@ -63,8 +63,8 @@ describe("dedup", () => {
       vi.mocked(checkDeliveryStatus).mockResolvedValue(null);
 
       const result = await checkContacted(["brand-1"], "campaign-1", [
-        { leadId: "lead-1", email: "alice@acme.com" },
-        { leadId: "lead-2", email: "bob@acme.com" },
+        { email: "alice@acme.com" },
+        { email: "bob@acme.com" },
       ]);
 
       expect(result.get("alice@acme.com")).toBe(false);
@@ -74,8 +74,8 @@ describe("dedup", () => {
     it("handles batch of multiple emails with mixed results", async () => {
       vi.mocked(checkDeliveryStatus).mockResolvedValue({
         results: [
-          { leadId: "lead-1", email: "alice@acme.com" } as never,
-          { leadId: "lead-2", email: "bob@acme.com" } as never,
+          { email: "alice@acme.com" } as never,
+          { email: "bob@acme.com" } as never,
         ],
       });
       vi.mocked(isContacted)
@@ -83,8 +83,8 @@ describe("dedup", () => {
         .mockReturnValueOnce(false);
 
       const result = await checkContacted(["brand-1"], "campaign-1", [
-        { leadId: "lead-1", email: "alice@acme.com" },
-        { leadId: "lead-2", email: "bob@acme.com" },
+        { email: "alice@acme.com" },
+        { email: "bob@acme.com" },
       ]);
 
       expect(result.get("alice@acme.com")).toBe(true);
@@ -94,13 +94,13 @@ describe("dedup", () => {
     it("uses first brand ID for email-gateway call with multi-brand", async () => {
       vi.mocked(checkDeliveryStatus).mockResolvedValue({
         results: [
-          { leadId: "lead-1", email: "alice@acme.com" } as never,
+          { email: "alice@acme.com" } as never,
         ],
       });
       vi.mocked(isContacted).mockReturnValue(true);
 
       await checkContacted(["brand-1", "brand-2", "brand-3"], "campaign-1", [
-        { leadId: "lead-1", email: "alice@acme.com" },
+        { email: "alice@acme.com" },
       ]);
 
       expect(checkDeliveryStatus).toHaveBeenCalledWith("brand-1", "campaign-1", expect.any(Array), undefined);
@@ -108,7 +108,7 @@ describe("dedup", () => {
 
     it("returns all-false when brandIds is empty", async () => {
       const result = await checkContacted([], "campaign-1", [
-        { leadId: "lead-1", email: "alice@acme.com" },
+        { email: "alice@acme.com" },
       ]);
 
       expect(result.get("alice@acme.com")).toBe(false);

--- a/tests/unit/email-gateway-client.test.ts
+++ b/tests/unit/email-gateway-client.test.ts
@@ -24,7 +24,6 @@ describe("email-gateway-client", () => {
       const responseBody = {
         results: [
           {
-            leadId: "lead-1",
             email: "alice@acme.com",
             broadcast: {
               campaign: { contacted: true, delivered: true, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
@@ -43,7 +42,7 @@ describe("email-gateway-client", () => {
       });
 
       const result = await checkDeliveryStatus("brand-1", "campaign-1", [
-        { leadId: "lead-1", email: "alice@acme.com" },
+        { email: "alice@acme.com" },
       ]);
 
       expect(result).toEqual(responseBody);
@@ -51,29 +50,27 @@ describe("email-gateway-client", () => {
       const [url, opts] = mockFetch.mock.calls[0];
       expect(url).toContain("/orgs/status");
       expect(opts.method).toBe("POST");
-      expect(opts.headers["x-brand-id"]).toBe("brand-1");
       const body = JSON.parse(opts.body);
-      expect(body.brandId).toBeUndefined();
+      expect(body.brandId).toBe("brand-1");
       expect(body.campaignId).toBe("campaign-1");
-      expect(body.items).toEqual([{ leadId: "lead-1", email: "alice@acme.com" }]);
+      expect(body.items).toEqual([{ email: "alice@acme.com" }]);
     });
 
-    it("sends brandId via x-brand-id header, not in body, when campaignId is undefined", async () => {
+    it("sends brandId in body when campaignId is undefined", async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({ results: [] }),
       });
 
       await checkDeliveryStatus("brand-1", undefined, [
-        { leadId: "lead-1", email: "alice@acme.com" },
+        { email: "alice@acme.com" },
       ]);
 
       const [, opts] = mockFetch.mock.calls[0];
-      expect(opts.headers["x-brand-id"]).toBe("brand-1");
       const body = JSON.parse(opts.body);
-      expect(body.brandId).toBeUndefined();
+      expect(body.brandId).toBe("brand-1");
       expect(body.campaignId).toBeUndefined();
-      expect(body.items).toEqual([{ leadId: "lead-1", email: "alice@acme.com" }]);
+      expect(body.items).toEqual([{ email: "alice@acme.com" }]);
     });
 
     it("returns null on non-200 response", async () => {
@@ -84,7 +81,7 @@ describe("email-gateway-client", () => {
       });
 
       const result = await checkDeliveryStatus("brand-1", "campaign-1", [
-        { leadId: "lead-1", email: "alice@acme.com" },
+        { email: "alice@acme.com" },
       ]);
 
       expect(result).toBeNull();
@@ -96,7 +93,7 @@ describe("email-gateway-client", () => {
       mockFetch.mockRejectedValue(new TypeError("fetch failed"));
 
       const result = await checkDeliveryStatus("brand-1", "campaign-1", [
-        { leadId: "lead-1", email: "alice@acme.com" },
+        { email: "alice@acme.com" },
       ]);
 
       expect(result).toBeNull();
@@ -116,7 +113,6 @@ describe("email-gateway-client", () => {
 
     it("batches items when exceeding batch size", async () => {
       const items = Array.from({ length: 150 }, (_, i) => ({
-        leadId: `lead-${i}`,
         email: `user${i}@acme.com`,
       }));
 
@@ -125,8 +121,7 @@ describe("email-gateway-client", () => {
         return {
           ok: true,
           json: () => Promise.resolve({
-            results: body.items.map((item: { leadId: string; email: string }) => ({
-              leadId: item.leadId,
+            results: body.items.map((item: { email: string }) => ({
               email: item.email,
             })),
           }),
@@ -146,7 +141,6 @@ describe("email-gateway-client", () => {
     it("returns null if any batch fails", async () => {
       vi.spyOn(console, "error").mockImplementation(() => {});
       const items = Array.from({ length: 150 }, (_, i) => ({
-        leadId: `lead-${i}`,
         email: `user${i}@acme.com`,
       }));
 
@@ -174,7 +168,7 @@ describe("email-gateway-client", () => {
       mockFetch.mockRejectedValue(unexpectedError);
 
       const result = await checkDeliveryStatus("brand-1", "campaign-1", [
-        { leadId: "lead-1", email: "alice@acme.com" },
+        { email: "alice@acme.com" },
       ]);
 
       expect(result).toBeNull();
@@ -206,7 +200,6 @@ describe("email-gateway-client", () => {
 
     it("returns false when nothing is contacted", () => {
       const result: StatusResult = {
-        leadId: "lead-1",
         email: "alice@acme.com",
         broadcast: emptyProvider,
         transactional: emptyProvider,
@@ -221,7 +214,6 @@ describe("email-gateway-client", () => {
 
     it("returns true when broadcast campaign is contacted", () => {
       const result: StatusResult = {
-        leadId: "lead-1",
         email: "alice@acme.com",
         broadcast: {
           ...emptyProvider,
@@ -233,7 +225,6 @@ describe("email-gateway-client", () => {
 
     it("returns true when broadcast brand is contacted", () => {
       const result: StatusResult = {
-        leadId: "lead-1",
         email: "alice@acme.com",
         broadcast: {
           ...emptyProvider,
@@ -245,7 +236,6 @@ describe("email-gateway-client", () => {
 
     it("returns true when transactional global email is contacted", () => {
       const result: StatusResult = {
-        leadId: "lead-1",
         email: "alice@acme.com",
         transactional: {
           ...emptyProvider,
@@ -259,7 +249,6 @@ describe("email-gateway-client", () => {
 
     it("returns true when broadcast global email is contacted", () => {
       const result: StatusResult = {
-        leadId: "lead-1",
         email: "alice@acme.com",
         broadcast: {
           ...emptyProvider,
@@ -269,6 +258,32 @@ describe("email-gateway-client", () => {
         },
       };
       expect(isContacted(result)).toBe(true);
+    });
+
+    it("returns true when broadcast byCampaign has a contacted entry", () => {
+      const result: StatusResult = {
+        email: "alice@acme.com",
+        broadcast: {
+          ...emptyProvider,
+          byCampaign: {
+            "campaign-other": { ...emptyScoped, contacted: true, delivered: true },
+          },
+        },
+      };
+      expect(isContacted(result)).toBe(true);
+    });
+
+    it("returns false when broadcast byCampaign entries are all not contacted", () => {
+      const result: StatusResult = {
+        email: "alice@acme.com",
+        broadcast: {
+          ...emptyProvider,
+          byCampaign: {
+            "campaign-other": emptyScoped,
+          },
+        },
+      };
+      expect(isContacted(result)).toBe(false);
     });
   });
 });

--- a/tests/unit/leads.test.ts
+++ b/tests/unit/leads.test.ts
@@ -191,14 +191,12 @@ describe("GET /orgs/leads", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadId: "lead-1",
           email: "alice@acme.com",
           broadcast: makeBroadcastStatus({
             campaign: { contacted: true, delivered: true, replied: true, replyClassification: "positive", lastDeliveredAt: "2026-03-29T10:00:00Z" },
           }),
         },
         {
-          leadId: "lead-2",
           email: "bob@acme.com",
           broadcast: makeBroadcastStatus({
             campaign: { contacted: true, bounced: true },
@@ -232,7 +230,6 @@ describe("GET /orgs/leads", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadId: "lead-1",
           email: "alice@acme.com",
           broadcast: makeBroadcastStatus({
             brand: { contacted: true, delivered: true, replied: true, replyClassification: "negative", lastDeliveredAt: "2026-04-01T12:00:00Z" },
@@ -296,10 +293,10 @@ describe("GET /orgs/leads", () => {
     const res = await request(app).get("/orgs/leads?campaignId=c1");
     expect(res.body.leads).toHaveLength(2);
 
-    // Only lead-1 should be sent to email-gateway
+    // Only lead-1's email should be sent to email-gateway (items no longer have leadId)
     const items = mockCheckDeliveryStatus.mock.calls[0][2];
     expect(items).toHaveLength(1);
-    expect(items[0].leadId).toBe("lead-1");
+    expect(items[0].email).toBe("alice@acme.com");
   });
 
   it("still returns enrichment alongside status", async () => {
@@ -321,7 +318,6 @@ describe("GET /orgs/leads", () => {
 describe("flattenCampaignStatus", () => {
   it("detects replied and replyClassification from broadcast campaign", () => {
     const result = flattenCampaignStatus({
-      leadId: "l1",
       email: "a@b.com",
       broadcast: makeBroadcastStatus({
         campaign: { contacted: true, delivered: true, replied: true, replyClassification: "positive", lastDeliveredAt: "2026-03-29T10:00:00Z" },
@@ -341,7 +337,6 @@ describe("flattenCampaignStatus", () => {
       replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null,
     };
     const result = flattenCampaignStatus({
-      leadId: "l1",
       email: "a@b.com",
       transactional: {
         campaign: { ...defaultScoped, contacted: true, delivered: true, lastDeliveredAt: "2026-03-28T08:00:00Z" },
@@ -370,7 +365,6 @@ describe("flattenCampaignStatus", () => {
 describe("flattenBrandStatus", () => {
   it("uses brand scope for cross-campaign status", () => {
     const result = flattenBrandStatus({
-      leadId: "l1",
       email: "a@b.com",
       broadcast: makeBroadcastStatus({
         brand: { contacted: true, delivered: true, replied: true, lastDeliveredAt: "2026-03-29T10:00:00Z" },
@@ -385,7 +379,6 @@ describe("flattenBrandStatus", () => {
 
   it("handles missing scopes in provider (partial response)", () => {
     const result = flattenBrandStatus({
-      leadId: "l1",
       email: "a@b.com",
       broadcast: { global: { email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: null } } } as any,
     });

--- a/tests/unit/service-clients-headers.test.ts
+++ b/tests/unit/service-clients-headers.test.ts
@@ -112,7 +112,7 @@ describe("service client headers", () => {
       fetchSpy.mockReturnValue(jsonResponse({ results: [] }));
 
       const { checkDeliveryStatus } = await import("../../src/lib/email-gateway-client.js");
-      await checkDeliveryStatus("brand-1", "camp-1", [{ leadId: "l1", email: "a@b.com" }], {
+      await checkDeliveryStatus("brand-1", "camp-1", [{ email: "a@b.com" }], {
         orgId: "org-1", userId: "user-1", runId: "run-1",
       });
 
@@ -127,7 +127,7 @@ describe("service client headers", () => {
       fetchSpy.mockReturnValue(jsonResponse({ results: [] }));
 
       const { checkDeliveryStatus } = await import("../../src/lib/email-gateway-client.js");
-      await checkDeliveryStatus("brand-1", "camp-1", [{ leadId: "l1", email: "a@b.com" }], {
+      await checkDeliveryStatus("brand-1", "camp-1", [{ email: "a@b.com" }], {
         orgId: "org-1", userId: "user-1", runId: "run-1",
         campaignId: "camp-1", brandId: "brand-1", workflowSlug: "wf-test", featureSlug: "feat-test",
       });

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -178,7 +178,6 @@ describe("GET /stats", () => {
     mockCheckDeliveryStatus.mockResolvedValue({
       results: [
         {
-          leadId: "lead-1",
           email: "alice@acme.com",
           broadcast: {
             campaign: { contacted: true },
@@ -187,7 +186,6 @@ describe("GET /stats", () => {
           },
         },
         {
-          leadId: "lead-2",
           email: "bob@acme.com",
           broadcast: {
             campaign: { contacted: false },
@@ -204,7 +202,7 @@ describe("GET /stats", () => {
     expect(res.body.contacted).toBe(1);
     expect(mockCheckDeliveryStatus).toHaveBeenCalledWith(
       "b1", "c1",
-      [{ leadId: "lead-1", email: "alice@acme.com" }, { leadId: "lead-2", email: "bob@acme.com" }],
+      [{ email: "alice@acme.com" }, { email: "bob@acme.com" }],
       expect.objectContaining({ orgId: "org-1" }),
     );
   });


### PR DESCRIPTION
## Summary
- Aligns lead-service's email-gateway client with the new `POST /orgs/status` contract (email-gateway PR #78)
- `brandId` now sent in request body instead of `x-brand-id` header for filtering
- `leadId` removed from request items and response — email is the only key
- Added `byCampaign` field support for brand-only mode responses
- Updated `isContacted()` to check `byCampaign` entries
- All call sites updated (stats, leads, buffer, dedup) + 156 unit tests pass

## Test plan
- [x] All 156 unit tests pass
- [x] TypeScript builds clean
- [ ] Verify in staging against email-gateway with PR #78 deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)