### PR TITLE
Fix transfer-brand: two-step update for brand conflict rewrite

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -733,7 +733,7 @@
       "TransferBrandRequest": {
         "type": "object",
         "properties": {
-          "brandId": {
+          "sourceBrandId": {
             "type": "string",
             "format": "uuid"
           },
@@ -744,10 +744,14 @@
           "targetOrgId": {
             "type": "string",
             "format": "uuid"
+          },
+          "targetBrandId": {
+            "type": "string",
+            "format": "uuid"
           }
         },
         "required": [
-          "brandId",
+          "sourceBrandId",
           "sourceOrgId",
           "targetOrgId"
         ]

--- a/src/routes/transfer-brand.ts
+++ b/src/routes/transfer-brand.ts
@@ -8,9 +8,10 @@ import { apiKeyAuth } from "../middleware/auth.js";
 const router = Router();
 
 const TransferBrandBodySchema = z.object({
-  brandId: z.string().uuid(),
+  sourceBrandId: z.string().uuid(),
   sourceOrgId: z.string().uuid(),
   targetOrgId: z.string().uuid(),
+  targetBrandId: z.string().uuid().optional(),
 });
 
 router.post("/internal/transfer-brand", apiKeyAuth, async (req, res) => {
@@ -20,19 +21,26 @@ router.post("/internal/transfer-brand", apiKeyAuth, async (req, res) => {
     return;
   }
 
-  const { brandId, sourceOrgId, targetOrgId } = parsed.data;
+  const { sourceBrandId, sourceOrgId, targetOrgId, targetBrandId } = parsed.data;
 
   console.log(
-    `[lead-service] Transfer brand ${brandId} from org ${sourceOrgId} to org ${targetOrgId}`
+    `[lead-service] Transfer brand ${sourceBrandId} from org ${sourceOrgId} to org ${targetOrgId}` +
+      (targetBrandId ? ` (rewrite to ${targetBrandId})` : "")
   );
 
-  // Solo-brand condition: brand_ids array has exactly one element and it equals brandId
-  const soloBrandCondition = sql`array_length(brand_ids, 1) = 1 AND brand_ids[1] = ${brandId}`;
+  // Solo-brand condition: brand_ids array has exactly one element and it equals sourceBrandId
+  const soloBrandCondition = sql`array_length(brand_ids, 1) = 1 AND brand_ids[1] = ${sourceBrandId}`;
+
+  // When targetBrandId is present, rewrite brand_ids too
+  const setClause: Record<string, unknown> = { orgId: targetOrgId };
+  if (targetBrandId) {
+    setClause.brandIds = sql`ARRAY[${targetBrandId}]::text[]`;
+  }
 
   // Update served_leads
   const servedResult = await db
     .update(servedLeads)
-    .set({ orgId: targetOrgId })
+    .set(setClause)
     .where(
       and(eq(servedLeads.orgId, sourceOrgId), soloBrandCondition)
     )
@@ -41,7 +49,7 @@ router.post("/internal/transfer-brand", apiKeyAuth, async (req, res) => {
   // Update lead_buffer (brand_ids is nullable, so also check it's not null)
   const bufferResult = await db
     .update(leadBuffer)
-    .set({ orgId: targetOrgId })
+    .set(setClause)
     .where(
       and(
         eq(leadBuffer.orgId, sourceOrgId),

--- a/src/routes/transfer-brand.ts
+++ b/src/routes/transfer-brand.ts
@@ -31,25 +31,18 @@ router.post("/internal/transfer-brand", apiKeyAuth, async (req, res) => {
   // Solo-brand condition: brand_ids array has exactly one element and it equals sourceBrandId
   const soloBrandCondition = sql`array_length(brand_ids, 1) = 1 AND brand_ids[1] = ${sourceBrandId}`;
 
-  // When targetBrandId is present, rewrite brand_ids too
-  const setClause: Record<string, unknown> = { orgId: targetOrgId };
-  if (targetBrandId) {
-    setClause.brandIds = sql`ARRAY[${targetBrandId}]::text[]`;
-  }
-
-  // Update served_leads
-  const servedResult = await db
+  // Step 1: Move org — UPDATE SET org_id = targetOrgId WHERE brand_id = sourceBrandId AND org_id = sourceOrgId
+  const servedStep1 = await db
     .update(servedLeads)
-    .set(setClause)
+    .set({ orgId: targetOrgId })
     .where(
       and(eq(servedLeads.orgId, sourceOrgId), soloBrandCondition)
     )
     .returning({ id: servedLeads.id });
 
-  // Update lead_buffer (brand_ids is nullable, so also check it's not null)
-  const bufferResult = await db
+  const bufferStep1 = await db
     .update(leadBuffer)
-    .set(setClause)
+    .set({ orgId: targetOrgId })
     .where(
       and(
         eq(leadBuffer.orgId, sourceOrgId),
@@ -59,9 +52,24 @@ router.post("/internal/transfer-brand", apiKeyAuth, async (req, res) => {
     )
     .returning({ id: leadBuffer.id });
 
+  // Step 2: Rewrite brand (if targetBrandId present) — no org_id filter, matches all rows with sourceBrandId
+  if (targetBrandId) {
+    const rewriteSet = { brandIds: sql`ARRAY[${targetBrandId}]::text[]` };
+
+    await db
+      .update(servedLeads)
+      .set(rewriteSet)
+      .where(soloBrandCondition);
+
+    await db
+      .update(leadBuffer)
+      .set(rewriteSet)
+      .where(and(sql`brand_ids IS NOT NULL`, soloBrandCondition));
+  }
+
   const updatedTables = [
-    { tableName: "served_leads", count: servedResult.length },
-    { tableName: "lead_buffer", count: bufferResult.length },
+    { tableName: "served_leads", count: servedStep1.length },
+    { tableName: "lead_buffer", count: bufferStep1.length },
   ];
 
   console.log(

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -611,9 +611,10 @@ const InternalApiKeyHeader = [
 
 export const TransferBrandRequestSchema = z
   .object({
-    brandId: z.string().uuid(),
+    sourceBrandId: z.string().uuid(),
     sourceOrgId: z.string().uuid(),
     targetOrgId: z.string().uuid(),
+    targetBrandId: z.string().uuid().optional(),
   })
   .openapi("TransferBrandRequest");
 

--- a/tests/unit/transfer-brand.test.ts
+++ b/tests/unit/transfer-brand.test.ts
@@ -31,6 +31,12 @@ function buildApp() {
   return app;
 }
 
+const VALID_BODY = {
+  sourceBrandId: "11111111-1111-4111-a111-111111111111",
+  sourceOrgId: "22222222-2222-4222-a222-222222222222",
+  targetOrgId: "33333333-3333-4333-a333-333333333333",
+};
+
 describe("POST /internal/transfer-brand", () => {
   beforeEach(() => {
     mockUpdate.mockReset();
@@ -59,7 +65,7 @@ describe("POST /internal/transfer-brand", () => {
     const res = await request(app)
       .post("/internal/transfer-brand")
       .send({
-        brandId: "not-a-uuid",
+        sourceBrandId: "not-a-uuid",
         sourceOrgId: "also-not",
         targetOrgId: "nope",
       });
@@ -67,8 +73,16 @@ describe("POST /internal/transfer-brand", () => {
     expect(res.status).toBe(400);
   });
 
-  it("updates both tables and returns counts", async () => {
-    // First call (served_leads) returns 2 rows, second (lead_buffer) returns 1
+  it("returns 400 for invalid targetBrandId", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post("/internal/transfer-brand")
+      .send({ ...VALID_BODY, targetBrandId: "not-a-uuid" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("updates both tables and returns counts (no targetBrandId)", async () => {
     mockReturning
       .mockResolvedValueOnce([{ id: "a" }, { id: "b" }])
       .mockResolvedValueOnce([{ id: "c" }]);
@@ -76,11 +90,7 @@ describe("POST /internal/transfer-brand", () => {
     const app = buildApp();
     const res = await request(app)
       .post("/internal/transfer-brand")
-      .send({
-        brandId: "11111111-1111-4111-a111-111111111111",
-        sourceOrgId: "22222222-2222-4222-a222-222222222222",
-        targetOrgId: "33333333-3333-4333-a333-333333333333",
-      });
+      .send(VALID_BODY);
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
@@ -91,10 +101,38 @@ describe("POST /internal/transfer-brand", () => {
     // db.update called twice (once per table)
     expect(mockUpdate).toHaveBeenCalledTimes(2);
 
-    // .set() called with targetOrgId both times
+    // .set() called with only orgId (no brand rewrite)
     expect(mockSet).toHaveBeenCalledWith({
       orgId: "33333333-3333-4333-a333-333333333333",
     });
+  });
+
+  it("rewrites brand_ids when targetBrandId is present", async () => {
+    mockReturning
+      .mockResolvedValueOnce([{ id: "a" }])
+      .mockResolvedValueOnce([]);
+
+    const app = buildApp();
+    const res = await request(app)
+      .post("/internal/transfer-brand")
+      .send({
+        ...VALID_BODY,
+        targetBrandId: "44444444-4444-4444-a444-444444444444",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.updatedTables).toEqual([
+      { tableName: "served_leads", count: 1 },
+      { tableName: "lead_buffer", count: 0 },
+    ]);
+
+    // .set() called with orgId AND brandIds
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: "33333333-3333-4333-a333-333333333333",
+        brandIds: expect.anything(),
+      })
+    );
   });
 
   it("is idempotent — returns 0 counts when already transferred", async () => {
@@ -105,11 +143,7 @@ describe("POST /internal/transfer-brand", () => {
     const app = buildApp();
     const res = await request(app)
       .post("/internal/transfer-brand")
-      .send({
-        brandId: "11111111-1111-4111-a111-111111111111",
-        sourceOrgId: "22222222-2222-4222-a222-222222222222",
-        targetOrgId: "33333333-3333-4333-a333-333333333333",
-      });
+      .send(VALID_BODY);
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([

--- a/tests/unit/transfer-brand.test.ts
+++ b/tests/unit/transfer-brand.test.ts
@@ -107,7 +107,7 @@ describe("POST /internal/transfer-brand", () => {
     });
   });
 
-  it("rewrites brand_ids when targetBrandId is present", async () => {
+  it("rewrites brand_ids in a separate step when targetBrandId is present", async () => {
     mockReturning
       .mockResolvedValueOnce([{ id: "a" }])
       .mockResolvedValueOnce([]);
@@ -126,13 +126,24 @@ describe("POST /internal/transfer-brand", () => {
       { tableName: "lead_buffer", count: 0 },
     ]);
 
-    // .set() called with orgId AND brandIds
-    expect(mockSet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        orgId: "33333333-3333-4333-a333-333333333333",
-        brandIds: expect.anything(),
-      })
-    );
+    // Step 1: org move (2 calls) + Step 2: brand rewrite (2 calls) = 4 total
+    expect(mockUpdate).toHaveBeenCalledTimes(4);
+
+    // Step 1 calls set orgId only
+    expect(mockSet).toHaveBeenNthCalledWith(1, {
+      orgId: "33333333-3333-4333-a333-333333333333",
+    });
+    expect(mockSet).toHaveBeenNthCalledWith(2, {
+      orgId: "33333333-3333-4333-a333-333333333333",
+    });
+
+    // Step 2 calls set brandIds only (no orgId)
+    expect(mockSet).toHaveBeenNthCalledWith(3, {
+      brandIds: expect.anything(),
+    });
+    expect(mockSet).toHaveBeenNthCalledWith(4, {
+      brandIds: expect.anything(),
+    });
   });
 
   it("is idempotent — returns 0 counts when already transferred", async () => {


### PR DESCRIPTION
## Summary
- Fixes `POST /internal/transfer-brand` to use **two separate updates** when `targetBrandId` is present:
  1. **Step 1 (org move):** `SET org_id = targetOrgId WHERE brand_ids = [sourceBrandId] AND org_id = sourceOrgId`
  2. **Step 2 (brand rewrite):** `SET brand_ids = [targetBrandId] WHERE brand_ids = [sourceBrandId]` — no org_id filter, catches all rows
- Without `targetBrandId`, behavior is unchanged (single org-move update)

## Test plan
- [x] Updated test verifies 4 db.update calls (2 for org move + 2 for brand rewrite)
- [x] All 179 unit tests pass
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)