### PR TITLE
Add brand-level dedup for leads (cross-campaign)

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -1,7 +1,7 @@
 import { eq, and, sql } from "drizzle-orm";
 import { db, sql as pgSql } from "../db/index.js";
 import { leadBuffer, enrichments } from "../db/schema.js";
-import { checkContacted, markServed } from "./dedup.js";
+import { checkContacted, markServed, isAlreadyServedForBrand, checkRaceWindow } from "./dedup.js";
 import { resolveOrCreateLead, findLeadByApolloPersonId } from "./leads-registry.js";
 import { apolloSearchNext, apolloEnrich, apolloSearchParams } from "./apollo-client.js";
 import { fetchCampaign } from "./campaign-client.js";
@@ -183,12 +183,13 @@ async function fillBufferFromSearch(params: {
             workflowSlug: params.workflowSlug,
             featureSlug: params.featureSlug,
           })
-        : new Map<string, boolean>();
+        : new Map<string, import("./email-gateway-client.js").EmailCheckResult>();
 
     let pageFilled = 0;
 
     for (const { data, externalId, email } of candidates) {
-      if (email && contactedMap.get(email)) continue;
+      const status = email ? contactedMap.get(email) : undefined;
+      if (status?.contacted || status?.bounced || status?.unsubscribed) continue;
 
       await db.insert(leadBuffer).values({
         namespace: "apollo",
@@ -407,8 +408,43 @@ export async function pullNext(params: {
       metadata: enrichedData,
     });
 
-    // Check contacted status via email-gateway
-    const contactedMap = await checkContacted(params.brandIds, params.campaignId, [
+    // DB-level brand dedup: check served_leads cross-campaign via brand_ids overlap
+    const brandCheck = await isAlreadyServedForBrand({
+      orgId: params.orgId,
+      brandIds: params.brandIds,
+      leadId,
+      email,
+      externalId: row.externalId,
+    });
+
+    if (brandCheck.blocked) {
+      console.log(`[lead-service] pullNext skip (brand dedup): ${brandCheck.reason} email=${email}`);
+      await db
+        .update(leadBuffer)
+        .set({ status: "skipped" })
+        .where(eq(leadBuffer.id, row.id));
+      continue;
+    }
+
+    // Race window: skip if another buffer row for the same brand was recently claimed/served
+    const inRaceWindow = await checkRaceWindow({
+      orgId: params.orgId,
+      brandIds: params.brandIds,
+      email,
+      excludeBufferId: row.id,
+    });
+
+    if (inRaceWindow) {
+      console.log(`[lead-service] pullNext skip (race window) email=${email}`);
+      await db
+        .update(leadBuffer)
+        .set({ status: "skipped" })
+        .where(eq(leadBuffer.id, row.id));
+      continue;
+    }
+
+    // Email-gateway: contacted + bounce + unsub check (fails loud if unreachable)
+    const statusMap = await checkContacted(params.brandIds, params.campaignId, [
       { email },
     ], {
       orgId: params.orgId,
@@ -420,7 +456,24 @@ export async function pullNext(params: {
       featureSlug: params.featureSlug,
     });
 
-    if (contactedMap.get(email)) {
+    const emailStatus = statusMap.get(email);
+    if (emailStatus?.contacted) {
+      await db
+        .update(leadBuffer)
+        .set({ status: "skipped" })
+        .where(eq(leadBuffer.id, row.id));
+      continue;
+    }
+    if (emailStatus?.bounced) {
+      console.log(`[lead-service] pullNext skip (bounced) email=${email}`);
+      await db
+        .update(leadBuffer)
+        .set({ status: "skipped" })
+        .where(eq(leadBuffer.id, row.id));
+      continue;
+    }
+    if (emailStatus?.unsubscribed) {
+      console.log(`[lead-service] pullNext skip (unsubscribed) email=${email}`);
       await db
         .update(leadBuffer)
         .set({ status: "skipped" })

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -1,49 +1,133 @@
-import { db } from "../db/index.js";
-import { servedLeads } from "../db/schema.js";
+import { db, sql as pgSql } from "../db/index.js";
+import { servedLeads, leadBuffer } from "../db/schema.js";
 import {
   checkDeliveryStatus,
-  isContacted,
+  checkEmailStatus,
   type DeliveryStatusItem,
+  type EmailCheckResult,
 } from "./email-gateway-client.js";
+
+const RACE_WINDOW_MINUTES = 60;
+
+/**
+ * Check if a lead has already been served for any overlapping brand,
+ * cross-campaign, using 3 axes: leadId, email, externalId.
+ * Uses the && (array overlap) operator on brand_ids.
+ */
+export async function isAlreadyServedForBrand(params: {
+  orgId: string;
+  brandIds: string[];
+  leadId?: string | null;
+  email?: string | null;
+  externalId?: string | null;
+}): Promise<{ blocked: boolean; reason?: string }> {
+  if (params.brandIds.length === 0) return { blocked: false };
+
+  const brandIdsArray = `{${params.brandIds.join(",")}}`;
+
+  // Build OR conditions for each available axis
+  const conditions: string[] = [];
+  const values: unknown[] = [params.orgId, brandIdsArray];
+  let paramIdx = 3;
+
+  if (params.leadId) {
+    conditions.push(`lead_id = $${paramIdx}`);
+    values.push(params.leadId);
+    paramIdx++;
+  }
+  if (params.email) {
+    conditions.push(`email = $${paramIdx}`);
+    values.push(params.email);
+    paramIdx++;
+  }
+  if (params.externalId) {
+    conditions.push(`external_id = $${paramIdx}`);
+    values.push(params.externalId);
+    paramIdx++;
+  }
+
+  if (conditions.length === 0) return { blocked: false };
+
+  const rows = await pgSql.unsafe(
+    `SELECT lead_id, email, external_id FROM served_leads
+     WHERE org_id = $1
+       AND brand_ids && $2::text[]
+       AND (${conditions.join(" OR ")})
+     LIMIT 1`,
+    values as string[],
+  );
+
+  if (rows.length > 0) {
+    const match = rows[0];
+    const axes: string[] = [];
+    if (params.leadId && match.lead_id === params.leadId) axes.push("lead_id");
+    if (params.email && match.email === params.email) axes.push("email");
+    if (params.externalId && match.external_id === params.externalId) axes.push("external_id");
+    return {
+      blocked: true,
+      reason: `already served for overlapping brand (matched on ${axes.join(", ") || "unknown axis"})`,
+    };
+  }
+
+  return { blocked: false };
+}
+
+/**
+ * Check if a lead is in the race window: claimed or served within the last hour
+ * for any overlapping brand. Prevents concurrent pullNext calls across campaigns
+ * from serving the same lead.
+ */
+export async function checkRaceWindow(params: {
+  orgId: string;
+  brandIds: string[];
+  email: string;
+  excludeBufferId: string;
+}): Promise<boolean> {
+  if (params.brandIds.length === 0) return false;
+
+  const brandIdsArray = `{${params.brandIds.join(",")}}`;
+
+  const rows = await pgSql.unsafe(
+    `SELECT 1 FROM lead_buffer
+     WHERE org_id = $1
+       AND brand_ids && $2::text[]
+       AND email = $3
+       AND status IN ('claimed', 'served')
+       AND created_at >= now() - interval '${RACE_WINDOW_MINUTES} minutes'
+       AND id != $4
+     LIMIT 1`,
+    [params.orgId, brandIdsArray, params.email, params.excludeBufferId],
+  );
+
+  return rows.length > 0;
+}
 
 /**
  * Check if items have already been contacted via email-gateway.
- * Returns a Map of email -> boolean (contacted or not).
- * Falls back to all-false if email-gateway is unreachable —
- * the downstream /send endpoint has its own idempotency.
- *
- * With multi-brand, checks against the first brand ID via brandId body field.
+ * Returns a Map of email -> EmailCheckResult.
+ * Throws if email-gateway is unreachable — fail loud, no silent fallback.
  */
 export async function checkContacted(
   brandIds: string[],
   campaignId: string,
   items: DeliveryStatusItem[],
   context?: { orgId?: string; userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowSlug?: string; featureSlug?: string }
-): Promise<Map<string, boolean>> {
-  const result = new Map<string, boolean>();
+): Promise<Map<string, EmailCheckResult>> {
+  const result = new Map<string, EmailCheckResult>();
 
   const primaryBrandId = brandIds[0];
   if (!primaryBrandId) {
-    // No brand IDs — can't check, assume not contacted
-    for (const item of items) {
-      result.set(item.email, false);
-    }
-    return result;
+    throw new Error("[dedup] No brand IDs provided — cannot check delivery status");
   }
 
   const statusResponse = await checkDeliveryStatus(primaryBrandId, campaignId, items, context);
 
-  if (statusResponse) {
-    for (const sr of statusResponse.results) {
-      result.set(sr.email, isContacted(sr));
-    }
-  } else {
-    console.warn(
-      "[dedup] email-gateway unreachable, proceeding without contacted check"
-    );
-    for (const item of items) {
-      result.set(item.email, false);
-    }
+  if (!statusResponse) {
+    throw new Error("[dedup] email-gateway unreachable — refusing to serve without delivery check");
+  }
+
+  for (const sr of statusResponse.results) {
+    result.set(sr.email, checkEmailStatus(sr));
   }
 
   return result;

--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -126,14 +126,36 @@ export async function checkDeliveryStatus(
   }
 }
 
+export interface EmailCheckResult {
+  contacted: boolean;
+  bounced: boolean;
+  unsubscribed: boolean;
+}
+
 /**
  * Check if a status result indicates the lead/email has already been contacted
  * via any provider (broadcast or transactional) at any scope (campaign, brand, or global).
  */
 export function isContacted(result: StatusResult): boolean {
+  return checkEmailStatus(result).contacted;
+}
+
+/**
+ * Full status check: contacted, bounced, and unsubscribed.
+ */
+export function checkEmailStatus(result: StatusResult): EmailCheckResult {
   const bc = result.broadcast;
   const tx = result.transactional;
 
+  let contacted = false;
+  let bounced = false;
+  let unsubscribed = false;
+
+  // Bounce & unsub — global scope (all brands, all orgs)
+  if (bc?.global?.email?.bounced || tx?.global?.email?.bounced) bounced = true;
+  if (bc?.global?.email?.unsubscribed || tx?.global?.email?.unsubscribed) unsubscribed = true;
+
+  // Contacted — any scope (campaign, brand, global)
   if (
     bc?.campaign?.contacted ||
     bc?.brand?.contacted ||
@@ -141,16 +163,22 @@ export function isContacted(result: StatusResult): boolean {
     tx?.campaign?.contacted ||
     tx?.brand?.contacted ||
     tx?.global?.email?.contacted
-  ) return true;
+  ) contacted = true;
 
   // Check byCampaign breakdown (populated in brand-only mode)
-  for (const provider of [bc, tx]) {
-    if (provider?.byCampaign) {
-      for (const status of Object.values(provider.byCampaign)) {
-        if (status.contacted) return true;
+  if (!contacted) {
+    for (const provider of [bc, tx]) {
+      if (provider?.byCampaign) {
+        for (const status of Object.values(provider.byCampaign)) {
+          if (status.contacted) {
+            contacted = true;
+            break;
+          }
+        }
+        if (contacted) break;
       }
     }
   }
 
-  return false;
+  return { contacted, bounced, unsubscribed };
 }

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // pgSql mock — must be hoisted since vi.mock factory runs before variable declarations
-const { pgSqlMock } = vi.hoisted(() => ({
-  pgSqlMock: vi.fn().mockResolvedValue([]),
-}));
+const { pgSqlMock, pgSqlUnsafeMock } = vi.hoisted(() => {
+  const unsafeMock = vi.fn().mockResolvedValue([]);
+  const mock = Object.assign(vi.fn().mockResolvedValue([]), { unsafe: unsafeMock });
+  return { pgSqlMock: mock, pgSqlUnsafeMock: unsafeMock };
+});
 
 // Mock db
 vi.mock("../../src/db/index.js", () => ({
@@ -44,6 +46,15 @@ vi.mock("../../src/lib/brand-client.js", () => ({
 vi.mock("../../src/lib/email-gateway-client.js", () => ({
   checkDeliveryStatus: vi.fn().mockResolvedValue({ results: [] }),
   isContacted: vi.fn().mockReturnValue(false),
+  checkEmailStatus: vi.fn().mockReturnValue({ contacted: false, bounced: false, unsubscribed: false }),
+}));
+
+// Mock dedup — brand dedup + race window + checkContacted + markServed
+vi.mock("../../src/lib/dedup.js", () => ({
+  isAlreadyServedForBrand: vi.fn().mockResolvedValue({ blocked: false }),
+  checkRaceWindow: vi.fn().mockResolvedValue(false),
+  checkContacted: vi.fn().mockResolvedValue(new Map()),
+  markServed: vi.fn().mockResolvedValue({ inserted: true }),
 }));
 
 // Mock leads-registry
@@ -57,6 +68,7 @@ import { db } from "../../src/db/index.js";
 import { pullNext } from "../../src/lib/buffer.js";
 import { apolloSearchNext, apolloSearchParams, apolloEnrich, apolloMatch } from "../../src/lib/apollo-client.js";
 import { checkDeliveryStatus } from "../../src/lib/email-gateway-client.js";
+import { isAlreadyServedForBrand, checkRaceWindow, checkContacted, markServed } from "../../src/lib/dedup.js";
 import { resolveOrCreateLead } from "../../src/lib/leads-registry.js";
 import { fetchCampaign } from "../../src/lib/campaign-client.js";
 import { extractBrandFields } from "../../src/lib/brand-client.js";
@@ -103,6 +115,10 @@ describe("buffer", () => {
     vi.mocked(extractBrandFields).mockResolvedValue(null);
     vi.mocked(apolloSearchParams).mockResolvedValue({ searchParams: {} });
     vi.mocked(apolloSearchNext).mockResolvedValue({ people: [], done: true });
+    vi.mocked(isAlreadyServedForBrand).mockResolvedValue({ blocked: false });
+    vi.mocked(checkRaceWindow).mockResolvedValue(false);
+    vi.mocked(checkContacted).mockResolvedValue(new Map());
+    vi.mocked(markServed).mockResolvedValue({ inserted: true });
   });
 
   describe("pullNext", () => {
@@ -309,30 +325,14 @@ describe("buffer", () => {
           userId: null,
         })]);
 
-      // First lead: delivered, second lead: not delivered
-      vi.mocked(checkDeliveryStatus)
-        .mockResolvedValueOnce({
-          results: [{ email: "alice@acme.com", broadcast: {
-            campaign: { contacted: true, delivered: true, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
-            brand: { contacted: false, delivered: false, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null },
-            global: { email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" } },
-          }}],
-        })
-        .mockResolvedValueOnce({ results: [] });
-
-      const { isContacted } = await import("../../src/lib/email-gateway-client.js");
-      vi.mocked(isContacted)
-        .mockReturnValueOnce(true)   // alice: delivered
-        .mockReturnValueOnce(false); // bob: not delivered (no results)
+      // First lead: contacted, second lead: not contacted
+      vi.mocked(checkContacted)
+        .mockResolvedValueOnce(new Map([["alice@acme.com", { contacted: true, bounced: false, unsubscribed: false }]]))
+        .mockResolvedValueOnce(new Map());
 
       vi.mocked(resolveOrCreateLead)
         .mockResolvedValueOnce({ leadId: "lead-alice", isNew: false })
         .mockResolvedValueOnce({ leadId: "lead-bob", isNew: true });
-
-      const returningMock = vi.fn().mockResolvedValue([{ id: "served-2" }]);
-      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
-      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
-      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
 
       const setMock = vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue(undefined),
@@ -993,7 +993,7 @@ describe("buffer", () => {
       expect(result.lead?.email).toBe("good@acme.com");
     });
 
-    it("continues when email-gateway is unreachable (fallback)", async () => {
+    it("throws when email-gateway is unreachable (no silent fallback)", async () => {
       pgSqlMock.mockResolvedValue([toClaimedRow({
         id: "buf-1",
         namespace: "campaign-1",
@@ -1006,29 +1006,23 @@ describe("buffer", () => {
         userId: null,
       })]);
 
-      // email-gateway is unreachable
-      vi.mocked(checkDeliveryStatus).mockResolvedValue(null);
-
-      const returningMock = vi.fn().mockResolvedValue([{ id: "served-1" }]);
-      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
-      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
-      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+      // checkContacted throws when email-gateway is unreachable
+      vi.mocked(checkContacted).mockRejectedValue(
+        new Error("[dedup] email-gateway unreachable — refusing to serve without delivery check")
+      );
 
       const setMock = vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue(undefined),
       });
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
 
-      const result = await pullNext({
-        orgId: "org-1",
-        campaignId: "campaign-1",
-        brandIds: ["brand-1"],
-
-      });
-
-      // Should still serve the lead (fallback: not delivered)
-      expect(result.found).toBe(true);
-      expect(result.lead?.email).toBe("alice@acme.com");
+      await expect(
+        pullNext({
+          orgId: "org-1",
+          campaignId: "campaign-1",
+          brandIds: ["brand-1"],
+        })
+      ).rejects.toThrow("email-gateway unreachable");
     });
 
     it("REMOVED journalist tests — journalist pipeline moved to journalists-service", () => {
@@ -1065,25 +1059,14 @@ describe("buffer", () => {
           userId: null,
         })]);
 
-      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
-
       vi.mocked(resolveOrCreateLead)
         .mockResolvedValueOnce({ leadId: "lead-dup", isNew: false })
         .mockResolvedValueOnce({ leadId: "lead-next", isNew: true });
 
-      // First markServed: conflict (another request already served this email)
-      // Second markServed: success
-      const returningMockEmpty = vi.fn().mockResolvedValueOnce([]);
-      const onConflictMockEmpty = vi.fn().mockReturnValue({ returning: returningMockEmpty });
-
-      const returningMockSuccess = vi.fn().mockResolvedValueOnce([{ id: "served-next" }]);
-      const onConflictMockSuccess = vi.fn().mockReturnValue({ returning: returningMockSuccess });
-
-      const valuesMock = vi.fn()
-        .mockReturnValueOnce({ onConflictDoNothing: onConflictMockEmpty })     // markServed → conflict
-        .mockReturnValueOnce({ onConflictDoNothing: onConflictMockSuccess });  // markServed → success
-
-      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+      // First markServed: conflict, second: success
+      vi.mocked(markServed)
+        .mockResolvedValueOnce({ inserted: false })
+        .mockResolvedValueOnce({ inserted: true });
 
       const setMock = vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue(undefined),
@@ -1170,17 +1153,7 @@ describe("buffer", () => {
         userId: null,
       })]);
 
-      vi.mocked(checkDeliveryStatus).mockResolvedValue({ results: [] });
       vi.mocked(resolveOrCreateLead).mockResolvedValue({ leadId: "lead-ms-1", isNew: true });
-
-      const insertValues: unknown[] = [];
-      const returningMock = vi.fn().mockResolvedValue([{ id: "served-ms-1" }]);
-      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
-      const valuesMock = vi.fn().mockImplementation((vals) => {
-        insertValues.push(vals);
-        return { onConflictDoNothing: onConflictMock };
-      });
-      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
 
       const setMock = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
       vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
@@ -1192,13 +1165,15 @@ describe("buffer", () => {
 
       });
 
-      // markServed inserts into servedLeads — find the insert that has namespace
-      const servedInsert = insertValues.find(
-        (v) => (v as Record<string, unknown>).namespace !== undefined
-      ) as Record<string, unknown>;
-      expect(servedInsert).toBeDefined();
-      expect(servedInsert.namespace).toBe("apollo");
-      expect(servedInsert.namespace).not.toBe("campaign-uuid-789");
+      // markServed should be called with namespace "apollo", not the campaignId
+      expect(markServed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          namespace: "apollo",
+          campaignId: "campaign-uuid-789",
+        })
+      );
+      const callArgs = vi.mocked(markServed).mock.calls[0][0];
+      expect(callArgs.namespace).not.toBe("campaign-uuid-789");
     });
   });
 });

--- a/tests/unit/dedup.test.ts
+++ b/tests/unit/dedup.test.ts
@@ -5,19 +5,23 @@ vi.mock("../../src/db/index.js", () => ({
   db: {
     insert: vi.fn(),
   },
+  sql: {
+    unsafe: vi.fn(),
+  },
 }));
 
 // Mock the email-gateway-client module
 vi.mock("../../src/lib/email-gateway-client.js", () => ({
   checkDeliveryStatus: vi.fn(),
   isContacted: vi.fn(),
+  checkEmailStatus: vi.fn(),
 }));
 
-import { db } from "../../src/db/index.js";
-import { checkContacted, markServed } from "../../src/lib/dedup.js";
+import { db, sql as pgSql } from "../../src/db/index.js";
+import { checkContacted, markServed, isAlreadyServedForBrand, checkRaceWindow } from "../../src/lib/dedup.js";
 import {
   checkDeliveryStatus,
-  isContacted,
+  checkEmailStatus,
 } from "../../src/lib/email-gateway-client.js";
 
 describe("dedup", () => {
@@ -26,49 +30,55 @@ describe("dedup", () => {
   });
 
   describe("checkContacted", () => {
-    it("returns contacted=true for emails that email-gateway reports as contacted", async () => {
+    it("returns EmailCheckResult for each email from email-gateway", async () => {
       vi.mocked(checkDeliveryStatus).mockResolvedValue({
         results: [
           { email: "alice@acme.com" } as never,
         ],
       });
-      vi.mocked(isContacted).mockReturnValue(true);
+      vi.mocked(checkEmailStatus).mockReturnValue({ contacted: true, bounced: false, unsubscribed: false });
 
       const result = await checkContacted(["brand-1"], "campaign-1", [
         { email: "alice@acme.com" },
       ]);
 
-      expect(result.get("alice@acme.com")).toBe(true);
+      expect(result.get("alice@acme.com")).toEqual({ contacted: true, bounced: false, unsubscribed: false });
       expect(checkDeliveryStatus).toHaveBeenCalledWith("brand-1", "campaign-1", [
         { email: "alice@acme.com" },
       ], undefined);
     });
 
-    it("returns contacted=false for emails not yet contacted", async () => {
+    it("returns not-contacted result for emails not yet contacted", async () => {
       vi.mocked(checkDeliveryStatus).mockResolvedValue({
         results: [
           { email: "bob@acme.com" } as never,
         ],
       });
-      vi.mocked(isContacted).mockReturnValue(false);
+      vi.mocked(checkEmailStatus).mockReturnValue({ contacted: false, bounced: false, unsubscribed: false });
 
       const result = await checkContacted(["brand-1"], "campaign-1", [
         { email: "bob@acme.com" },
       ]);
 
-      expect(result.get("bob@acme.com")).toBe(false);
+      expect(result.get("bob@acme.com")).toEqual({ contacted: false, bounced: false, unsubscribed: false });
     });
 
-    it("returns all-false when email-gateway is unreachable (null response)", async () => {
+    it("throws when email-gateway is unreachable (null response)", async () => {
       vi.mocked(checkDeliveryStatus).mockResolvedValue(null);
 
-      const result = await checkContacted(["brand-1"], "campaign-1", [
-        { email: "alice@acme.com" },
-        { email: "bob@acme.com" },
-      ]);
+      await expect(
+        checkContacted(["brand-1"], "campaign-1", [
+          { email: "alice@acme.com" },
+        ])
+      ).rejects.toThrow("email-gateway unreachable");
+    });
 
-      expect(result.get("alice@acme.com")).toBe(false);
-      expect(result.get("bob@acme.com")).toBe(false);
+    it("throws when brandIds is empty", async () => {
+      await expect(
+        checkContacted([], "campaign-1", [
+          { email: "alice@acme.com" },
+        ])
+      ).rejects.toThrow("No brand IDs provided");
     });
 
     it("handles batch of multiple emails with mixed results", async () => {
@@ -78,17 +88,17 @@ describe("dedup", () => {
           { email: "bob@acme.com" } as never,
         ],
       });
-      vi.mocked(isContacted)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false);
+      vi.mocked(checkEmailStatus)
+        .mockReturnValueOnce({ contacted: true, bounced: false, unsubscribed: false })
+        .mockReturnValueOnce({ contacted: false, bounced: true, unsubscribed: false });
 
       const result = await checkContacted(["brand-1"], "campaign-1", [
         { email: "alice@acme.com" },
         { email: "bob@acme.com" },
       ]);
 
-      expect(result.get("alice@acme.com")).toBe(true);
-      expect(result.get("bob@acme.com")).toBe(false);
+      expect(result.get("alice@acme.com")).toEqual({ contacted: true, bounced: false, unsubscribed: false });
+      expect(result.get("bob@acme.com")).toEqual({ contacted: false, bounced: true, unsubscribed: false });
     });
 
     it("uses first brand ID for email-gateway call with multi-brand", async () => {
@@ -97,7 +107,7 @@ describe("dedup", () => {
           { email: "alice@acme.com" } as never,
         ],
       });
-      vi.mocked(isContacted).mockReturnValue(true);
+      vi.mocked(checkEmailStatus).mockReturnValue({ contacted: true, bounced: false, unsubscribed: false });
 
       await checkContacted(["brand-1", "brand-2", "brand-3"], "campaign-1", [
         { email: "alice@acme.com" },
@@ -105,14 +115,174 @@ describe("dedup", () => {
 
       expect(checkDeliveryStatus).toHaveBeenCalledWith("brand-1", "campaign-1", expect.any(Array), undefined);
     });
+  });
 
-    it("returns all-false when brandIds is empty", async () => {
-      const result = await checkContacted([], "campaign-1", [
-        { email: "alice@acme.com" },
-      ]);
+  describe("isAlreadyServedForBrand", () => {
+    it("returns blocked=false when no match found", async () => {
+      vi.mocked(pgSql.unsafe).mockResolvedValue([] as never);
 
-      expect(result.get("alice@acme.com")).toBe(false);
-      expect(checkDeliveryStatus).not.toHaveBeenCalled();
+      const result = await isAlreadyServedForBrand({
+        orgId: "org-1",
+        brandIds: ["brand-1"],
+        email: "alice@acme.com",
+      });
+
+      expect(result).toEqual({ blocked: false });
+    });
+
+    it("returns blocked=true with reason when email matches", async () => {
+      vi.mocked(pgSql.unsafe).mockResolvedValue([
+        { lead_id: null, email: "alice@acme.com", external_id: null },
+      ] as never);
+
+      const result = await isAlreadyServedForBrand({
+        orgId: "org-1",
+        brandIds: ["brand-1"],
+        email: "alice@acme.com",
+      });
+
+      expect(result.blocked).toBe(true);
+      expect(result.reason).toContain("email");
+    });
+
+    it("returns blocked=true when leadId matches", async () => {
+      vi.mocked(pgSql.unsafe).mockResolvedValue([
+        { lead_id: "lead-1", email: "other@acme.com", external_id: null },
+      ] as never);
+
+      const result = await isAlreadyServedForBrand({
+        orgId: "org-1",
+        brandIds: ["brand-1"],
+        leadId: "lead-1",
+        email: "alice@acme.com",
+      });
+
+      expect(result.blocked).toBe(true);
+      expect(result.reason).toContain("lead_id");
+    });
+
+    it("returns blocked=true when externalId matches", async () => {
+      vi.mocked(pgSql.unsafe).mockResolvedValue([
+        { lead_id: null, email: "other@acme.com", external_id: "apollo-123" },
+      ] as never);
+
+      const result = await isAlreadyServedForBrand({
+        orgId: "org-1",
+        brandIds: ["brand-1"],
+        externalId: "apollo-123",
+      });
+
+      expect(result.blocked).toBe(true);
+      expect(result.reason).toContain("external_id");
+    });
+
+    it("uses brand_ids && overlap in the query", async () => {
+      vi.mocked(pgSql.unsafe).mockResolvedValue([] as never);
+
+      await isAlreadyServedForBrand({
+        orgId: "org-1",
+        brandIds: ["brand-1", "brand-2"],
+        email: "alice@acme.com",
+      });
+
+      const call = vi.mocked(pgSql.unsafe).mock.calls[0];
+      expect(call[0]).toContain("brand_ids && $2::text[]");
+      expect(call[1]).toEqual(["org-1", "{brand-1,brand-2}", "alice@acme.com"]);
+    });
+
+    it("returns blocked=false when brandIds is empty", async () => {
+      const result = await isAlreadyServedForBrand({
+        orgId: "org-1",
+        brandIds: [],
+        email: "alice@acme.com",
+      });
+
+      expect(result).toEqual({ blocked: false });
+      expect(pgSql.unsafe).not.toHaveBeenCalled();
+    });
+
+    it("returns blocked=false when no axes provided", async () => {
+      const result = await isAlreadyServedForBrand({
+        orgId: "org-1",
+        brandIds: ["brand-1"],
+      });
+
+      expect(result).toEqual({ blocked: false });
+      expect(pgSql.unsafe).not.toHaveBeenCalled();
+    });
+
+    it("combines all 3 axes with OR in a single query", async () => {
+      vi.mocked(pgSql.unsafe).mockResolvedValue([] as never);
+
+      await isAlreadyServedForBrand({
+        orgId: "org-1",
+        brandIds: ["brand-1"],
+        leadId: "lead-1",
+        email: "alice@acme.com",
+        externalId: "apollo-123",
+      });
+
+      const call = vi.mocked(pgSql.unsafe).mock.calls[0];
+      expect(call[0]).toContain("lead_id = $3");
+      expect(call[0]).toContain("email = $4");
+      expect(call[0]).toContain("external_id = $5");
+      expect(call[0]).toContain(" OR ");
+    });
+  });
+
+  describe("checkRaceWindow", () => {
+    it("returns false when no race window conflict", async () => {
+      vi.mocked(pgSql.unsafe).mockResolvedValue([] as never);
+
+      const result = await checkRaceWindow({
+        orgId: "org-1",
+        brandIds: ["brand-1"],
+        email: "alice@acme.com",
+        excludeBufferId: "buffer-1",
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it("returns true when a race window conflict exists", async () => {
+      vi.mocked(pgSql.unsafe).mockResolvedValue([{ id: "other-buffer" }] as never);
+
+      const result = await checkRaceWindow({
+        orgId: "org-1",
+        brandIds: ["brand-1"],
+        email: "alice@acme.com",
+        excludeBufferId: "buffer-1",
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("uses brand_ids overlap and excludes current buffer row", async () => {
+      vi.mocked(pgSql.unsafe).mockResolvedValue([] as never);
+
+      await checkRaceWindow({
+        orgId: "org-1",
+        brandIds: ["brand-1", "brand-2"],
+        email: "alice@acme.com",
+        excludeBufferId: "buffer-1",
+      });
+
+      const call = vi.mocked(pgSql.unsafe).mock.calls[0];
+      expect(call[0]).toContain("brand_ids && $2::text[]");
+      expect(call[0]).toContain("id != $4");
+      expect(call[1]).toEqual(["org-1", "{brand-1,brand-2}", "alice@acme.com", "buffer-1"]);
+    });
+
+    it("returns false when brandIds is empty", async () => {
+      const result = await checkRaceWindow({
+        orgId: "org-1",
+        brandIds: [],
+        email: "alice@acme.com",
+        excludeBufferId: "buffer-1",
+      });
+
+      expect(result).toBe(false);
+      expect(pgSql.unsafe).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/email-gateway-client.test.ts
+++ b/tests/unit/email-gateway-client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   checkDeliveryStatus,
   isContacted,
+  checkEmailStatus,
   type StatusResult,
   type ProviderStatus,
   type ScopedStatus,
@@ -284,6 +285,85 @@ describe("email-gateway-client", () => {
         },
       };
       expect(isContacted(result)).toBe(false);
+    });
+  });
+
+  describe("checkEmailStatus", () => {
+    const emptyScoped: ScopedStatus = {
+      contacted: false, delivered: false, opened: false, replied: false,
+      replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null,
+    };
+
+    const emptyGlobal = {
+      email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+    };
+
+    const emptyProvider: ProviderStatus = {
+      campaign: emptyScoped,
+      brand: emptyScoped,
+      global: emptyGlobal,
+    };
+
+    it("returns all false when nothing is set", () => {
+      const result: StatusResult = {
+        email: "alice@acme.com",
+        broadcast: emptyProvider,
+        transactional: emptyProvider,
+      };
+      expect(checkEmailStatus(result)).toEqual({ contacted: false, bounced: false, unsubscribed: false });
+    });
+
+    it("detects global bounce from broadcast", () => {
+      const result: StatusResult = {
+        email: "alice@acme.com",
+        broadcast: {
+          ...emptyProvider,
+          global: {
+            email: { contacted: false, delivered: false, bounced: true, unsubscribed: false, lastDeliveredAt: null },
+          },
+        },
+      };
+      expect(checkEmailStatus(result)).toEqual({ contacted: false, bounced: true, unsubscribed: false });
+    });
+
+    it("detects global unsubscribe from transactional", () => {
+      const result: StatusResult = {
+        email: "alice@acme.com",
+        transactional: {
+          ...emptyProvider,
+          global: {
+            email: { contacted: false, delivered: false, bounced: false, unsubscribed: true, lastDeliveredAt: null },
+          },
+        },
+      };
+      expect(checkEmailStatus(result)).toEqual({ contacted: false, bounced: false, unsubscribed: true });
+    });
+
+    it("detects contacted + bounced simultaneously", () => {
+      const result: StatusResult = {
+        email: "alice@acme.com",
+        broadcast: {
+          campaign: { ...emptyScoped, contacted: true },
+          brand: emptyScoped,
+          global: {
+            email: { contacted: false, delivered: false, bounced: true, unsubscribed: false, lastDeliveredAt: null },
+          },
+        },
+      };
+      const status = checkEmailStatus(result);
+      expect(status.contacted).toBe(true);
+      expect(status.bounced).toBe(true);
+    });
+
+    it("isContacted delegates to checkEmailStatus", () => {
+      const result: StatusResult = {
+        email: "alice@acme.com",
+        broadcast: {
+          ...emptyProvider,
+          brand: { ...emptyScoped, contacted: true },
+        },
+      };
+      expect(isContacted(result)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- **Brand-level DB dedup**: new `isAlreadyServedForBrand()` checks `served_leads` cross-campaign using `brand_ids && $brandIds::text[]` (array overlap) on 3 axes: `lead_id`, `email`, `external_id` — inspired by journalists-service pattern
- **Race window**: new `checkRaceWindow()` blocks a lead if another buffer row for the same brand was claimed/served within the last hour
- **Bounce/unsub global checks**: new `checkEmailStatus()` returns `{ contacted, bounced, unsubscribed }` — leads with global bounce or unsub are now independently blocked
- **Fail loud on email-gateway unreachable**: `checkContacted()` now throws instead of silently returning all-false, preventing duplicate serves when email-gateway is down
- No DB migration needed — existing `brand_ids` column + GIN index already support the `&&` operator

## Test plan
- [x] All 173 unit tests pass
- [x] TypeScript build clean
- [ ] Verify integration tests pass in CI (require DB connection)
- [ ] Confirm brand-level dedup blocks same lead across campaigns for the same brand
- [ ] Confirm race window prevents concurrent serves
- [ ] Confirm email-gateway unreachable → 502 (no silent fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)