### PR TITLE
Rename brandId → sourceBrandId + add targetBrandId for brand rewrite

### DIFF
--- a/src/routes/transfer-brand.ts
+++ b/src/routes/transfer-brand.ts
@@ -31,25 +31,18 @@ router.post("/internal/transfer-brand", apiKeyAuth, async (req, res) => {
   // Solo-brand condition: brand_ids array has exactly one element and it equals sourceBrandId
   const soloBrandCondition = sql`array_length(brand_ids, 1) = 1 AND brand_ids[1] = ${sourceBrandId}`;
 
-  // When targetBrandId is present, rewrite brand_ids too
-  const setClause: Record<string, unknown> = { orgId: targetOrgId };
-  if (targetBrandId) {
-    setClause.brandIds = sql`ARRAY[${targetBrandId}]::text[]`;
-  }
-
-  // Update served_leads
-  const servedResult = await db
+  // Step 1: Move org — UPDATE SET org_id = targetOrgId WHERE brand_id = sourceBrandId AND org_id = sourceOrgId
+  const servedStep1 = await db
     .update(servedLeads)
-    .set(setClause)
+    .set({ orgId: targetOrgId })
     .where(
       and(eq(servedLeads.orgId, sourceOrgId), soloBrandCondition)
     )
     .returning({ id: servedLeads.id });
 
-  // Update lead_buffer (brand_ids is nullable, so also check it's not null)
-  const bufferResult = await db
+  const bufferStep1 = await db
     .update(leadBuffer)
-    .set(setClause)
+    .set({ orgId: targetOrgId })
     .where(
       and(
         eq(leadBuffer.orgId, sourceOrgId),
@@ -59,9 +52,24 @@ router.post("/internal/transfer-brand", apiKeyAuth, async (req, res) => {
     )
     .returning({ id: leadBuffer.id });
 
+  // Step 2: Rewrite brand (if targetBrandId present) — no org_id filter, matches all rows with sourceBrandId
+  if (targetBrandId) {
+    const rewriteSet = { brandIds: sql`ARRAY[${targetBrandId}]::text[]` };
+
+    await db
+      .update(servedLeads)
+      .set(rewriteSet)
+      .where(soloBrandCondition);
+
+    await db
+      .update(leadBuffer)
+      .set(rewriteSet)
+      .where(and(sql`brand_ids IS NOT NULL`, soloBrandCondition));
+  }
+
   const updatedTables = [
-    { tableName: "served_leads", count: servedResult.length },
-    { tableName: "lead_buffer", count: bufferResult.length },
+    { tableName: "served_leads", count: servedStep1.length },
+    { tableName: "lead_buffer", count: bufferStep1.length },
   ];
 
   console.log(

--- a/tests/unit/transfer-brand.test.ts
+++ b/tests/unit/transfer-brand.test.ts
@@ -107,7 +107,7 @@ describe("POST /internal/transfer-brand", () => {
     });
   });
 
-  it("rewrites brand_ids when targetBrandId is present", async () => {
+  it("rewrites brand_ids in a separate step when targetBrandId is present", async () => {
     mockReturning
       .mockResolvedValueOnce([{ id: "a" }])
       .mockResolvedValueOnce([]);
@@ -126,13 +126,24 @@ describe("POST /internal/transfer-brand", () => {
       { tableName: "lead_buffer", count: 0 },
     ]);
 
-    // .set() called with orgId AND brandIds
-    expect(mockSet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        orgId: "33333333-3333-4333-a333-333333333333",
-        brandIds: expect.anything(),
-      })
-    );
+    // Step 1: org move (2 calls) + Step 2: brand rewrite (2 calls) = 4 total
+    expect(mockUpdate).toHaveBeenCalledTimes(4);
+
+    // Step 1 calls set orgId only
+    expect(mockSet).toHaveBeenNthCalledWith(1, {
+      orgId: "33333333-3333-4333-a333-333333333333",
+    });
+    expect(mockSet).toHaveBeenNthCalledWith(2, {
+      orgId: "33333333-3333-4333-a333-333333333333",
+    });
+
+    // Step 2 calls set brandIds only (no orgId)
+    expect(mockSet).toHaveBeenNthCalledWith(3, {
+      brandIds: expect.anything(),
+    });
+    expect(mockSet).toHaveBeenNthCalledWith(4, {
+      brandIds: expect.anything(),
+    });
   });
 
   it("is idempotent — returns 0 counts when already transferred", async () => {


### PR DESCRIPTION
## Summary
- Renames `brandId` → `sourceBrandId` in `POST /internal/transfer-brand`
- Adds optional `targetBrandId` — when present, rewrites `brand_ids` in a **separate step** (no org_id filter)
- Two-step logic: step 1 moves org, step 2 rewrites brand references

## Test plan
- [x] Unit tests verify 4 db.update calls when targetBrandId present (2 for org move + 2 for brand rewrite)
- [x] All 179 tests pass
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)