### PR TITLE
Prep buffer test for hotfix v0.7.1 sync

### DIFF
--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -1035,6 +1035,7 @@ describe("buffer", () => {
       // Lead has no email (needs enrichment) but externalId is already served for this brand.
       // pullNext should skip it WITHOUT calling apolloEnrich.
       pgSqlMock
+        .mockResolvedValueOnce([])  // stale claim recovery
         .mockResolvedValueOnce([toClaimedRow({
           id: "buf-predeup",
           namespace: "apollo",


### PR DESCRIPTION
## Summary
- Adds stale claim recovery mock to the pre-enrichment brand dedup test so it passes after hotfix v0.7.1 syncs to staging

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, re-run sync PR #192 CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)