### PR TITLE
Add structured event tracing via traceEvent

### DIFF
--- a/src/lib/trace-event.ts
+++ b/src/lib/trace-event.ts
@@ -1,0 +1,45 @@
+import { RUNS_SERVICE_URL, RUNS_SERVICE_API_KEY } from "../config.js";
+
+const IDENTITY_HEADERS = [
+  "x-org-id",
+  "x-user-id",
+  "x-brand-id",
+  "x-campaign-id",
+  "x-workflow-slug",
+  "x-feature-slug",
+] as const;
+
+export async function traceEvent(
+  runId: string,
+  payload: {
+    service: string;
+    event: string;
+    detail?: string;
+    level?: "info" | "warn" | "error";
+    data?: Record<string, unknown>;
+  },
+  headers: Record<string, string | string[] | undefined>,
+): Promise<void> {
+  if (!RUNS_SERVICE_URL || !RUNS_SERVICE_API_KEY) {
+    console.error("[lead-service] RUNS_SERVICE_URL or RUNS_SERVICE_API_KEY not set, skipping trace event");
+    return;
+  }
+  try {
+    const forwardHeaders: Record<string, string> = {
+      "Content-Type": "application/json",
+      "x-api-key": RUNS_SERVICE_API_KEY,
+    };
+    for (const key of IDENTITY_HEADERS) {
+      const val = headers[key];
+      if (val) forwardHeaders[key] = val as string;
+    }
+
+    await fetch(`${RUNS_SERVICE_URL}/v1/runs/${runId}/events`, {
+      method: "POST",
+      headers: forwardHeaders,
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    console.error("[lead-service] Failed to trace event:", err);
+  }
+}

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -3,6 +3,7 @@ import { eq, lt } from "drizzle-orm";
 import { type AuthenticatedRequest, apiKeyAuth, requireOrgId } from "../middleware/auth.js";
 import { pullNext } from "../lib/buffer.js";
 import { createRun, updateRun } from "../lib/runs-client.js";
+import { traceEvent } from "../lib/trace-event.js";
 import { BufferNextRequestSchema } from "../schemas.js";
 import { db } from "../db/index.js";
 import { idempotencyCache } from "../db/schema.js";
@@ -56,6 +57,7 @@ router.post("/orgs/buffer/next", apiKeyAuth, requireOrgId, async (req: Authentic
   });
   if (cached) {
     console.log(`[lead-service] Idempotency hit for runId=${runId}`);
+    traceEvent(runId, { service: "lead-service", event: "idempotency-hit", detail: `Returning cached response for runId=${runId}` }, req.headers).catch(() => {});
     return res.json(cached.response);
   }
 
@@ -72,6 +74,8 @@ router.post("/orgs/buffer/next", apiKeyAuth, requireOrgId, async (req: Authentic
     featureSlug: req.featureSlug,
   });
   const serveRunId = childRun.id;
+
+  traceEvent(serveRunId, { service: "lead-service", event: "buffer-next-start", detail: `campaignId=${campaignId}, brandIds=${brandIds.join(",")}` }, req.headers).catch(() => {});
 
   try {
     const result = await pullNext({
@@ -98,12 +102,15 @@ router.post("/orgs/buffer/next", apiKeyAuth, requireOrgId, async (req: Authentic
       console.warn("[lead-service] Failed to cache idempotency response:", err);
     }
 
+    traceEvent(serveRunId, { service: "lead-service", event: "buffer-next-done", detail: `found=${result.found}`, data: { found: result.found } }, req.headers).catch(() => {});
+
     const runStatus = result.found ? "completed" : "failed";
     await updateRun(serveRunId, runStatus, runMeta);
 
     res.json(result);
   } catch (error) {
     console.error("[lead-service] buffer/next error:", error);
+    traceEvent(serveRunId, { service: "lead-service", event: "buffer-next-error", level: "error", detail: String(error) }, req.headers).catch(() => {});
     try {
       await updateRun(serveRunId, "failed", runMeta);
     } catch (runErr) {

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -8,6 +8,7 @@ import {
   type StatusResult,
   type DeliveryStatusItem,
 } from "../lib/email-gateway-client.js";
+import { traceEvent } from "../lib/trace-event.js";
 
 const router = Router();
 
@@ -110,6 +111,7 @@ const DEFAULT_STATUS = { contacted: false, delivered: false, bounced: false, rep
 
 router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedRequest, res) => {
   try {
+    if (req.runId) traceEvent(req.runId, { service: "lead-service", event: "leads-query-start", detail: `orgId=${req.orgId}` }, req.headers).catch(() => {});
     const { brandId, campaignId, orgId, userId } = req.query;
 
     // Build filter conditions
@@ -184,6 +186,7 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
       };
     });
 
+    if (req.runId) traceEvent(req.runId, { service: "lead-service", event: "leads-query-done", detail: `count=${enrichedLeads.length}`, data: { count: enrichedLeads.length } }, req.headers).catch(() => {});
     res.json({ leads: enrichedLeads });
   } catch (error) {
     console.error("[lead-service] Leads error:", error);

--- a/src/routes/transfer-brand.ts
+++ b/src/routes/transfer-brand.ts
@@ -4,6 +4,7 @@ import { eq, and, sql } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { servedLeads, leadBuffer } from "../db/schema.js";
 import { apiKeyAuth } from "../middleware/auth.js";
+import { traceEvent } from "../lib/trace-event.js";
 
 const router = Router();
 
@@ -22,6 +23,9 @@ router.post("/internal/transfer-brand", apiKeyAuth, async (req, res) => {
   }
 
   const { sourceBrandId, sourceOrgId, targetOrgId, targetBrandId } = parsed.data;
+
+  const runId = req.headers["x-run-id"] as string | undefined;
+  if (runId) traceEvent(runId, { service: "lead-service", event: "transfer-brand-start", detail: `sourceBrandId=${sourceBrandId}, sourceOrgId=${sourceOrgId}, targetOrgId=${targetOrgId}` }, req.headers).catch(() => {});
 
   console.log(
     `[lead-service] Transfer brand ${sourceBrandId} from org ${sourceOrgId} to org ${targetOrgId}` +
@@ -75,6 +79,8 @@ router.post("/internal/transfer-brand", apiKeyAuth, async (req, res) => {
   console.log(
     `[lead-service] Transfer complete: ${JSON.stringify(updatedTables)}`
   );
+
+  if (runId) traceEvent(runId, { service: "lead-service", event: "transfer-brand-done", detail: `updated: ${JSON.stringify(updatedTables)}`, data: { updatedTables } }, req.headers).catch(() => {});
 
   res.json({ updatedTables });
 });

--- a/tests/unit/trace-event.test.ts
+++ b/tests/unit/trace-event.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock config before importing the module under test
+vi.mock("../../src/config.js", () => ({
+  RUNS_SERVICE_URL: "https://runs.test",
+  RUNS_SERVICE_API_KEY: "test-api-key",
+  LEAD_SERVICE_API_KEY: "test-key",
+  PORT: "3006",
+  APOLLO_SERVICE_URL: "http://apollo",
+  APOLLO_SERVICE_API_KEY: "key",
+  BRAND_SERVICE_URL: "http://brand",
+  BRAND_SERVICE_API_KEY: "key",
+  CAMPAIGN_SERVICE_URL: "http://campaign",
+  CAMPAIGN_SERVICE_API_KEY: "key",
+  EMAIL_GATEWAY_SERVICE_URL: "http://email-gw",
+  EMAIL_GATEWAY_SERVICE_API_KEY: "key",
+  KEY_SERVICE_URL: "http://key",
+  KEY_SERVICE_API_KEY: "key",
+  FEATURES_SERVICE_URL: "http://features",
+  FEATURES_SERVICE_API_KEY: "key",
+  WORKFLOW_SERVICE_URL: "http://workflow",
+  WORKFLOW_SERVICE_API_KEY: "key",
+}));
+
+describe("traceEvent", () => {
+  const fetchSpy = vi.fn().mockResolvedValue({ ok: true });
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchSpy);
+    fetchSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts correct payload to runs-service", async () => {
+    const { traceEvent } = await import("../../src/lib/trace-event.js");
+
+    await traceEvent("run-123", {
+      service: "lead-service",
+      event: "buffer-next-start",
+      detail: "Starting buffer pull",
+      level: "info",
+      data: { campaignId: "c-1" },
+    }, { "x-org-id": "org-1" });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, opts] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://runs.test/v1/runs/run-123/events");
+    expect(opts.method).toBe("POST");
+    expect(JSON.parse(opts.body)).toEqual({
+      service: "lead-service",
+      event: "buffer-next-start",
+      detail: "Starting buffer pull",
+      level: "info",
+      data: { campaignId: "c-1" },
+    });
+  });
+
+  it("forwards all identity headers", async () => {
+    const { traceEvent } = await import("../../src/lib/trace-event.js");
+
+    await traceEvent("run-123", {
+      service: "lead-service",
+      event: "test",
+    }, {
+      "x-org-id": "org-1",
+      "x-user-id": "user-1",
+      "x-brand-id": "brand-1,brand-2",
+      "x-campaign-id": "camp-1",
+      "x-workflow-slug": "wf-slug",
+      "x-feature-slug": "feat-slug",
+    });
+
+    const [, opts] = fetchSpy.mock.calls[0];
+    expect(opts.headers["x-org-id"]).toBe("org-1");
+    expect(opts.headers["x-user-id"]).toBe("user-1");
+    expect(opts.headers["x-brand-id"]).toBe("brand-1,brand-2");
+    expect(opts.headers["x-campaign-id"]).toBe("camp-1");
+    expect(opts.headers["x-workflow-slug"]).toBe("wf-slug");
+    expect(opts.headers["x-feature-slug"]).toBe("feat-slug");
+  });
+
+  it("skips missing optional headers", async () => {
+    const { traceEvent } = await import("../../src/lib/trace-event.js");
+
+    await traceEvent("run-123", {
+      service: "lead-service",
+      event: "test",
+    }, { "x-org-id": "org-1" });
+
+    const [, opts] = fetchSpy.mock.calls[0];
+    expect(opts.headers["x-org-id"]).toBe("org-1");
+    expect(opts.headers).not.toHaveProperty("x-user-id");
+    expect(opts.headers).not.toHaveProperty("x-brand-id");
+    expect(opts.headers).not.toHaveProperty("x-campaign-id");
+    expect(opts.headers).not.toHaveProperty("x-workflow-slug");
+    expect(opts.headers).not.toHaveProperty("x-feature-slug");
+  });
+
+  it("swallows fetch errors and never throws", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("Network error"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { traceEvent } = await import("../../src/lib/trace-event.js");
+
+    // Should NOT throw
+    await expect(
+      traceEvent("run-123", { service: "lead-service", event: "test" }, {})
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[lead-service] Failed to trace event:",
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("skips if RUNS_SERVICE_URL is missing", async () => {
+    // Re-mock config with missing URL and re-import trace-event
+    vi.resetModules();
+    vi.doMock("../../src/config.js", () => ({
+      RUNS_SERVICE_URL: "",
+      RUNS_SERVICE_API_KEY: "test-api-key",
+      LEAD_SERVICE_API_KEY: "test-key",
+      PORT: "3006",
+      APOLLO_SERVICE_URL: "http://apollo",
+      APOLLO_SERVICE_API_KEY: "key",
+      BRAND_SERVICE_URL: "http://brand",
+      BRAND_SERVICE_API_KEY: "key",
+      CAMPAIGN_SERVICE_URL: "http://campaign",
+      CAMPAIGN_SERVICE_API_KEY: "key",
+      EMAIL_GATEWAY_SERVICE_URL: "http://email-gw",
+      EMAIL_GATEWAY_SERVICE_API_KEY: "key",
+      KEY_SERVICE_URL: "http://key",
+      KEY_SERVICE_API_KEY: "key",
+      FEATURES_SERVICE_URL: "http://features",
+      FEATURES_SERVICE_API_KEY: "key",
+      WORKFLOW_SERVICE_URL: "http://workflow",
+      WORKFLOW_SERVICE_API_KEY: "key",
+    }));
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const mod = await import("../../src/lib/trace-event.js");
+
+    await mod.traceEvent("run-123", { service: "lead-service", event: "test" }, {});
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Added `src/lib/trace-event.ts` — fire-and-forget helper that POSTs to `runs-service POST /v1/runs/{runId}/events`, forwarding all identity headers (x-org-id, x-user-id, x-brand-id, x-campaign-id, x-workflow-slug, x-feature-slug). Never throws.
- Instrumented **buffer/next** flow with 4 events: `idempotency-hit`, `buffer-next-start`, `buffer-next-done`, `buffer-next-error`
- Instrumented **leads query** flow with 2 events: `leads-query-start`, `leads-query-done`
- Instrumented **transfer-brand** flow with 2 events: `transfer-brand-start`, `transfer-brand-done`
- Added 5 unit tests for the traceEvent helper (payload, header forwarding, error swallowing, env var guard)

## Test plan
- [x] All 186 unit tests pass (`npm run test:unit`)
- [x] No changes to Zod schemas or openapi.json
- [x] No new env vars needed (RUNS_SERVICE_URL and RUNS_SERVICE_API_KEY already exist)
- [x] Pattern matches content-generation-service PR #100 and campaign-service PR #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)