### PR TITLE
Align lead-service with journalists-service patterns

### DIFF
--- a/drizzle/0014_rename_external_id_to_apollo_person_id.sql
+++ b/drizzle/0014_rename_external_id_to_apollo_person_id.sql
@@ -1,0 +1,16 @@
+-- Rename external_id → apollo_person_id in all tables
+ALTER TABLE "leads" RENAME COLUMN "external_id" TO "apollo_person_id";--> statement-breakpoint
+ALTER TABLE "served_leads" RENAME COLUMN "external_id" TO "apollo_person_id";--> statement-breakpoint
+ALTER TABLE "lead_buffer" RENAME COLUMN "external_id" TO "apollo_person_id";--> statement-breakpoint
+ALTER TABLE "enrichments" RENAME COLUMN "external_id" TO "apollo_person_id";--> statement-breakpoint
+
+-- Add email_status column to enrichments (nullable, no default)
+ALTER TABLE "enrichments" ADD COLUMN IF NOT EXISTS "email_status" text;--> statement-breakpoint
+
+-- Rename indexes to match new column name
+ALTER INDEX IF EXISTS "idx_leads_external_id" RENAME TO "idx_leads_apollo_person_id";--> statement-breakpoint
+ALTER INDEX IF EXISTS "idx_enrichments_external_id" RENAME TO "idx_enrichments_apollo_person_id";--> statement-breakpoint
+
+-- Recreate buffer index with new column name
+DROP INDEX IF EXISTS "idx_buffer_org_campaign_extid";--> statement-breakpoint
+CREATE INDEX "idx_buffer_org_campaign_extid" ON "lead_buffer" USING btree ("org_id","campaign_id","apollo_person_id");

--- a/drizzle/0014_rename_external_id_to_apollo_person_id.sql
+++ b/drizzle/0014_rename_external_id_to_apollo_person_id.sql
@@ -1,8 +1,24 @@
--- Rename external_id → apollo_person_id in all tables
-ALTER TABLE "leads" RENAME COLUMN "external_id" TO "apollo_person_id";--> statement-breakpoint
-ALTER TABLE "served_leads" RENAME COLUMN "external_id" TO "apollo_person_id";--> statement-breakpoint
-ALTER TABLE "lead_buffer" RENAME COLUMN "external_id" TO "apollo_person_id";--> statement-breakpoint
-ALTER TABLE "enrichments" RENAME COLUMN "external_id" TO "apollo_person_id";--> statement-breakpoint
+-- Rename external_id → apollo_person_id in all tables (idempotent)
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'leads' AND column_name = 'external_id') THEN
+    ALTER TABLE "leads" RENAME COLUMN "external_id" TO "apollo_person_id";
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'served_leads' AND column_name = 'external_id') THEN
+    ALTER TABLE "served_leads" RENAME COLUMN "external_id" TO "apollo_person_id";
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'lead_buffer' AND column_name = 'external_id') THEN
+    ALTER TABLE "lead_buffer" RENAME COLUMN "external_id" TO "apollo_person_id";
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'enrichments' AND column_name = 'external_id') THEN
+    ALTER TABLE "enrichments" RENAME COLUMN "external_id" TO "apollo_person_id";
+  END IF;
+END $$;--> statement-breakpoint
 
 -- Add email_status column to enrichments (nullable, no default)
 ALTER TABLE "enrichments" ADD COLUMN IF NOT EXISTS "email_status" text;--> statement-breakpoint
@@ -11,6 +27,6 @@ ALTER TABLE "enrichments" ADD COLUMN IF NOT EXISTS "email_status" text;--> state
 ALTER INDEX IF EXISTS "idx_leads_external_id" RENAME TO "idx_leads_apollo_person_id";--> statement-breakpoint
 ALTER INDEX IF EXISTS "idx_enrichments_external_id" RENAME TO "idx_enrichments_apollo_person_id";--> statement-breakpoint
 
--- Recreate buffer index with new column name
+-- Recreate buffer index with new column name (idempotent)
 DROP INDEX IF EXISTS "idx_buffer_org_campaign_extid";--> statement-breakpoint
-CREATE INDEX "idx_buffer_org_campaign_extid" ON "lead_buffer" USING btree ("org_id","campaign_id","apollo_person_id");
+CREATE INDEX IF NOT EXISTS "idx_buffer_org_campaign_extid" ON "lead_buffer" USING btree ("org_id","campaign_id","apollo_person_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1775376000000,
       "tag": "0013_fix_buffer_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1775635200000,
+      "tag": "0014_rename_external_id_to_apollo_person_id",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -530,9 +530,15 @@
           "email": {
             "type": "string"
           },
-          "externalId": {
+          "apolloPersonId": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Apollo person ID from enrichment"
+          },
+          "emailStatus": {
+            "type": "string",
+            "nullable": true,
+            "description": "Email verification status from Apollo (verified, extrapolated, etc.)"
           },
           "metadata": {
             "$ref": "#/components/schemas/ApolloPersonData"
@@ -570,10 +576,22 @@
           "contacted": {
             "type": "boolean"
           },
+          "sent": {
+            "type": "boolean"
+          },
           "delivered": {
             "type": "boolean"
           },
+          "opened": {
+            "type": "boolean"
+          },
+          "clicked": {
+            "type": "boolean"
+          },
           "bounced": {
+            "type": "boolean"
+          },
+          "unsubscribed": {
             "type": "boolean"
           },
           "replied": {
@@ -594,6 +612,22 @@
           "lastDeliveredAt": {
             "type": "string",
             "nullable": true
+          },
+          "global": {
+            "type": "object",
+            "properties": {
+              "bounced": {
+                "type": "boolean"
+              },
+              "unsubscribed": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "bounced",
+              "unsubscribed"
+            ],
+            "description": "Global-scope status (across all brands/campaigns). bounced and unsubscribed are global flags."
           }
         },
         "required": [
@@ -601,7 +635,8 @@
           "leadId",
           "namespace",
           "email",
-          "externalId",
+          "apolloPersonId",
+          "emailStatus",
           "metadata",
           "parentRunId",
           "runId",
@@ -612,58 +647,175 @@
           "servedAt",
           "enrichment",
           "contacted",
+          "sent",
           "delivered",
+          "opened",
+          "clicked",
           "bounced",
+          "unsubscribed",
           "replied",
           "replyClassification",
-          "lastDeliveredAt"
+          "lastDeliveredAt",
+          "global"
         ]
       },
       "StatsResponse": {
         "type": "object",
         "properties": {
-          "served": {
+          "totalLeads": {
             "type": "number"
           },
-          "contacted": {
-            "type": "number"
+          "byOutreachStatus": {
+            "type": "object",
+            "properties": {
+              "contacted": {
+                "type": "number"
+              },
+              "sent": {
+                "type": "number"
+              },
+              "delivered": {
+                "type": "number"
+              },
+              "opened": {
+                "type": "number"
+              },
+              "bounced": {
+                "type": "number"
+              },
+              "clicked": {
+                "type": "number"
+              },
+              "unsubscribed": {
+                "type": "number"
+              },
+              "repliesPositive": {
+                "type": "number"
+              },
+              "repliesNegative": {
+                "type": "number"
+              },
+              "repliesNeutral": {
+                "type": "number"
+              },
+              "repliesAutoReply": {
+                "type": "number"
+              },
+              "repliesDetail": {
+                "type": "object",
+                "properties": {
+                  "interested": {
+                    "type": "number"
+                  },
+                  "meetingBooked": {
+                    "type": "number"
+                  },
+                  "closed": {
+                    "type": "number"
+                  },
+                  "notInterested": {
+                    "type": "number"
+                  },
+                  "wrongPerson": {
+                    "type": "number"
+                  },
+                  "unsubscribe": {
+                    "type": "number"
+                  },
+                  "neutral": {
+                    "type": "number"
+                  },
+                  "autoReply": {
+                    "type": "number"
+                  },
+                  "outOfOffice": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "interested",
+                  "meetingBooked",
+                  "closed",
+                  "notInterested",
+                  "wrongPerson",
+                  "unsubscribe",
+                  "neutral",
+                  "autoReply",
+                  "outOfOffice"
+                ]
+              }
+            },
+            "required": [
+              "contacted",
+              "sent",
+              "delivered",
+              "opened",
+              "bounced",
+              "clicked",
+              "unsubscribed",
+              "repliesPositive",
+              "repliesNegative",
+              "repliesNeutral",
+              "repliesAutoReply",
+              "repliesDetail"
+            ]
+          },
+          "repliesDetail": {
+            "type": "object",
+            "properties": {
+              "interested": {
+                "type": "number"
+              },
+              "meetingBooked": {
+                "type": "number"
+              },
+              "closed": {
+                "type": "number"
+              },
+              "notInterested": {
+                "type": "number"
+              },
+              "wrongPerson": {
+                "type": "number"
+              },
+              "unsubscribe": {
+                "type": "number"
+              },
+              "neutral": {
+                "type": "number"
+              },
+              "autoReply": {
+                "type": "number"
+              },
+              "outOfOffice": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "interested",
+              "meetingBooked",
+              "closed",
+              "notInterested",
+              "wrongPerson",
+              "unsubscribe",
+              "neutral",
+              "autoReply",
+              "outOfOffice"
+            ]
           },
           "buffered": {
             "type": "number"
           },
           "skipped": {
             "type": "number"
-          },
-          "apollo": {
-            "type": "object",
-            "properties": {
-              "enrichedLeadsCount": {
-                "type": "number"
-              },
-              "searchCount": {
-                "type": "number"
-              },
-              "fetchedPeopleCount": {
-                "type": "number"
-              },
-              "totalMatchingPeople": {
-                "type": "number"
-              }
-            },
-            "required": [
-              "enrichedLeadsCount",
-              "searchCount",
-              "fetchedPeopleCount",
-              "totalMatchingPeople"
-            ]
           }
         },
         "required": [
-          "served",
-          "contacted",
+          "totalLeads",
+          "byOutreachStatus",
+          "repliesDetail",
           "buffered",
-          "skipped",
-          "apollo"
+          "skipped"
         ]
       },
       "StatsGroupedResponse": {
@@ -677,11 +829,146 @@
                 "key": {
                   "type": "string"
                 },
-                "served": {
+                "totalLeads": {
                   "type": "number"
                 },
-                "contacted": {
-                  "type": "number"
+                "byOutreachStatus": {
+                  "type": "object",
+                  "properties": {
+                    "contacted": {
+                      "type": "number"
+                    },
+                    "sent": {
+                      "type": "number"
+                    },
+                    "delivered": {
+                      "type": "number"
+                    },
+                    "opened": {
+                      "type": "number"
+                    },
+                    "bounced": {
+                      "type": "number"
+                    },
+                    "clicked": {
+                      "type": "number"
+                    },
+                    "unsubscribed": {
+                      "type": "number"
+                    },
+                    "repliesPositive": {
+                      "type": "number"
+                    },
+                    "repliesNegative": {
+                      "type": "number"
+                    },
+                    "repliesNeutral": {
+                      "type": "number"
+                    },
+                    "repliesAutoReply": {
+                      "type": "number"
+                    },
+                    "repliesDetail": {
+                      "type": "object",
+                      "properties": {
+                        "interested": {
+                          "type": "number"
+                        },
+                        "meetingBooked": {
+                          "type": "number"
+                        },
+                        "closed": {
+                          "type": "number"
+                        },
+                        "notInterested": {
+                          "type": "number"
+                        },
+                        "wrongPerson": {
+                          "type": "number"
+                        },
+                        "unsubscribe": {
+                          "type": "number"
+                        },
+                        "neutral": {
+                          "type": "number"
+                        },
+                        "autoReply": {
+                          "type": "number"
+                        },
+                        "outOfOffice": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "interested",
+                        "meetingBooked",
+                        "closed",
+                        "notInterested",
+                        "wrongPerson",
+                        "unsubscribe",
+                        "neutral",
+                        "autoReply",
+                        "outOfOffice"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "contacted",
+                    "sent",
+                    "delivered",
+                    "opened",
+                    "bounced",
+                    "clicked",
+                    "unsubscribed",
+                    "repliesPositive",
+                    "repliesNegative",
+                    "repliesNeutral",
+                    "repliesAutoReply",
+                    "repliesDetail"
+                  ]
+                },
+                "repliesDetail": {
+                  "type": "object",
+                  "properties": {
+                    "interested": {
+                      "type": "number"
+                    },
+                    "meetingBooked": {
+                      "type": "number"
+                    },
+                    "closed": {
+                      "type": "number"
+                    },
+                    "notInterested": {
+                      "type": "number"
+                    },
+                    "wrongPerson": {
+                      "type": "number"
+                    },
+                    "unsubscribe": {
+                      "type": "number"
+                    },
+                    "neutral": {
+                      "type": "number"
+                    },
+                    "autoReply": {
+                      "type": "number"
+                    },
+                    "outOfOffice": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "interested",
+                    "meetingBooked",
+                    "closed",
+                    "notInterested",
+                    "wrongPerson",
+                    "unsubscribe",
+                    "neutral",
+                    "autoReply",
+                    "outOfOffice"
+                  ]
                 },
                 "buffered": {
                   "type": "number"
@@ -692,8 +979,9 @@
               },
               "required": [
                 "key",
-                "served",
-                "contacted",
+                "totalLeads",
+                "byOutreachStatus",
+                "repliesDetail",
                 "buffered",
                 "skipped"
               ]
@@ -1122,7 +1410,7 @@
     "/orgs/leads": {
       "get": {
         "summary": "List served leads with enrichment and delivery status",
-        "description": "Returns served leads with Apollo enrichment data and delivery status (contacted, delivered, bounced, replied, replyClassification, lastDeliveredAt). Status is fetched from email-gateway when brandId or campaignId is provided. With campaignId: campaign-scoped status. With brandId only: brand-scoped (cross-campaign). Without either: status fields default to false/null.",
+        "description": "Returns served leads with Apollo enrichment data, apolloPersonId, emailStatus, and full delivery status (contacted, sent, delivered, opened, clicked, bounced, unsubscribed, replied, replyClassification, lastDeliveredAt, global). Status is fetched from email-gateway when brandId or campaignId is provided. With campaignId: campaign-scoped status. With brandId only: brand-scoped (cross-campaign). Without either: status fields default to false/null.",
         "parameters": [
           {
             "in": "header",
@@ -1249,7 +1537,7 @@
     "/orgs/stats": {
       "get": {
         "summary": "Get lead stats by status",
-        "description": "Returns counts of leads by status: served (delivered with verified email), contacted (unique leads with at least one successful email send), buffered (awaiting enrichment), and skipped (no email found).",
+        "description": "Returns lead stats with outreach status from email-gateway. totalLeads = served leads count, byOutreachStatus = full recipientStats (contacted, sent, delivered, opened, clicked, bounced, unsubscribed, replies*), repliesDetail = granular reply breakdown, buffered/skipped = buffer counts.",
         "parameters": [
           {
             "in": "header",
@@ -1438,7 +1726,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Lead stats by status. Without groupBy: flat stats with Apollo metrics. With groupBy: grouped stats array.",
+            "description": "Lead stats with outreach status. Without groupBy: flat response with totalLeads, byOutreachStatus, repliesDetail, buffered, skipped. With groupBy: grouped stats array.",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -8,5 +8,7 @@ if (!connectionString) {
   throw new Error("LEAD_SERVICE_DATABASE_URL is not set");
 }
 
-export const sql = postgres(connectionString);
+export const sql = postgres(connectionString, {
+  prepare: false,
+});
 export const db = drizzle(sql, { schema });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -39,7 +39,7 @@ export const servedLeads = pgTable(
     leadId: uuid("lead_id").references(() => leads.id),
     namespace: text("namespace").notNull(),
     email: text("email").notNull(),
-    externalId: text("external_id"),
+    apolloPersonId: text("apollo_person_id"),
     metadata: jsonb("metadata"),
     parentRunId: text("parent_run_id"),
     runId: text("run_id"),
@@ -68,7 +68,7 @@ export const leadBuffer = pgTable(
     namespace: text("namespace").notNull(),
     campaignId: text("campaign_id").notNull(),
     email: text("email").notNull(),
-    externalId: text("external_id"),
+    apolloPersonId: text("apollo_person_id"),
     data: jsonb("data"),
     status: text("status").notNull().default("buffered"),
     pushRunId: text("push_run_id"),
@@ -81,7 +81,7 @@ export const leadBuffer = pgTable(
   },
   (table) => [
     index("idx_buffer_org_campaign_ns_status").on(table.orgId, table.campaignId, table.namespace, table.status),
-    index("idx_buffer_org_campaign_extid").on(table.orgId, table.campaignId, table.externalId),
+    index("idx_buffer_org_campaign_extid").on(table.orgId, table.campaignId, table.apolloPersonId),
   ]
 );
 
@@ -91,6 +91,7 @@ export const enrichments = pgTable(
   {
     id: uuid("id").primaryKey().defaultRandom(),
     email: text("email"),
+    emailStatus: text("email_status"),
     apolloPersonId: text("apollo_person_id"),
     firstName: text("first_name"),
     lastName: text("last_name"),

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -231,6 +231,7 @@ export async function pullNext(params: {
   orgId: string;
   campaignId: string;
   brandIds: string[];
+  parentRunId?: string | null;
   runId?: string | null;
   userId?: string | null;
   workflowSlug?: string;
@@ -308,6 +309,25 @@ export async function pullNext(params: {
 
       console.log(`[lead-service] pullNext found=false campaign=${params.campaignId}`);
       return { found: false };
+    }
+
+    // Pre-enrichment brand dedup: skip leads already served for this brand
+    // before paying for Apollo enrichment (uses externalId only, no email needed)
+    if (row.externalId) {
+      const preCheck = await isAlreadyServedForBrand({
+        orgId: params.orgId,
+        brandIds: params.brandIds,
+        externalId: row.externalId,
+      });
+
+      if (preCheck.blocked) {
+        console.log(`[lead-service] pullNext skip (pre-enrich brand dedup): ${preCheck.reason} externalId=${row.externalId}`);
+        await db
+          .update(leadBuffer)
+          .set({ status: "skipped" })
+          .where(eq(leadBuffer.id, row.id));
+        continue;
+      }
     }
 
     // Enrich if no email
@@ -490,6 +510,7 @@ export async function pullNext(params: {
       leadId,
       externalId: row.externalId,
       metadata: enrichedData,
+      parentRunId: params.parentRunId ?? null,
       runId: params.runId ?? null,
       userId: row.userId,
       workflowSlug: params.workflowSlug ?? null,

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -7,12 +7,24 @@ import { apolloSearchNext, apolloEnrich, apolloSearchParams } from "./apollo-cli
 import { fetchCampaign } from "./campaign-client.js";
 import { extractBrandFields } from "./brand-client.js";
 
-async function isInBuffer(orgId: string, campaignId: string, externalId: string): Promise<boolean> {
+/** Valid Apollo email statuses — all others are skipped */
+const VALID_EMAIL_STATUSES = new Set(["verified", "extrapolated"]);
+
+/** Enrichment cache TTL: 6 months for found emails, 1 day for no-email results */
+const CACHE_TTL_EMAIL_FOUND_MS = 6 * 30 * 24 * 60 * 60 * 1000; // ~6 months
+const CACHE_TTL_NO_EMAIL_MS = 1 * 24 * 60 * 60 * 1000; // 1 day
+
+function isCacheFresh(enrichedAt: Date, hasEmail: boolean): boolean {
+  const ttl = hasEmail ? CACHE_TTL_EMAIL_FOUND_MS : CACHE_TTL_NO_EMAIL_MS;
+  return Date.now() - enrichedAt.getTime() < ttl;
+}
+
+async function isInBuffer(orgId: string, campaignId: string, apolloPersonId: string): Promise<boolean> {
   const row = await db.query.leadBuffer.findFirst({
     where: and(
       eq(leadBuffer.orgId, orgId),
       eq(leadBuffer.campaignId, campaignId),
-      eq(leadBuffer.externalId, externalId)
+      eq(leadBuffer.apolloPersonId, apolloPersonId)
     ),
   });
   return !!row;
@@ -124,7 +136,7 @@ async function fillBufferFromSearch(params: {
     // Collect candidates from this page (not already in buffer)
     const candidates: Array<{
       data: Record<string, unknown>;
-      externalId?: string;
+      apolloPersonId?: string;
       email?: string;
       leadId?: string;
     }> = [];
@@ -136,6 +148,7 @@ async function fillBufferFromSearch(params: {
       }
 
       let email = person.email || undefined;
+      let emailStatus = person.emailStatus || undefined;
       let leadId: string | undefined;
       let data: Record<string, unknown> = person;
 
@@ -146,16 +159,25 @@ async function fillBufferFromSearch(params: {
         });
 
         if (cached) {
-          if (!cached.email) {
-            // Previously enriched, no email found — skip entirely
+          if (!isCacheFresh(cached.enrichedAt, !!cached.email)) {
+            // Cache expired — will be re-enriched during pullNext
+          } else if (!cached.email) {
+            // Previously enriched, no email found, cache still fresh — skip entirely
             continue;
-          }
-          email = cached.email;
-          // Merge enriched data so buffer row has full person data (lastName, etc.)
-          if (cached.responseRaw && typeof cached.responseRaw === "object") {
-            data = { ...person, ...(cached.responseRaw as Record<string, unknown>) };
+          } else {
+            email = cached.email;
+            emailStatus = cached.emailStatus ?? undefined;
+            // Merge enriched data so buffer row has full person data (lastName, etc.)
+            if (cached.responseRaw && typeof cached.responseRaw === "object") {
+              data = { ...person, ...(cached.responseRaw as Record<string, unknown>) };
+            }
           }
         }
+      }
+
+      // Skip if email status is not valid
+      if (email && emailStatus && !VALID_EMAIL_STATUSES.has(emailStatus)) {
+        continue;
       }
 
       // Try to find existing leadId
@@ -164,7 +186,7 @@ async function fillBufferFromSearch(params: {
         if (existingLeadId) leadId = existingLeadId;
       }
 
-      candidates.push({ data, externalId: person.id, email, leadId });
+      candidates.push({ data, apolloPersonId: person.id, email, leadId });
     }
 
     // Batch contacted check for candidates with emails and leadIds
@@ -187,7 +209,7 @@ async function fillBufferFromSearch(params: {
 
     let pageFilled = 0;
 
-    for (const { data, externalId, email } of candidates) {
+    for (const { data, apolloPersonId, email } of candidates) {
       const status = email ? contactedMap.get(email) : undefined;
       if (status?.contacted || status?.bounced || status?.unsubscribed) continue;
 
@@ -195,7 +217,7 @@ async function fillBufferFromSearch(params: {
         namespace: "apollo",
         campaignId: params.campaignId,
         email: email ?? "",
-        externalId: externalId,
+        apolloPersonId: apolloPersonId,
         data,
         status: "buffered",
         pushRunId: params.pushRunId ?? null,
@@ -281,7 +303,7 @@ export async function pullNext(params: {
       namespace: claimedRows[0].namespace as string,
       campaignId: claimedRows[0].campaign_id as string,
       email: claimedRows[0].email as string,
-      externalId: claimedRows[0].external_id as string | null,
+      apolloPersonId: claimedRows[0].apollo_person_id as string | null,
       data: claimedRows[0].data as unknown,
       status: claimedRows[0].status as string,
       pushRunId: claimedRows[0].push_run_id as string | null,
@@ -312,16 +334,16 @@ export async function pullNext(params: {
     }
 
     // Pre-enrichment brand dedup: skip leads already served for this brand
-    // before paying for Apollo enrichment (uses externalId only, no email needed)
-    if (row.externalId) {
+    // before paying for Apollo enrichment (uses apolloPersonId only, no email needed)
+    if (row.apolloPersonId) {
       const preCheck = await isAlreadyServedForBrand({
         orgId: params.orgId,
         brandIds: params.brandIds,
-        externalId: row.externalId,
+        apolloPersonId: row.apolloPersonId,
       });
 
       if (preCheck.blocked) {
-        console.log(`[lead-service] pullNext skip (pre-enrich brand dedup): ${preCheck.reason} externalId=${row.externalId}`);
+        console.log(`[lead-service] pullNext skip (pre-enrich brand dedup): ${preCheck.reason} apolloPersonId=${row.apolloPersonId}`);
         await db
           .update(leadBuffer)
           .set({ status: "skipped" })
@@ -334,19 +356,28 @@ export async function pullNext(params: {
     let email = row.email;
     let enrichedData = row.data;
 
-    if (!email && row.externalId) {
+    if (!email && row.apolloPersonId) {
       // Check enrichment cache first to avoid duplicate Apollo API calls
       const cached = await db.query.enrichments.findFirst({
-        where: eq(enrichments.apolloPersonId, row.externalId),
+        where: eq(enrichments.apolloPersonId, row.apolloPersonId),
       });
 
-      if (cached) {
+      if (cached && isCacheFresh(cached.enrichedAt, !!cached.email)) {
         if (cached.email) {
+          // Check email status from cache
+          if (cached.emailStatus && !VALID_EMAIL_STATUSES.has(cached.emailStatus)) {
+            console.log(`[lead-service] pullNext skip (invalid emailStatus: ${cached.emailStatus}) apolloPersonId=${row.apolloPersonId}`);
+            await db
+              .update(leadBuffer)
+              .set({ status: "skipped" })
+              .where(eq(leadBuffer.id, row.id));
+            continue;
+          }
           // Use cached enrichment — no apollo-service call needed
           email = cached.email;
           enrichedData = cached.responseRaw ?? row.data;
         } else {
-          // Previously enriched but no email found — skip without calling Apollo
+          // Previously enriched but no email found, cache still fresh — skip without calling Apollo
           await db
             .update(leadBuffer)
             .set({ status: "skipped" })
@@ -354,7 +385,7 @@ export async function pullNext(params: {
           continue;
         }
       } else {
-        const enrichResult = await apolloEnrich(row.externalId, {
+        const enrichResult = await apolloEnrich(row.apolloPersonId, {
           runId: params.runId,
           orgId: params.orgId,
           userId: params.userId,
@@ -368,7 +399,8 @@ export async function pullNext(params: {
           // Cache the no-email result to avoid re-enriching this person
           await db.insert(enrichments).values({
             email: null,
-            apolloPersonId: row.externalId,
+            emailStatus: null,
+            apolloPersonId: row.apolloPersonId,
             firstName: enrichResult?.person?.firstName ?? null,
             lastName: enrichResult?.person?.lastName ?? null,
             title: enrichResult?.person?.title ?? null,
@@ -386,13 +418,40 @@ export async function pullNext(params: {
           continue;
         }
 
+        // Check email status from fresh enrichment
+        const freshEmailStatus = enrichResult.person.emailStatus;
+        if (freshEmailStatus && !VALID_EMAIL_STATUSES.has(freshEmailStatus)) {
+          console.log(`[lead-service] pullNext skip (invalid emailStatus: ${freshEmailStatus}) apolloPersonId=${row.apolloPersonId}`);
+          // Still cache the result
+          await db.insert(enrichments).values({
+            email: enrichResult.person.email,
+            emailStatus: freshEmailStatus,
+            apolloPersonId: row.apolloPersonId,
+            firstName: enrichResult.person.firstName ?? null,
+            lastName: enrichResult.person.lastName ?? null,
+            title: enrichResult.person.title ?? null,
+            linkedinUrl: enrichResult.person.linkedinUrl ?? null,
+            organizationName: enrichResult.person.organizationName ?? null,
+            organizationDomain: enrichResult.person.organizationDomain ?? null,
+            organizationIndustry: enrichResult.person.organizationIndustry ?? null,
+            organizationSize: enrichResult.person.organizationSize ?? null,
+            responseRaw: enrichResult.person,
+          }).onConflictDoNothing();
+          await db
+            .update(leadBuffer)
+            .set({ status: "skipped" })
+            .where(eq(leadBuffer.id, row.id));
+          continue;
+        }
+
         email = enrichResult.person.email;
         enrichedData = { ...(row.data as object ?? {}), ...enrichResult.person };
 
         // Save to enrichment cache for future lookups
         await db.insert(enrichments).values({
           email,
-          apolloPersonId: row.externalId,
+          emailStatus: freshEmailStatus ?? null,
+          apolloPersonId: row.apolloPersonId,
           firstName: enrichResult.person.firstName ?? null,
           lastName: enrichResult.person.lastName ?? null,
           title: enrichResult.person.title ?? null,
@@ -423,7 +482,7 @@ export async function pullNext(params: {
 
     // Resolve or create the lead identity
     const { leadId } = await resolveOrCreateLead({
-      apolloPersonId: row.externalId,
+      apolloPersonId: row.apolloPersonId,
       email,
       metadata: enrichedData,
     });
@@ -434,7 +493,7 @@ export async function pullNext(params: {
       brandIds: params.brandIds,
       leadId,
       email,
-      externalId: row.externalId,
+      apolloPersonId: row.apolloPersonId,
     });
 
     if (brandCheck.blocked) {
@@ -508,7 +567,7 @@ export async function pullNext(params: {
       campaignId: params.campaignId,
       email,
       leadId,
-      externalId: row.externalId,
+      apolloPersonId: row.apolloPersonId,
       metadata: enrichedData,
       parentRunId: params.parentRunId ?? null,
       runId: params.runId ?? null,
@@ -537,8 +596,6 @@ export async function pullNext(params: {
         ? { ...(enrichedData as Record<string, unknown>), email }
         : { email };
 
-    const dataObj = finalData as Record<string, unknown>;
-
     console.log(`[lead-service] pullNext found=true campaign=${params.campaignId} email=${email} leadId=${leadId}`);
     return {
       found: true,
@@ -549,7 +606,7 @@ export async function pullNext(params: {
         brandIds: params.brandIds,
         orgId: row.orgId,
         userId: row.userId,
-        apolloPersonId: (dataObj.id as string) ?? null,
+        apolloPersonId: row.apolloPersonId,
       },
     };
   }

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -146,6 +146,7 @@ export async function markServed(params: {
   leadId?: string | null;
   externalId?: string | null;
   metadata?: unknown;
+  parentRunId?: string | null;
   runId?: string | null;
   userId?: string | null;
   workflowSlug?: string | null;
@@ -160,6 +161,7 @@ export async function markServed(params: {
       leadId: params.leadId ?? null,
       externalId: params.externalId ?? null,
       metadata: params.metadata ?? null,
+      parentRunId: params.parentRunId ?? null,
       runId: params.runId ?? null,
       brandIds: params.brandIds,
       campaignId: params.campaignId,

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -8,18 +8,20 @@ import {
 } from "./email-gateway-client.js";
 
 const RACE_WINDOW_MINUTES = 60;
+const BRAND_DEDUP_TTL_MONTHS = 6;
 
 /**
  * Check if a lead has already been served for any overlapping brand,
- * cross-campaign, using 3 axes: leadId, email, externalId.
+ * cross-campaign, using 3 axes: leadId, email, apolloPersonId.
  * Uses the && (array overlap) operator on brand_ids.
+ * TTL: only blocks if served within the last 6 months.
  */
 export async function isAlreadyServedForBrand(params: {
   orgId: string;
   brandIds: string[];
   leadId?: string | null;
   email?: string | null;
-  externalId?: string | null;
+  apolloPersonId?: string | null;
 }): Promise<{ blocked: boolean; reason?: string }> {
   if (params.brandIds.length === 0) return { blocked: false };
 
@@ -40,18 +42,19 @@ export async function isAlreadyServedForBrand(params: {
     values.push(params.email);
     paramIdx++;
   }
-  if (params.externalId) {
-    conditions.push(`external_id = $${paramIdx}`);
-    values.push(params.externalId);
+  if (params.apolloPersonId) {
+    conditions.push(`apollo_person_id = $${paramIdx}`);
+    values.push(params.apolloPersonId);
     paramIdx++;
   }
 
   if (conditions.length === 0) return { blocked: false };
 
   const rows = await pgSql.unsafe(
-    `SELECT lead_id, email, external_id FROM served_leads
+    `SELECT lead_id, email, apollo_person_id FROM served_leads
      WHERE org_id = $1
        AND brand_ids && $2::text[]
+       AND served_at >= now() - interval '${BRAND_DEDUP_TTL_MONTHS} months'
        AND (${conditions.join(" OR ")})
      LIMIT 1`,
     values as string[],
@@ -62,7 +65,7 @@ export async function isAlreadyServedForBrand(params: {
     const axes: string[] = [];
     if (params.leadId && match.lead_id === params.leadId) axes.push("lead_id");
     if (params.email && match.email === params.email) axes.push("email");
-    if (params.externalId && match.external_id === params.externalId) axes.push("external_id");
+    if (params.apolloPersonId && match.apollo_person_id === params.apolloPersonId) axes.push("apollo_person_id");
     return {
       blocked: true,
       reason: `already served for overlapping brand (matched on ${axes.join(", ") || "unknown axis"})`,
@@ -144,7 +147,7 @@ export async function markServed(params: {
   campaignId: string;
   email: string;
   leadId?: string | null;
-  externalId?: string | null;
+  apolloPersonId?: string | null;
   metadata?: unknown;
   parentRunId?: string | null;
   runId?: string | null;
@@ -159,7 +162,7 @@ export async function markServed(params: {
       namespace: params.namespace,
       email: params.email,
       leadId: params.leadId ?? null,
-      externalId: params.externalId ?? null,
+      apolloPersonId: params.apolloPersonId ?? null,
       metadata: params.metadata ?? null,
       parentRunId: params.parentRunId ?? null,
       runId: params.runId ?? null,

--- a/src/lib/email-gateway-client.ts
+++ b/src/lib/email-gateway-client.ts
@@ -6,8 +6,10 @@ export interface DeliveryStatusItem {
 
 export interface ScopedStatus {
   contacted: boolean;
+  sent: boolean;
   delivered: boolean;
   opened: boolean;
+  clicked: boolean;
   replied: boolean;
   replyClassification: "positive" | "negative" | "neutral" | null;
   bounced: boolean;
@@ -17,11 +19,8 @@ export interface ScopedStatus {
 
 export interface GlobalStatus {
   email: {
-    contacted: boolean;
-    delivered: boolean;
     bounced: boolean;
     unsubscribed: boolean;
-    lastDeliveredAt: string | null;
   };
 }
 
@@ -49,7 +48,7 @@ async function checkDeliveryStatusBatch(
   campaignId: string | undefined,
   items: DeliveryStatusItem[],
   headers: Record<string, string>,
-): Promise<DeliveryStatusResponse | null> {
+): Promise<DeliveryStatusResponse> {
   const body: Record<string, unknown> = { brandId, items };
   if (campaignId) body.campaignId = campaignId;
 
@@ -62,10 +61,9 @@ async function checkDeliveryStatusBatch(
 
   if (!response.ok) {
     const error = await response.text();
-    console.error(
+    throw new Error(
       `[email-gateway-client] Status check failed: ${response.status} - ${error}`
     );
-    return null;
   }
 
   return (await response.json()) as DeliveryStatusResponse;
@@ -76,54 +74,126 @@ export async function checkDeliveryStatus(
   campaignId: string | undefined,
   items: DeliveryStatusItem[],
   context?: { orgId?: string; userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowSlug?: string; featureSlug?: string }
-): Promise<DeliveryStatusResponse | null> {
+): Promise<DeliveryStatusResponse> {
   if (items.length === 0) return { results: [] };
 
-  try {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      "X-API-Key": EMAIL_GATEWAY_SERVICE_API_KEY,
-    };
-    if (context?.orgId) headers["x-org-id"] = context.orgId;
-    if (context?.userId) headers["x-user-id"] = context.userId;
-    if (context?.runId) headers["x-run-id"] = context.runId;
-    if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
-    if (context?.brandId) headers["x-brand-id"] = context.brandId;
-    if (context?.workflowSlug) headers["x-workflow-slug"] = context.workflowSlug;
-    if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-API-Key": EMAIL_GATEWAY_SERVICE_API_KEY,
+  };
+  if (context?.orgId) headers["x-org-id"] = context.orgId;
+  if (context?.userId) headers["x-user-id"] = context.userId;
+  if (context?.runId) headers["x-run-id"] = context.runId;
+  if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
+  if (context?.brandId) headers["x-brand-id"] = context.brandId;
+  if (context?.workflowSlug) headers["x-workflow-slug"] = context.workflowSlug;
+  if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
 
-    if (items.length <= BATCH_SIZE) {
-      return await checkDeliveryStatusBatch(brandId, campaignId, items, headers);
-    }
-
-    const batches: DeliveryStatusItem[][] = [];
-    for (let i = 0; i < items.length; i += BATCH_SIZE) {
-      batches.push(items.slice(i, i + BATCH_SIZE));
-    }
-
-    const batchResults = await Promise.all(
-      batches.map((batch) => checkDeliveryStatusBatch(brandId, campaignId, batch, headers))
-    );
-
-    const allResults: StatusResult[] = [];
-    for (const result of batchResults) {
-      if (!result) return null;
-      allResults.push(...result.results);
-    }
-
-    return { results: allResults };
-  } catch (error) {
-    const isConnectionError =
-      error instanceof TypeError && error.message === "fetch failed";
-    if (isConnectionError) {
-      console.warn(
-        "[email-gateway-client] email-gateway unreachable, skipping delivery check"
-      );
-    } else {
-      console.error("[email-gateway-client] Status check error:", error);
-    }
-    return null;
+  if (items.length <= BATCH_SIZE) {
+    return await checkDeliveryStatusBatch(brandId, campaignId, items, headers);
   }
+
+  const batches: DeliveryStatusItem[][] = [];
+  for (let i = 0; i < items.length; i += BATCH_SIZE) {
+    batches.push(items.slice(i, i + BATCH_SIZE));
+  }
+
+  const batchResults = await Promise.all(
+    batches.map((batch) => checkDeliveryStatusBatch(brandId, campaignId, batch, headers))
+  );
+
+  const allResults: StatusResult[] = [];
+  for (const result of batchResults) {
+    allResults.push(...result.results);
+  }
+
+  return { results: allResults };
+}
+
+/** Stats from email-gateway GET /orgs/stats */
+export interface RecipientStats {
+  contacted: number;
+  sent: number;
+  delivered: number;
+  opened: number;
+  bounced: number;
+  clicked: number;
+  unsubscribed: number;
+  repliesPositive: number;
+  repliesNegative: number;
+  repliesNeutral: number;
+  repliesAutoReply: number;
+  repliesDetail: {
+    interested: number;
+    meetingBooked: number;
+    closed: number;
+    notInterested: number;
+    wrongPerson: number;
+    unsubscribe: number;
+    neutral: number;
+    autoReply: number;
+    outOfOffice: number;
+  };
+}
+
+export interface EmailGatewayStatsResponse {
+  transactional?: { recipientStats: RecipientStats };
+  broadcast?: { recipientStats: RecipientStats };
+}
+
+export interface EmailGatewayGroupedStatsResponse {
+  groups: Array<{
+    key: string;
+    transactional?: { recipientStats: RecipientStats };
+    broadcast?: { recipientStats: RecipientStats };
+  }>;
+}
+
+export async function fetchEmailGatewayStats(
+  params: {
+    brandId?: string;
+    campaignId?: string;
+    workflowSlugs?: string;
+    featureSlugs?: string;
+    groupBy?: string;
+  },
+  context?: { orgId?: string; userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowSlug?: string; featureSlug?: string }
+): Promise<EmailGatewayStatsResponse | EmailGatewayGroupedStatsResponse> {
+  const queryParams = new URLSearchParams();
+  if (params.brandId) queryParams.set("brandId", params.brandId);
+  if (params.campaignId) queryParams.set("campaignId", params.campaignId);
+  if (params.workflowSlugs) queryParams.set("workflowSlugs", params.workflowSlugs);
+  if (params.featureSlugs) queryParams.set("featureSlugs", params.featureSlugs);
+  if (params.groupBy) queryParams.set("groupBy", params.groupBy);
+
+  const headers: Record<string, string> = {
+    "X-API-Key": EMAIL_GATEWAY_SERVICE_API_KEY,
+  };
+  if (context?.orgId) headers["x-org-id"] = context.orgId;
+  if (context?.userId) headers["x-user-id"] = context.userId;
+  if (context?.runId) headers["x-run-id"] = context.runId;
+  if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
+  if (context?.brandId) headers["x-brand-id"] = context.brandId;
+  if (context?.workflowSlug) headers["x-workflow-slug"] = context.workflowSlug;
+  if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
+
+  const qs = queryParams.toString();
+  const url = `${EMAIL_GATEWAY_SERVICE_URL}/orgs/stats${qs ? `?${qs}` : ""}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers,
+    signal: AbortSignal.timeout(300_000),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(
+      `[email-gateway-client] Stats fetch failed: ${response.status} - ${error}`
+    );
+  }
+
+  return response.json();
 }
 
 export interface EmailCheckResult {
@@ -159,10 +229,8 @@ export function checkEmailStatus(result: StatusResult): EmailCheckResult {
   if (
     bc?.campaign?.contacted ||
     bc?.brand?.contacted ||
-    bc?.global?.email?.contacted ||
     tx?.campaign?.contacted ||
-    tx?.brand?.contacted ||
-    tx?.global?.email?.contacted
+    tx?.brand?.contacted
   ) contacted = true;
 
   // Check byCampaign breakdown (populated in brand-only mode)

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -78,6 +78,7 @@ router.post("/orgs/buffer/next", apiKeyAuth, requireOrgId, async (req: Authentic
       orgId: req.orgId!,
       campaignId,
       brandIds,
+      parentRunId: runId,
       runId: serveRunId,
       userId: req.userId ?? null,
       workflowSlug,

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -7,6 +7,8 @@ import {
   checkDeliveryStatus,
   type StatusResult,
   type DeliveryStatusItem,
+  type ScopedStatus,
+  type GlobalStatus,
 } from "../lib/email-gateway-client.js";
 
 const router = Router();
@@ -20,93 +22,106 @@ export function extractEnrichment(metadata: unknown): Record<string, unknown> | 
   return { ...m };
 }
 
+interface FlattenedStatus {
+  contacted: boolean;
+  sent: boolean;
+  delivered: boolean;
+  opened: boolean;
+  clicked: boolean;
+  bounced: boolean;
+  unsubscribed: boolean;
+  replied: boolean;
+  replyClassification: "positive" | "negative" | "neutral" | null;
+  lastDeliveredAt: string | null;
+  global: {
+    bounced: boolean;
+    unsubscribed: boolean;
+  };
+}
+
+function pickScoped(s: ScopedStatus | null | undefined) {
+  return {
+    contacted: !!s?.contacted,
+    sent: !!s?.sent,
+    delivered: !!s?.delivered,
+    opened: !!s?.opened,
+    clicked: !!s?.clicked,
+    bounced: !!s?.bounced,
+    unsubscribed: !!s?.unsubscribed,
+    replied: !!s?.replied,
+    replyClassification: s?.replyClassification ?? null,
+    lastDeliveredAt: s?.lastDeliveredAt ?? null,
+  };
+}
+
+function mergeGlobal(bc?: GlobalStatus | null, tx?: GlobalStatus | null) {
+  return {
+    bounced: !!(bc?.email?.bounced || tx?.email?.bounced),
+    unsubscribed: !!(bc?.email?.unsubscribed || tx?.email?.unsubscribed),
+  };
+}
+
+function mergeProviders(
+  bcScope: ReturnType<typeof pickScoped>,
+  txScope: ReturnType<typeof pickScoped>,
+): Omit<FlattenedStatus, "global"> {
+  return {
+    contacted: bcScope.contacted || txScope.contacted,
+    sent: bcScope.sent || txScope.sent,
+    delivered: bcScope.delivered || txScope.delivered,
+    opened: bcScope.opened || txScope.opened,
+    clicked: bcScope.clicked || txScope.clicked,
+    bounced: bcScope.bounced || txScope.bounced,
+    unsubscribed: bcScope.unsubscribed || txScope.unsubscribed,
+    replied: bcScope.replied || txScope.replied,
+    replyClassification: bcScope.replyClassification ?? txScope.replyClassification ?? null,
+    lastDeliveredAt: bcScope.lastDeliveredAt ?? txScope.lastDeliveredAt ?? null,
+  };
+}
+
 /**
  * Flatten status using campaign scope (when campaignId is provided).
+ * Also checks brand + global for contacted flag.
  */
-export function flattenCampaignStatus(result: StatusResult) {
+export function flattenCampaignStatus(result: StatusResult): FlattenedStatus {
   const bc = result.broadcast;
   const tx = result.transactional;
 
-  const contacted = !!(
-    bc?.campaign?.contacted ||
-    bc?.brand?.contacted ||
-    bc?.global?.email?.contacted ||
-    tx?.campaign?.contacted ||
-    tx?.brand?.contacted ||
-    tx?.global?.email?.contacted
-  );
+  const bcCampaign = pickScoped(bc?.campaign);
+  const txCampaign = pickScoped(tx?.campaign);
+  const merged = mergeProviders(bcCampaign, txCampaign);
 
-  const delivered = !!(
-    bc?.campaign?.delivered ||
-    tx?.campaign?.delivered
-  );
+  // contacted: also true if brand or global says contacted
+  if (bc?.brand?.contacted || tx?.brand?.contacted) {
+    merged.contacted = true;
+  }
 
-  const bounced = !!(
-    bc?.campaign?.bounced ||
-    tx?.campaign?.bounced
-  );
+  const global = mergeGlobal(bc?.global, tx?.global);
 
-  const replied = !!(
-    bc?.campaign?.replied ||
-    tx?.campaign?.replied
-  );
-
-  const replyClassification =
-    bc?.campaign?.replyClassification ??
-    tx?.campaign?.replyClassification ??
-    null;
-
-  const lastDeliveredAt =
-    bc?.campaign?.lastDeliveredAt ??
-    tx?.campaign?.lastDeliveredAt ??
-    null;
-
-  return { contacted, delivered, bounced, replied, replyClassification, lastDeliveredAt };
+  return { ...merged, global };
 }
 
 /**
  * Flatten status using brand scope (when no campaignId — cross-campaign view).
  */
-export function flattenBrandStatus(result: StatusResult) {
+export function flattenBrandStatus(result: StatusResult): FlattenedStatus {
   const bc = result.broadcast;
   const tx = result.transactional;
 
-  const contacted = !!(
-    bc?.brand?.contacted ||
-    bc?.global?.email?.contacted ||
-    tx?.brand?.contacted ||
-    tx?.global?.email?.contacted
-  );
+  const bcBrand = pickScoped(bc?.brand);
+  const txBrand = pickScoped(tx?.brand);
+  const merged = mergeProviders(bcBrand, txBrand);
 
-  const delivered = !!(
-    bc?.brand?.delivered ||
-    tx?.brand?.delivered
-  );
+  const global = mergeGlobal(bc?.global, tx?.global);
 
-  const bounced = !!(
-    bc?.brand?.bounced ||
-    tx?.brand?.bounced
-  );
-
-  const replied = !!(
-    bc?.brand?.replied ||
-    tx?.brand?.replied
-  );
-
-  const replyClassification =
-    bc?.brand?.replyClassification ??
-    tx?.brand?.replyClassification ??
-    null;
-
-  const lastDeliveredAt =
-    bc?.brand?.lastDeliveredAt ??
-    tx?.brand?.lastDeliveredAt ??
-    null;
-
-  return { contacted, delivered, bounced, replied, replyClassification, lastDeliveredAt };
+  return { ...merged, global };
 }
 
-const DEFAULT_STATUS = { contacted: false, delivered: false, bounced: false, replied: false, replyClassification: null, lastDeliveredAt: null };
+const DEFAULT_STATUS: FlattenedStatus = {
+  contacted: false, sent: false, delivered: false, opened: false, clicked: false,
+  bounced: false, unsubscribed: false, replied: false, replyClassification: null, lastDeliveredAt: null,
+  global: { bounced: false, unsubscribed: false },
+};
 
 router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedRequest, res) => {
   try {
@@ -162,7 +177,6 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
             group.items,
             context,
           );
-          if (!response) return;
           for (const result of response.results) {
             statusMap.set(result.email, result);
           }
@@ -176,10 +190,15 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
         ? (statusResult ? flatten(statusResult) : DEFAULT_STATUS)
         : DEFAULT_STATUS;
 
+      const enrichment = extractEnrichment(lead.metadata);
+      const emailStatus = (enrichment?.emailStatus as string) ?? null;
+
       return {
         ...lead,
         leadId: lead.leadId ?? null,
-        enrichment: extractEnrichment(lead.metadata),
+        apolloPersonId: lead.apolloPersonId ?? null,
+        emailStatus,
+        enrichment,
         ...status,
       };
     });

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,12 +1,13 @@
 import { Router } from "express";
-import { eq, and, count, inArray, or, sql, type SQL } from "drizzle-orm";
+import { eq, and, count, inArray, sql, type SQL } from "drizzle-orm";
 import { type AuthenticatedRequest, type ServiceContext, apiKeyAuth, requireOrgId, getServiceContext } from "../middleware/auth.js";
 import { db } from "../db/index.js";
 import { servedLeads, leadBuffer } from "../db/schema.js";
-import { fetchApolloStats } from "../lib/apollo-client.js";
 import {
-  checkDeliveryStatus,
-  isContacted,
+  fetchEmailGatewayStats,
+  type RecipientStats,
+  type EmailGatewayStatsResponse,
+  type EmailGatewayGroupedStatsResponse,
 } from "../lib/email-gateway-client.js";
 import {
   resolveFeatureDynastySlugs,
@@ -30,6 +31,14 @@ const COLUMN_MAP = {
   workflowSlug: { served: servedLeads.workflowSlug, buffer: leadBuffer.workflowSlug },
   featureSlug: { served: servedLeads.featureSlug, buffer: leadBuffer.featureSlug },
 } as const;
+
+/** Map groupBy param to email-gateway groupBy value */
+const EG_GROUP_BY_MAP: Record<string, string> = {
+  campaignId: "campaignId",
+  brandId: "brandId",
+  workflowSlug: "workflowSlug",
+  featureSlug: "featureSlug",
+};
 
 const router = Router();
 
@@ -103,10 +112,7 @@ function buildConditions(
     if (userIdStr) conds.push(eq(servedLeads.userId, userIdStr));
     if (runIdList.length > 0) {
       conds.push(
-        or(
-          inArray(servedLeads.parentRunId, runIdList),
-          inArray(servedLeads.runId, runIdList),
-        )!,
+        sql`(${servedLeads.parentRunId} = ANY(ARRAY[${sql.join(runIdList.map(id => sql`${id}`), sql`, `)}]) OR ${servedLeads.runId} = ANY(ARRAY[${sql.join(runIdList.map(id => sql`${id}`), sql`, `)}]))`,
       );
     }
     if (dynastyResolved.workflowSlugs && dynastyResolved.workflowSlugs.length > 0) {
@@ -135,205 +141,46 @@ function buildConditions(
   return { conds, runIdList, brandIdStr, campaignIdStr, orgIdStr };
 }
 
-/**
- * Count distinct contacted leads by querying email-gateway for delivery status.
- * Groups served leads by first brandId + campaignId, calls email-gateway per group,
- * and returns the count of unique leadIds confirmed contacted.
- */
-async function countContacted(
-  servedConds: SQL[],
-  context: ServiceContext,
-): Promise<number> {
-  const rows = await db
-    .select({
-      leadId: servedLeads.leadId,
-      email: servedLeads.email,
-      brandIds: servedLeads.brandIds,
-      campaignId: servedLeads.campaignId,
-    })
-    .from(servedLeads)
-    .where(and(...servedConds));
+const ZERO_RECIPIENT_STATS: RecipientStats = {
+  contacted: 0, sent: 0, delivered: 0, opened: 0, bounced: 0, clicked: 0,
+  unsubscribed: 0, repliesPositive: 0, repliesNegative: 0, repliesNeutral: 0,
+  repliesAutoReply: 0,
+  repliesDetail: {
+    interested: 0, meetingBooked: 0, closed: 0, notInterested: 0,
+    wrongPerson: 0, unsubscribe: 0, neutral: 0, autoReply: 0, outOfOffice: 0,
+  },
+};
 
-  if (rows.length === 0) return 0;
+function mergeRecipientStats(broadcast?: { recipientStats: RecipientStats }, transactional?: { recipientStats: RecipientStats }): { byOutreachStatus: RecipientStats; repliesDetail: RecipientStats["repliesDetail"] } {
+  const bc = broadcast?.recipientStats ?? ZERO_RECIPIENT_STATS;
+  const tx = transactional?.recipientStats ?? ZERO_RECIPIENT_STATS;
 
-  // Group by first brandId + campaignId since email-gateway scopes status per brand/campaign
-  const groups = new Map<string, { brandId: string; campaignId: string; items: { leadId: string; email: string }[] }>();
-  for (const row of rows) {
-    if (!row.leadId) continue;
-    const primaryBrandId = row.brandIds[0] ?? "unknown";
-    const key = `${primaryBrandId}::${row.campaignId}`;
-    if (!groups.has(key)) {
-      groups.set(key, { brandId: primaryBrandId, campaignId: row.campaignId, items: [] });
-    }
-    groups.get(key)!.items.push({ leadId: row.leadId, email: row.email });
-  }
+  const byOutreachStatus: RecipientStats = {
+    contacted: bc.contacted + tx.contacted,
+    sent: bc.sent + tx.sent,
+    delivered: bc.delivered + tx.delivered,
+    opened: bc.opened + tx.opened,
+    bounced: bc.bounced + tx.bounced,
+    clicked: bc.clicked + tx.clicked,
+    unsubscribed: bc.unsubscribed + tx.unsubscribed,
+    repliesPositive: bc.repliesPositive + tx.repliesPositive,
+    repliesNegative: bc.repliesNegative + tx.repliesNegative,
+    repliesNeutral: bc.repliesNeutral + tx.repliesNeutral,
+    repliesAutoReply: bc.repliesAutoReply + tx.repliesAutoReply,
+    repliesDetail: {
+      interested: (bc.repliesDetail?.interested ?? 0) + (tx.repliesDetail?.interested ?? 0),
+      meetingBooked: (bc.repliesDetail?.meetingBooked ?? 0) + (tx.repliesDetail?.meetingBooked ?? 0),
+      closed: (bc.repliesDetail?.closed ?? 0) + (tx.repliesDetail?.closed ?? 0),
+      notInterested: (bc.repliesDetail?.notInterested ?? 0) + (tx.repliesDetail?.notInterested ?? 0),
+      wrongPerson: (bc.repliesDetail?.wrongPerson ?? 0) + (tx.repliesDetail?.wrongPerson ?? 0),
+      unsubscribe: (bc.repliesDetail?.unsubscribe ?? 0) + (tx.repliesDetail?.unsubscribe ?? 0),
+      neutral: (bc.repliesDetail?.neutral ?? 0) + (tx.repliesDetail?.neutral ?? 0),
+      autoReply: (bc.repliesDetail?.autoReply ?? 0) + (tx.repliesDetail?.autoReply ?? 0),
+      outOfOffice: (bc.repliesDetail?.outOfOffice ?? 0) + (tx.repliesDetail?.outOfOffice ?? 0),
+    },
+  };
 
-  const contactedLeadIds = new Set<string>();
-
-  await Promise.all(
-    Array.from(groups.values()).map(async (group) => {
-      const response = await checkDeliveryStatus(
-        group.brandId,
-        group.campaignId,
-        group.items.map((i) => ({ email: i.email })),
-        context,
-      );
-      if (!response) return;
-      for (const result of response.results) {
-        if (isContacted(result)) {
-          // Find the leadId for this email
-          const item = group.items.find((i) => i.email === result.email);
-          if (item?.leadId) contactedLeadIds.add(item.leadId);
-        }
-      }
-    }),
-  );
-
-  return contactedLeadIds.size;
-}
-
-/**
- * Count contacted leads per groupBy dimension.
- * For brandId groupBy, unnests brand_ids to get per-brand counts.
- */
-async function countContactedGrouped(
-  servedConds: SQL[],
-  groupByField: "campaignId" | "workflowSlug" | "featureSlug",
-  context: ServiceContext,
-): Promise<Map<string, number>> {
-  const groupCol = COLUMN_MAP[groupByField].served;
-
-  const rows = await db
-    .select({
-      leadId: servedLeads.leadId,
-      email: servedLeads.email,
-      brandIds: servedLeads.brandIds,
-      campaignId: servedLeads.campaignId,
-      groupKey: groupCol,
-    })
-    .from(servedLeads)
-    .where(and(...servedConds));
-
-  if (rows.length === 0) return new Map();
-
-  // Group by first brandId + campaignId for email-gateway calls
-  const callGroups = new Map<string, { brandId: string; campaignId: string; items: { leadId: string; email: string; groupKey: string }[] }>();
-  for (const row of rows) {
-    if (!row.leadId) continue;
-    const primaryBrandId = row.brandIds[0] ?? "unknown";
-    const key = `${primaryBrandId}::${row.campaignId}`;
-    if (!callGroups.has(key)) {
-      callGroups.set(key, { brandId: primaryBrandId, campaignId: row.campaignId, items: [] });
-    }
-    callGroups.get(key)!.items.push({
-      leadId: row.leadId,
-      email: row.email,
-      groupKey: row.groupKey ?? "unknown",
-    });
-  }
-
-  // Track contacted leadIds per groupBy key
-  const contactedPerGroup = new Map<string, Set<string>>();
-
-  await Promise.all(
-    Array.from(callGroups.values()).map(async (group) => {
-      const response = await checkDeliveryStatus(
-        group.brandId,
-        group.campaignId,
-        group.items.map((i) => ({ email: i.email })),
-        context,
-      );
-      if (!response) return;
-      for (const result of response.results) {
-        if (isContacted(result)) {
-          const item = group.items.find((i) => i.email === result.email);
-          if (item) {
-            if (!contactedPerGroup.has(item.groupKey)) {
-              contactedPerGroup.set(item.groupKey, new Set());
-            }
-            contactedPerGroup.get(item.groupKey)!.add(item.leadId);
-          }
-        }
-      }
-    }),
-  );
-
-  const result = new Map<string, number>();
-  for (const [key, set] of contactedPerGroup) {
-    result.set(key, set.size);
-  }
-  return result;
-}
-
-/**
- * Count contacted leads grouped by individual brand ID (unnesting brand_ids).
- */
-async function countContactedGroupedByBrand(
-  servedConds: SQL[],
-  context: ServiceContext,
-): Promise<Map<string, number>> {
-  const rows = await db
-    .select({
-      leadId: servedLeads.leadId,
-      email: servedLeads.email,
-      brandIds: servedLeads.brandIds,
-      campaignId: servedLeads.campaignId,
-    })
-    .from(servedLeads)
-    .where(and(...servedConds));
-
-  if (rows.length === 0) return new Map();
-
-  // Group by first brandId + campaignId for email-gateway calls
-  const callGroups = new Map<string, { brandId: string; campaignId: string; items: { leadId: string; email: string; brandIds: string[] }[] }>();
-  for (const row of rows) {
-    if (!row.leadId) continue;
-    const primaryBrandId = row.brandIds[0] ?? "unknown";
-    const key = `${primaryBrandId}::${row.campaignId}`;
-    if (!callGroups.has(key)) {
-      callGroups.set(key, { brandId: primaryBrandId, campaignId: row.campaignId, items: [] });
-    }
-    callGroups.get(key)!.items.push({
-      leadId: row.leadId,
-      email: row.email,
-      brandIds: row.brandIds,
-    });
-  }
-
-  // Track contacted leadIds per brand
-  const contactedPerBrand = new Map<string, Set<string>>();
-
-  await Promise.all(
-    Array.from(callGroups.values()).map(async (group) => {
-      const response = await checkDeliveryStatus(
-        group.brandId,
-        group.campaignId,
-        group.items.map((i) => ({ email: i.email })),
-        context,
-      );
-      if (!response) return;
-      for (const result of response.results) {
-        if (isContacted(result)) {
-          const item = group.items.find((i) => i.email === result.email);
-          if (item) {
-            // Attribute to each brand in the array
-            for (const bid of item.brandIds) {
-              if (!contactedPerBrand.has(bid)) {
-                contactedPerBrand.set(bid, new Set());
-              }
-              contactedPerBrand.get(bid)!.add(item.leadId);
-            }
-          }
-        }
-      }
-    }),
-  );
-
-  const result = new Map<string, number>();
-  for (const [key, set] of contactedPerBrand) {
-    result.set(key, set.size);
-  }
-  return result;
+  return { byOutreachStatus, repliesDetail: byOutreachStatus.repliesDetail };
 }
 
 const ZERO_STATS = { groups: [] };
@@ -353,16 +200,15 @@ router.get("/orgs/stats", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
     // Resolve dynasty slugs (if provided) before building conditions
     const dynastyResolved = await resolveDynastySlugs(req);
     if (dynastyResolved.emptyDynasty) {
-      // Dynasty resolved to zero slugs — return zero stats immediately
       if (groupByParam) {
         res.json(ZERO_STATS);
       } else {
         res.json({
-          served: 0,
-          contacted: 0,
+          totalLeads: 0,
+          byOutreachStatus: ZERO_RECIPIENT_STATS,
+          repliesDetail: ZERO_RECIPIENT_STATS.repliesDetail,
           buffered: 0,
           skipped: 0,
-          apollo: { enrichedLeadsCount: 0, searchCount: 0, fetchedPeopleCount: 0, totalMatchingPeople: 0 },
         });
       }
       return;
@@ -372,6 +218,13 @@ router.get("/orgs/stats", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
     const buffer = buildConditions(req, "buffer", dynastyResolved);
     const egContext = getServiceContext(req);
 
+    // Build email-gateway stats params
+    const egParams: Parameters<typeof fetchEmailGatewayStats>[0] = {};
+    if (served.brandIdStr) egParams.brandId = served.brandIdStr;
+    if (served.campaignIdStr) egParams.campaignId = served.campaignIdStr;
+    if (dynastyResolved.workflowSlugs) egParams.workflowSlugs = dynastyResolved.workflowSlugs.join(",");
+    if (dynastyResolved.featureSlugs) egParams.featureSlugs = dynastyResolved.featureSlugs.join(",");
+
     // --- Dynasty groupBy (requires reverse map) ---
     if (groupByParam === "workflowDynastySlug" || groupByParam === "featureDynastySlug") {
       const isWorkflow = groupByParam === "workflowDynastySlug";
@@ -380,14 +233,17 @@ router.get("/orgs/stats", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
       const bufferCol = COLUMN_MAP[dbField].buffer;
       const context = { orgId: req.orgId, userId: req.userId, runId: req.runId };
 
-      const [dynastyMap, servedRows, contactedMap, bufferRows] = await Promise.all([
+      // For dynasty groupBy, fetch email-gateway stats grouped by the underlying field
+      egParams.groupBy = dbField;
+
+      const [dynastyMap, servedRows, egStats, bufferRows] = await Promise.all([
         isWorkflow ? fetchWorkflowDynastyMap(context) : fetchFeatureDynastyMap(context),
         db
           .select({ key: servedCol, count: count() })
           .from(servedLeads)
           .where(and(...served.conds))
           .groupBy(servedCol),
-        countContactedGrouped(served.conds, dbField, egContext),
+        fetchEmailGatewayStats(egParams, egContext),
         db
           .select({ key: bufferCol, status: leadBuffer.status, count: count() })
           .from(leadBuffer)
@@ -395,15 +251,20 @@ router.get("/orgs/stats", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
           .groupBy(bufferCol, leadBuffer.status),
       ]);
 
-      // Aggregate by dynasty slug using reverse map
       const groups = new Map<
         string,
-        { served: number; contacted: number; buffered: number; skipped: number }
+        { totalLeads: number; byOutreachStatus: RecipientStats; repliesDetail: RecipientStats["repliesDetail"]; buffered: number; skipped: number }
       >();
 
       const getGroup = (dynastyKey: string) => {
         if (!groups.has(dynastyKey))
-          groups.set(dynastyKey, { served: 0, contacted: 0, buffered: 0, skipped: 0 });
+          groups.set(dynastyKey, {
+            totalLeads: 0,
+            byOutreachStatus: { ...ZERO_RECIPIENT_STATS, repliesDetail: { ...ZERO_RECIPIENT_STATS.repliesDetail } },
+            repliesDetail: { ...ZERO_RECIPIENT_STATS.repliesDetail },
+            buffered: 0,
+            skipped: 0,
+          });
         return groups.get(dynastyKey)!;
       };
 
@@ -411,11 +272,27 @@ router.get("/orgs/stats", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
         dynastyMap.get(slug ?? "") ?? slug ?? "unknown";
 
       for (const row of servedRows) {
-        getGroup(toDynasty(row.key)).served += row.count;
+        getGroup(toDynasty(row.key)).totalLeads += row.count;
       }
-      for (const [key, contacted] of contactedMap) {
-        getGroup(toDynasty(key)).contacted += contacted;
+
+      // Map email-gateway grouped stats to dynasty slugs
+      if ("groups" in egStats) {
+        for (const g of (egStats as EmailGatewayGroupedStatsResponse).groups) {
+          const dynastyKey = toDynasty(g.key);
+          const group = getGroup(dynastyKey);
+          const merged = mergeRecipientStats(g.broadcast, g.transactional);
+          // Accumulate (dynasty may map multiple slugs)
+          for (const k of Object.keys(merged.byOutreachStatus) as (keyof RecipientStats)[]) {
+            if (k === "repliesDetail") continue;
+            (group.byOutreachStatus[k] as number) += merged.byOutreachStatus[k] as number;
+          }
+          for (const k of Object.keys(merged.repliesDetail) as (keyof RecipientStats["repliesDetail"])[]) {
+            (group.repliesDetail[k] as number) += merged.repliesDetail[k] as number;
+            (group.byOutreachStatus.repliesDetail[k] as number) += merged.repliesDetail[k] as number;
+          }
+        }
       }
+
       for (const row of bufferRows) {
         const g = getGroup(toDynasty(row.key));
         if (row.status === "buffered") g.buffered += row.count;
@@ -433,16 +310,16 @@ router.get("/orgs/stats", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
 
     // --- brandId groupBy (unnest brand_ids) ---
     if (groupByParam === "brandId") {
-      const [servedRows, contactedMap, bufferRows] = await Promise.all([
-        // Unnest brand_ids for per-brand served counts
+      egParams.groupBy = "brandId";
+
+      const [servedRows, egStats, bufferRows] = await Promise.all([
         db.execute(sql`
           SELECT unnest(brand_ids) AS key, COUNT(*)::int AS count
           FROM served_leads
           WHERE ${and(...served.conds)}
           GROUP BY key
         `) as Promise<{ key: string; count: number }[]>,
-        countContactedGroupedByBrand(served.conds, egContext),
-        // Unnest brand_ids for per-brand buffer counts
+        fetchEmailGatewayStats(egParams, egContext),
         db.execute(sql`
           SELECT unnest(brand_ids) AS key, status, COUNT(*)::int AS count
           FROM lead_buffer
@@ -453,22 +330,35 @@ router.get("/orgs/stats", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
 
       const groups = new Map<
         string,
-        { served: number; contacted: number; buffered: number; skipped: number }
+        { totalLeads: number; byOutreachStatus: RecipientStats; repliesDetail: RecipientStats["repliesDetail"]; buffered: number; skipped: number }
       >();
 
       const getGroup = (key: string | null) => {
         const k = key ?? "unknown";
         if (!groups.has(k))
-          groups.set(k, { served: 0, contacted: 0, buffered: 0, skipped: 0 });
+          groups.set(k, {
+            totalLeads: 0,
+            byOutreachStatus: { ...ZERO_RECIPIENT_STATS, repliesDetail: { ...ZERO_RECIPIENT_STATS.repliesDetail } },
+            repliesDetail: { ...ZERO_RECIPIENT_STATS.repliesDetail },
+            buffered: 0,
+            skipped: 0,
+          });
         return groups.get(k)!;
       };
 
       for (const row of servedRows) {
-        getGroup(row.key).served = row.count;
+        getGroup(row.key).totalLeads = row.count;
       }
-      for (const [key, contacted] of contactedMap) {
-        getGroup(key).contacted = contacted;
+
+      if ("groups" in egStats) {
+        for (const g of (egStats as EmailGatewayGroupedStatsResponse).groups) {
+          const group = getGroup(g.key);
+          const merged = mergeRecipientStats(g.broadcast, g.transactional);
+          group.byOutreachStatus = merged.byOutreachStatus;
+          group.repliesDetail = merged.repliesDetail;
+        }
       }
+
       for (const row of bufferRows) {
         const g = getGroup(row.key);
         if (row.status === "buffered") g.buffered = row.count;
@@ -490,13 +380,15 @@ router.get("/orgs/stats", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
       const servedCol = COLUMN_MAP[field].served;
       const bufferCol = COLUMN_MAP[field].buffer;
 
-      const [servedRows, contactedMap, bufferRows] = await Promise.all([
+      egParams.groupBy = EG_GROUP_BY_MAP[field] ?? field;
+
+      const [servedRows, egStats, bufferRows] = await Promise.all([
         db
           .select({ key: servedCol, count: count() })
           .from(servedLeads)
           .where(and(...served.conds))
           .groupBy(servedCol),
-        countContactedGrouped(served.conds, field, egContext),
+        fetchEmailGatewayStats(egParams, egContext),
         db
           .select({ key: bufferCol, status: leadBuffer.status, count: count() })
           .from(leadBuffer)
@@ -504,29 +396,41 @@ router.get("/orgs/stats", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
           .groupBy(bufferCol, leadBuffer.status),
       ]);
 
-      // Merge into a map keyed by groupBy value
       const groups = new Map<
         string,
-        { served: number; contacted: number; buffered: number; skipped: number }
+        { totalLeads: number; byOutreachStatus: RecipientStats; repliesDetail: RecipientStats["repliesDetail"]; buffered: number; skipped: number }
       >();
 
       const getGroup = (key: string | null) => {
         const k = key ?? "unknown";
         if (!groups.has(k))
-          groups.set(k, { served: 0, contacted: 0, buffered: 0, skipped: 0 });
+          groups.set(k, {
+            totalLeads: 0,
+            byOutreachStatus: { ...ZERO_RECIPIENT_STATS, repliesDetail: { ...ZERO_RECIPIENT_STATS.repliesDetail } },
+            repliesDetail: { ...ZERO_RECIPIENT_STATS.repliesDetail },
+            buffered: 0,
+            skipped: 0,
+          });
         return groups.get(k)!;
       };
 
       for (const row of servedRows) {
-        getGroup(row.key).served = row.count;
+        getGroup(row.key).totalLeads = row.count;
       }
-      for (const [key, contacted] of contactedMap) {
-        getGroup(key).contacted = contacted;
+
+      if ("groups" in egStats) {
+        for (const g of (egStats as EmailGatewayGroupedStatsResponse).groups) {
+          const group = getGroup(g.key);
+          const merged = mergeRecipientStats(g.broadcast, g.transactional);
+          group.byOutreachStatus = merged.byOutreachStatus;
+          group.repliesDetail = merged.repliesDetail;
+        }
       }
+
       for (const row of bufferRows) {
         const g = getGroup(row.key);
-        if (row.status === "buffered") g.buffered = row.count;
-        if (row.status === "skipped") g.skipped = row.count;
+        if (row.status === "buffered") g.buffered += row.count;
+        if (row.status === "skipped") g.skipped += row.count;
       }
 
       res.json({
@@ -539,40 +443,33 @@ router.get("/orgs/stats", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
     }
 
     // --- Flat response ---
-    const apolloFilters: Record<string, unknown> = {};
-    if (served.brandIdStr) apolloFilters.brandId = served.brandIdStr;
-    if (served.campaignIdStr) apolloFilters.campaignId = served.campaignIdStr;
-    if (served.runIdList.length > 0) apolloFilters.runIds = served.runIdList;
-
-    const [servedResult, contacted, bufferRows, apollo] = await Promise.all([
+    const [servedResult, egStats, bufferRows] = await Promise.all([
       db
         .select({ count: count() })
         .from(servedLeads)
         .where(and(...served.conds))
         .then(([r]) => r),
-      countContacted(served.conds, egContext),
+      fetchEmailGatewayStats(egParams, egContext),
       db
         .select({ status: leadBuffer.status, count: count() })
         .from(leadBuffer)
         .where(and(...buffer.conds))
         .groupBy(leadBuffer.status),
-      fetchApolloStats(
-        apolloFilters as Parameters<typeof fetchApolloStats>[0],
-        served.orgIdStr ?? req.orgId,
-        egContext,
-      ),
     ]);
 
     const bufferByStatus = Object.fromEntries(
       bufferRows.map((r) => [r.status, r.count]),
     );
 
+    const egFlat = egStats as EmailGatewayStatsResponse;
+    const merged = mergeRecipientStats(egFlat.broadcast, egFlat.transactional);
+
     res.json({
-      served: servedResult?.count ?? 0,
-      contacted,
+      totalLeads: servedResult?.count ?? 0,
+      byOutreachStatus: merged.byOutreachStatus,
+      repliesDetail: merged.repliesDetail,
       buffered: bufferByStatus["buffered"] ?? 0,
       skipped: bufferByStatus["skipped"] ?? 0,
-      apollo,
     });
   } catch (error) {
     console.error("[lead-service] Stats error:", error);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -278,7 +278,12 @@ const LeadDetailSchema = z
     leadId: z.string().uuid().nullable(),
     namespace: z.string(),
     email: z.string(),
-    externalId: z.string().nullable(),
+    apolloPersonId: z.string().nullable().openapi({
+      description: "Apollo person ID from enrichment",
+    }),
+    emailStatus: z.string().nullable().openapi({
+      description: "Email verification status from Apollo (verified, extrapolated, etc.)",
+    }),
     metadata: ApolloPersonDataSchema.nullable(),
     parentRunId: z.string().nullable(),
     runId: z.string().nullable(),
@@ -289,8 +294,12 @@ const LeadDetailSchema = z
     servedAt: z.string(),
     enrichment: ApolloPersonDataSchema.nullable(),
     contacted: z.boolean(),
+    sent: z.boolean(),
     delivered: z.boolean(),
+    opened: z.boolean(),
+    clicked: z.boolean(),
     bounced: z.boolean(),
+    unsubscribed: z.boolean(),
     replied: z
       .boolean()
       .openapi({ description: "Whether the lead replied (any reply, regardless of sentiment)" }),
@@ -306,6 +315,12 @@ const LeadDetailSchema = z
           "null when no reply detected.",
       }),
     lastDeliveredAt: z.string().nullable(),
+    global: z.object({
+      bounced: z.boolean(),
+      unsubscribed: z.boolean(),
+    }).openapi({
+      description: "Global-scope status (across all brands/campaigns). bounced and unsubscribed are global flags.",
+    }),
   })
   .openapi("LeadDetail");
 
@@ -317,27 +332,48 @@ const LeadsResponseSchema = z
 
 // --- Stats ---
 
-const ApolloStatsSchema = z.object({
-  enrichedLeadsCount: z.number(),
-  searchCount: z.number(),
-  fetchedPeopleCount: z.number(),
-  totalMatchingPeople: z.number(),
+const RepliesDetailSchema = z.object({
+  interested: z.number(),
+  meetingBooked: z.number(),
+  closed: z.number(),
+  notInterested: z.number(),
+  wrongPerson: z.number(),
+  unsubscribe: z.number(),
+  neutral: z.number(),
+  autoReply: z.number(),
+  outOfOffice: z.number(),
+});
+
+const ByOutreachStatusSchema = z.object({
+  contacted: z.number(),
+  sent: z.number(),
+  delivered: z.number(),
+  opened: z.number(),
+  bounced: z.number(),
+  clicked: z.number(),
+  unsubscribed: z.number(),
+  repliesPositive: z.number(),
+  repliesNegative: z.number(),
+  repliesNeutral: z.number(),
+  repliesAutoReply: z.number(),
+  repliesDetail: RepliesDetailSchema,
 });
 
 const StatsResponseSchema = z
   .object({
-    served: z.number(),
-    contacted: z.number(),
+    totalLeads: z.number(),
+    byOutreachStatus: ByOutreachStatusSchema,
+    repliesDetail: RepliesDetailSchema,
     buffered: z.number(),
     skipped: z.number(),
-    apollo: ApolloStatsSchema,
   })
   .openapi("StatsResponse");
 
 const StatsGroupSchema = z.object({
   key: z.string(),
-  served: z.number(),
-  contacted: z.number(),
+  totalLeads: z.number(),
+  byOutreachStatus: ByOutreachStatusSchema,
+  repliesDetail: RepliesDetailSchema,
   buffered: z.number(),
   skipped: z.number(),
 });
@@ -433,8 +469,8 @@ registry.registerPath({
   path: "/orgs/leads",
   summary: "List served leads with enrichment and delivery status",
   description:
-    "Returns served leads with Apollo enrichment data and delivery status " +
-    "(contacted, delivered, bounced, replied, replyClassification, lastDeliveredAt). " +
+    "Returns served leads with Apollo enrichment data, apolloPersonId, emailStatus, and full delivery status " +
+    "(contacted, sent, delivered, opened, clicked, bounced, unsubscribed, replied, replyClassification, lastDeliveredAt, global). " +
     "Status is fetched from email-gateway when brandId or campaignId is provided. " +
     "With campaignId: campaign-scoped status. With brandId only: brand-scoped (cross-campaign). " +
     "Without either: status fields default to false/null.",
@@ -479,7 +515,7 @@ registry.registerPath({
   path: "/orgs/stats",
   summary: "Get lead stats by status",
   description:
-    "Returns counts of leads by status: served (delivered with verified email), contacted (unique leads with at least one successful email send), buffered (awaiting enrichment), and skipped (no email found).",
+    "Returns lead stats with outreach status from email-gateway. totalLeads = served leads count, byOutreachStatus = full recipientStats (contacted, sent, delivered, opened, clicked, bounced, unsubscribed, replies*), repliesDetail = granular reply breakdown, buffered/skipped = buffer counts.",
   parameters: [
     ...AuthHeaders,
     {
@@ -581,7 +617,7 @@ registry.registerPath({
   responses: {
     200: {
       description:
-        "Lead stats by status. Without groupBy: flat stats with Apollo metrics. With groupBy: grouped stats array.",
+        "Lead stats with outreach status. Without groupBy: flat response with totalLeads, byOutreachStatus, repliesDetail, buffered, skipped. With groupBy: grouped stats array.",
       content: {
         "application/json": {
           schema: z.union([StatsResponseSchema, StatsGroupedResponseSchema]),

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -339,7 +339,7 @@ describe("API Integration Tests", { timeout: 30000 }, () => {
       await seedBuffer({
         campaignId: "campaign-leads",
         brandId: "brand-leads",
-        leads: [{ email: "diana@example.com", externalId: "apollo-1", data: richData }],
+        leads: [{ email: "diana@example.com", apolloPersonId: "apollo-1", data: richData }],
       });
 
       // Pull it to move to served_leads

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -44,14 +44,14 @@ export function getAuthHeaders(extra?: { campaignId?: string; brandId?: string; 
 export async function seedBuffer(params: {
   campaignId: string;
   brandId: string;
-  leads: Array<{ email: string; externalId?: string; data?: unknown }>;
+  leads: Array<{ email: string; apolloPersonId?: string; data?: unknown }>;
 }): Promise<void> {
   for (const lead of params.leads) {
     await db.insert(leadBuffer).values({
       namespace: "apollo",
       campaignId: params.campaignId,
       email: lead.email,
-      externalId: lead.externalId ?? null,
+      apolloPersonId: lead.apolloPersonId ?? null,
       data: lead.data ?? null,
       status: "buffered",
       pushRunId: null,

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -79,7 +79,7 @@ function toClaimedRow(row: {
   namespace: string;
   campaignId: string;
   email: string;
-  externalId: string | null;
+  apolloPersonId: string | null;
   data: unknown;
   status?: string;
   pushRunId?: string | null;
@@ -93,7 +93,7 @@ function toClaimedRow(row: {
     namespace: row.namespace,
     campaign_id: row.campaignId,
     email: row.email,
-    external_id: row.externalId,
+    apollo_person_id: row.apolloPersonId,
     data: row.data,
     status: "claimed",
     push_run_id: row.pushRunId ?? null,
@@ -160,7 +160,7 @@ describe("buffer", () => {
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "hire@example.com",
-          externalId: "apollo-1",
+          apolloPersonId: "apollo-1",
           data: { firstName: "Jane", email: "hire@example.com" },
           brandIds: ["brand-1"],
           orgId: "org-1",
@@ -217,7 +217,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "alice@acme.com",
-        externalId: "e-1",
+        apolloPersonId: "e-1",
         data: { name: "Alice" },
         brandIds: ["brand-1"],
         orgId: "org-1",
@@ -252,7 +252,7 @@ describe("buffer", () => {
       expect(result.found).toBe(true);
       expect(result.lead?.leadId).toBe("lead-abc");
       expect(result.lead?.email).toBe("alice@acme.com");
-      expect(result.lead?.apolloPersonId).toBeNull();
+      expect(result.lead?.apolloPersonId).toBe("e-1");
       expect(result.lead?.data).toEqual({ name: "Alice", email: "alice@acme.com" });
     });
 
@@ -269,7 +269,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "svitlana@hashtagweb3.com",
-        externalId: "e-1",
+        apolloPersonId: "e-1",
         data: apolloData,
         brandIds: ["brand-1"],
         orgId: "org-1",
@@ -307,7 +307,7 @@ describe("buffer", () => {
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "alice@acme.com",
-          externalId: "e-1",
+          apolloPersonId: "e-1",
           data: { name: "Alice" },
           brandIds: ["brand-1"],
           orgId: "org-1",
@@ -318,7 +318,7 @@ describe("buffer", () => {
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "bob@acme.com",
-          externalId: "e-2",
+          apolloPersonId: "e-2",
           data: { name: "Bob" },
           brandIds: ["brand-1"],
           orgId: "org-1",
@@ -357,7 +357,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "new-lead@example.com",
-        externalId: "apollo-1",
+        apolloPersonId: "apollo-1",
         data: { firstName: "New" },
         brandIds: ["brand-1"],
         orgId: "org-1",
@@ -413,7 +413,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "ctx-lead@example.com",
-        externalId: "apollo-ctx",
+        apolloPersonId: "apollo-ctx",
         data: { firstName: "Ctx" },
         brandIds: ["brand-1"],
         orgId: "org-1",
@@ -482,7 +482,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "conv@example.com",
-        externalId: "apollo-conv",
+        apolloPersonId: "apollo-conv",
         data: { firstName: "Conv" },
         brandIds: ["brand-1"],
         orgId: "org-1",
@@ -579,7 +579,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "briannah@example.com",
-        externalId: "apollo-enr-1",
+        apolloPersonId: "apollo-enr-1",
         data: {
           id: "apollo-enr-1",
           firstName: "Briannah",
@@ -688,7 +688,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "",
-        externalId: "apollo-person-1",
+        apolloPersonId: "apollo-person-1",
         data: { firstName: "Ray" },
         brandIds: ["brand-1"],
         orgId: "org-1",
@@ -744,7 +744,7 @@ describe("buffer", () => {
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "",
-          externalId: "known-no-email",
+          apolloPersonId: "known-no-email",
           data: { firstName: "Ghost" },
           brandIds: ["brand-1"],
           orgId: "org-1",
@@ -755,7 +755,7 @@ describe("buffer", () => {
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "bob@acme.com",
-          externalId: "e-2",
+          apolloPersonId: "e-2",
           data: { name: "Bob" },
           brandIds: ["brand-1"],
           orgId: "org-1",
@@ -800,7 +800,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "",
-        externalId: "apollo-wf-1",
+        apolloPersonId: "apollo-wf-1",
         data: { firstName: "Workflow" },
         brandIds: ["brand-1"],
         orgId: "org-1",
@@ -872,7 +872,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "torian@theorion.com",
-        externalId: "e-1",
+        apolloPersonId: "e-1",
         data: { firstName: "Torian", email: null, title: "Director" },
         brandIds: ["brand-1"],
         orgId: "org-1",
@@ -907,14 +907,14 @@ describe("buffer", () => {
       expect(data.title).toBe("Director");
     });
 
-    it("skips buffer rows with no email and no externalId (never returns found: true with empty email)", async () => {
+    it("skips buffer rows with no email and no apolloPersonId (never returns found: true with empty email)", async () => {
       pgSqlMock
         .mockResolvedValueOnce([toClaimedRow({
           id: "buf-no-email",
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "",
-          externalId: null,
+          apolloPersonId: null,
           data: { name: "Ghost" },
           brandIds: ["brand-1"],
           orgId: "org-1",
@@ -946,7 +946,7 @@ describe("buffer", () => {
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "",
-          externalId: "apollo-no-email",
+          apolloPersonId: "apollo-no-email",
           data: { name: "NoEmail" },
           brandIds: ["brand-1"],
           orgId: "org-1",
@@ -957,7 +957,7 @@ describe("buffer", () => {
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "good@acme.com",
-          externalId: "e-good",
+          apolloPersonId: "e-good",
           data: { name: "Good" },
           brandIds: ["brand-1"],
           orgId: "org-1",
@@ -999,7 +999,7 @@ describe("buffer", () => {
         namespace: "campaign-1",
         campaignId: "campaign-1",
         email: "alice@acme.com",
-        externalId: "e-1",
+        apolloPersonId: "e-1",
         data: { name: "Alice" },
         brandIds: ["brand-1"],
         orgId: "org-1",
@@ -1031,8 +1031,8 @@ describe("buffer", () => {
       expect(true).toBe(true);
     });
 
-    it("skips lead via brand dedup by externalId BEFORE calling apolloEnrich (no wasted credits)", async () => {
-      // Lead has no email (needs enrichment) but externalId is already served for this brand.
+    it("skips lead via brand dedup by apolloPersonId BEFORE calling apolloEnrich (no wasted credits)", async () => {
+      // Lead has no email (needs enrichment) but apolloPersonId is already served for this brand.
       // pullNext should skip it WITHOUT calling apolloEnrich.
       pgSqlMock
         .mockResolvedValueOnce([toClaimedRow({
@@ -1040,7 +1040,7 @@ describe("buffer", () => {
           namespace: "apollo",
           campaignId: "campaign-1",
           email: "",
-          externalId: "already-served-person",
+          apolloPersonId: "already-served-person",
           data: { firstName: "Dupe" },
           brandIds: ["brand-1"],
           orgId: "org-1",
@@ -1051,16 +1051,16 @@ describe("buffer", () => {
           namespace: "apollo",
           campaignId: "campaign-1",
           email: "good@acme.com",
-          externalId: "fresh-person",
+          apolloPersonId: "fresh-person",
           data: { firstName: "Good" },
           brandIds: ["brand-1"],
           orgId: "org-1",
           userId: null,
         })]);
 
-      // First lead: brand dedup blocks by externalId
+      // First lead: brand dedup blocks by apolloPersonId
       vi.mocked(isAlreadyServedForBrand)
-        .mockResolvedValueOnce({ blocked: true, reason: "already served for overlapping brand (matched on external_id)" })
+        .mockResolvedValueOnce({ blocked: true, reason: "already served for overlapping brand (matched on apollo_person_id)" })
         .mockResolvedValueOnce({ blocked: false });
 
       vi.mocked(resolveOrCreateLead).mockResolvedValue({ leadId: "lead-good", isNew: true });
@@ -1080,9 +1080,9 @@ describe("buffer", () => {
       expect(result.lead?.email).toBe("good@acme.com");
       // Critical: apolloEnrich must NOT have been called for the first lead
       expect(vi.mocked(apolloEnrich)).not.toHaveBeenCalled();
-      // Brand dedup was called with externalId before enrichment
+      // Brand dedup was called with apolloPersonId before enrichment
       expect(vi.mocked(isAlreadyServedForBrand).mock.calls[0][0]).toEqual(
-        expect.objectContaining({ externalId: "already-served-person" })
+        expect.objectContaining({ apolloPersonId: "already-served-person" })
       );
     });
 
@@ -1096,7 +1096,7 @@ describe("buffer", () => {
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "jserra@elkisconstruction.com",
-          externalId: "e-dup",
+          apolloPersonId: "e-dup",
           data: { name: "J Serra" },
           brandIds: ["brand-1"],
           orgId: "org-1",
@@ -1107,7 +1107,7 @@ describe("buffer", () => {
           namespace: "campaign-1",
           campaignId: "campaign-1",
           email: "unique@other.com",
-          externalId: "e-next",
+          apolloPersonId: "e-next",
           data: { name: "Unique" },
           brandIds: ["brand-1"],
           orgId: "org-1",
@@ -1151,7 +1151,7 @@ describe("buffer", () => {
           namespace: "apollo",
           campaignId: "campaign-uuid-123",
           email: "ns-test@example.com",
-          externalId: "apollo-ns-1",
+          apolloPersonId: "apollo-ns-1",
           data: { firstName: "NsTest" },
           brandIds: ["brand-1"],
           orgId: "org-1",
@@ -1201,7 +1201,7 @@ describe("buffer", () => {
         namespace: "apollo",
         campaignId: "campaign-uuid-789",
         email: "served@example.com",
-        externalId: "e-ms-1",
+        apolloPersonId: "e-ms-1",
         data: { name: "Served" },
         brandIds: ["brand-1"],
         orgId: "org-1",

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -1031,6 +1031,61 @@ describe("buffer", () => {
       expect(true).toBe(true);
     });
 
+    it("skips lead via brand dedup by externalId BEFORE calling apolloEnrich (no wasted credits)", async () => {
+      // Lead has no email (needs enrichment) but externalId is already served for this brand.
+      // pullNext should skip it WITHOUT calling apolloEnrich.
+      pgSqlMock
+        .mockResolvedValueOnce([toClaimedRow({
+          id: "buf-predeup",
+          namespace: "apollo",
+          campaignId: "campaign-1",
+          email: "",
+          externalId: "already-served-person",
+          data: { firstName: "Dupe" },
+          brandIds: ["brand-1"],
+          orgId: "org-1",
+          userId: null,
+        })])
+        .mockResolvedValueOnce([toClaimedRow({
+          id: "buf-good",
+          namespace: "apollo",
+          campaignId: "campaign-1",
+          email: "good@acme.com",
+          externalId: "fresh-person",
+          data: { firstName: "Good" },
+          brandIds: ["brand-1"],
+          orgId: "org-1",
+          userId: null,
+        })]);
+
+      // First lead: brand dedup blocks by externalId
+      vi.mocked(isAlreadyServedForBrand)
+        .mockResolvedValueOnce({ blocked: true, reason: "already served for overlapping brand (matched on external_id)" })
+        .mockResolvedValueOnce({ blocked: false });
+
+      vi.mocked(resolveOrCreateLead).mockResolvedValue({ leadId: "lead-good", isNew: true });
+
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+      const result = await pullNext({
+        orgId: "org-1",
+        campaignId: "campaign-1",
+        brandIds: ["brand-1"],
+      });
+
+      expect(result.found).toBe(true);
+      expect(result.lead?.email).toBe("good@acme.com");
+      // Critical: apolloEnrich must NOT have been called for the first lead
+      expect(vi.mocked(apolloEnrich)).not.toHaveBeenCalled();
+      // Brand dedup was called with externalId before enrichment
+      expect(vi.mocked(isAlreadyServedForBrand).mock.calls[0][0]).toEqual(
+        expect.objectContaining({ externalId: "already-served-person" })
+      );
+    });
+
     it("skips lead when markServed returns inserted: false (race condition dedup)", async () => {
       // Regression test: two concurrent pullNext calls claim different rows
       // but both have the same email. The second call's markServed returns

--- a/tests/unit/db-indexes.test.ts
+++ b/tests/unit/db-indexes.test.ts
@@ -16,10 +16,10 @@ describe("lead_buffer indexes", () => {
     expect(idx.columns).toEqual(["org_id", "campaign_id", "namespace", "status"]);
   });
 
-  it("has index covering isInBuffer query (org_id, campaign_id, external_id)", () => {
+  it("has index covering isInBuffer query (org_id, campaign_id, apollo_person_id)", () => {
     expect(indexNames).toContain("idx_buffer_org_campaign_extid");
     const idx = indexes.find((i) => i.name === "idx_buffer_org_campaign_extid")!;
-    expect(idx.columns).toEqual(["org_id", "campaign_id", "external_id"]);
+    expect(idx.columns).toEqual(["org_id", "campaign_id", "apollo_person_id"]);
   });
 
   it("does NOT have the old suboptimal index (org_id, namespace, status)", () => {

--- a/tests/unit/dedup.test.ts
+++ b/tests/unit/dedup.test.ts
@@ -344,6 +344,28 @@ describe("dedup", () => {
       );
     });
 
+    it("stores parentRunId when provided", async () => {
+      const returningMock = vi.fn().mockResolvedValue([{ id: "uuid-1" }]);
+      const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      await markServed({
+        orgId: "org-1",
+        namespace: "apollo",
+        brandIds: ["brand-1"],
+        campaignId: "campaign-1",
+        email: "alice@acme.com",
+        leadId: "lead-uuid-1",
+        runId: "child-run-1",
+        parentRunId: "caller-run-1",
+      });
+
+      expect(valuesMock).toHaveBeenCalledWith(
+        expect.objectContaining({ parentRunId: "caller-run-1" })
+      );
+    });
+
     it("stores multiple brandIds in the insert", async () => {
       const returningMock = vi.fn().mockResolvedValue([{ id: "uuid-1" }]);
       const onConflictMock = vi.fn().mockReturnValue({ returning: returningMock });

--- a/tests/unit/dedup.test.ts
+++ b/tests/unit/dedup.test.ts
@@ -132,7 +132,7 @@ describe("dedup", () => {
 
     it("returns blocked=true with reason when email matches", async () => {
       vi.mocked(pgSql.unsafe).mockResolvedValue([
-        { lead_id: null, email: "alice@acme.com", external_id: null },
+        { lead_id: null, email: "alice@acme.com", apollo_person_id: null },
       ] as never);
 
       const result = await isAlreadyServedForBrand({
@@ -147,7 +147,7 @@ describe("dedup", () => {
 
     it("returns blocked=true when leadId matches", async () => {
       vi.mocked(pgSql.unsafe).mockResolvedValue([
-        { lead_id: "lead-1", email: "other@acme.com", external_id: null },
+        { lead_id: "lead-1", email: "other@acme.com", apollo_person_id: null },
       ] as never);
 
       const result = await isAlreadyServedForBrand({
@@ -161,19 +161,32 @@ describe("dedup", () => {
       expect(result.reason).toContain("lead_id");
     });
 
-    it("returns blocked=true when externalId matches", async () => {
+    it("returns blocked=true when apolloPersonId matches", async () => {
       vi.mocked(pgSql.unsafe).mockResolvedValue([
-        { lead_id: null, email: "other@acme.com", external_id: "apollo-123" },
+        { lead_id: null, email: "other@acme.com", apollo_person_id: "apollo-123" },
       ] as never);
 
       const result = await isAlreadyServedForBrand({
         orgId: "org-1",
         brandIds: ["brand-1"],
-        externalId: "apollo-123",
+        apolloPersonId: "apollo-123",
       });
 
       expect(result.blocked).toBe(true);
-      expect(result.reason).toContain("external_id");
+      expect(result.reason).toContain("apollo_person_id");
+    });
+
+    it("includes 6-month TTL in the query", async () => {
+      vi.mocked(pgSql.unsafe).mockResolvedValue([] as never);
+
+      await isAlreadyServedForBrand({
+        orgId: "org-1",
+        brandIds: ["brand-1"],
+        email: "alice@acme.com",
+      });
+
+      const call = vi.mocked(pgSql.unsafe).mock.calls[0];
+      expect(call[0]).toContain("served_at >= now() - interval '6 months'");
     });
 
     it("uses brand_ids && overlap in the query", async () => {
@@ -219,13 +232,13 @@ describe("dedup", () => {
         brandIds: ["brand-1"],
         leadId: "lead-1",
         email: "alice@acme.com",
-        externalId: "apollo-123",
+        apolloPersonId: "apollo-123",
       });
 
       const call = vi.mocked(pgSql.unsafe).mock.calls[0];
       expect(call[0]).toContain("lead_id = $3");
       expect(call[0]).toContain("email = $4");
-      expect(call[0]).toContain("external_id = $5");
+      expect(call[0]).toContain("apollo_person_id = $5");
       expect(call[0]).toContain(" OR ");
     });
   });
@@ -300,7 +313,7 @@ describe("dedup", () => {
         campaignId: "campaign-1",
         email: "alice@acme.com",
         leadId: "lead-uuid-1",
-        externalId: "enrich-123",
+        apolloPersonId: "enrich-123",
         runId: "child-run-1",
       });
 

--- a/tests/unit/email-gateway-client.test.ts
+++ b/tests/unit/email-gateway-client.test.ts
@@ -30,7 +30,7 @@ describe("email-gateway-client", () => {
               campaign: { contacted: true, delivered: true, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
               brand: { contacted: true, delivered: true, opened: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
               global: {
-                email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
+                email: { bounced: false, unsubscribed: false },
               },
             },
           },
@@ -74,36 +74,28 @@ describe("email-gateway-client", () => {
       expect(body.items).toEqual([{ email: "alice@acme.com" }]);
     });
 
-    it("returns null on non-200 response", async () => {
+    it("throws on non-200 response (fail loud)", async () => {
       mockFetch.mockResolvedValue({
         ok: false,
         status: 500,
         text: () => Promise.resolve("Internal server error"),
       });
 
-      const result = await checkDeliveryStatus("brand-1", "campaign-1", [
-        { email: "alice@acme.com" },
-      ]);
-
-      expect(result).toBeNull();
+      await expect(
+        checkDeliveryStatus("brand-1", "campaign-1", [
+          { email: "alice@acme.com" },
+        ])
+      ).rejects.toThrow("Status check failed: 500");
     });
 
-    it("returns null and logs warn on connection error (fetch failed)", async () => {
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    it("throws on connection error (fail loud)", async () => {
       mockFetch.mockRejectedValue(new TypeError("fetch failed"));
 
-      const result = await checkDeliveryStatus("brand-1", "campaign-1", [
-        { email: "alice@acme.com" },
-      ]);
-
-      expect(result).toBeNull();
-      expect(warnSpy).toHaveBeenCalledWith(
-        "[email-gateway-client] email-gateway unreachable, skipping delivery check"
-      );
-      expect(errorSpy).not.toHaveBeenCalled();
-      warnSpy.mockRestore();
-      errorSpy.mockRestore();
+      await expect(
+        checkDeliveryStatus("brand-1", "campaign-1", [
+          { email: "alice@acme.com" },
+        ])
+      ).rejects.toThrow("fetch failed");
     });
 
     it("returns empty results for empty items array", async () => {
@@ -136,11 +128,10 @@ describe("email-gateway-client", () => {
       const secondBatch = JSON.parse(mockFetch.mock.calls[1][1].body);
       expect(firstBatch.items).toHaveLength(100);
       expect(secondBatch.items).toHaveLength(50);
-      expect(result!.results).toHaveLength(150);
+      expect(result.results).toHaveLength(150);
     });
 
-    it("returns null if any batch fails", async () => {
-      vi.spyOn(console, "error").mockImplementation(() => {});
+    it("throws if any batch fails (fail loud)", async () => {
       const items = Array.from({ length: 150 }, (_, i) => ({
         email: `user${i}@acme.com`,
       }));
@@ -157,40 +148,20 @@ describe("email-gateway-client", () => {
         };
       });
 
-      const result = await checkDeliveryStatus("brand-1", "campaign-1", items);
-      expect(result).toBeNull();
-      vi.restoreAllMocks();
-    });
-
-    it("returns null and logs error on unexpected errors", async () => {
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const unexpectedError = new Error("something unexpected");
-      mockFetch.mockRejectedValue(unexpectedError);
-
-      const result = await checkDeliveryStatus("brand-1", "campaign-1", [
-        { email: "alice@acme.com" },
-      ]);
-
-      expect(result).toBeNull();
-      expect(errorSpy).toHaveBeenCalledWith(
-        "[email-gateway-client] Status check error:",
-        unexpectedError
-      );
-      expect(warnSpy).not.toHaveBeenCalled();
-      warnSpy.mockRestore();
-      errorSpy.mockRestore();
+      await expect(
+        checkDeliveryStatus("brand-1", "campaign-1", items)
+      ).rejects.toThrow("Status check failed: 500");
     });
   });
 
   describe("isContacted", () => {
     const emptyScoped: ScopedStatus = {
-      contacted: false, delivered: false, opened: false, replied: false,
+      contacted: false, sent: false, delivered: false, opened: false, clicked: false, replied: false,
       replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null,
     };
 
     const emptyGlobal = {
-      email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+      email: { bounced: false, unsubscribed: false },
     };
 
     const emptyProvider: ProviderStatus = {
@@ -209,7 +180,7 @@ describe("email-gateway-client", () => {
     });
 
     it("returns false when no providers present", () => {
-      const result: StatusResult = { leadId: "lead-1", email: "alice@acme.com" };
+      const result: StatusResult = { email: "alice@acme.com" };
       expect(isContacted(result)).toBe(false);
     });
 
@@ -230,32 +201,6 @@ describe("email-gateway-client", () => {
         broadcast: {
           ...emptyProvider,
           brand: { ...emptyScoped, contacted: true, delivered: true },
-        },
-      };
-      expect(isContacted(result)).toBe(true);
-    });
-
-    it("returns true when transactional global email is contacted", () => {
-      const result: StatusResult = {
-        email: "alice@acme.com",
-        transactional: {
-          ...emptyProvider,
-          global: {
-            email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
-          },
-        },
-      };
-      expect(isContacted(result)).toBe(true);
-    });
-
-    it("returns true when broadcast global email is contacted", () => {
-      const result: StatusResult = {
-        email: "alice@acme.com",
-        broadcast: {
-          ...emptyProvider,
-          global: {
-            email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: "2024-01-01" },
-          },
         },
       };
       expect(isContacted(result)).toBe(true);
@@ -290,12 +235,12 @@ describe("email-gateway-client", () => {
 
   describe("checkEmailStatus", () => {
     const emptyScoped: ScopedStatus = {
-      contacted: false, delivered: false, opened: false, replied: false,
+      contacted: false, sent: false, delivered: false, opened: false, clicked: false, replied: false,
       replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null,
     };
 
     const emptyGlobal = {
-      email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+      email: { bounced: false, unsubscribed: false },
     };
 
     const emptyProvider: ProviderStatus = {
@@ -319,7 +264,7 @@ describe("email-gateway-client", () => {
         broadcast: {
           ...emptyProvider,
           global: {
-            email: { contacted: false, delivered: false, bounced: true, unsubscribed: false, lastDeliveredAt: null },
+            email: { bounced: true, unsubscribed: false },
           },
         },
       };
@@ -332,7 +277,7 @@ describe("email-gateway-client", () => {
         transactional: {
           ...emptyProvider,
           global: {
-            email: { contacted: false, delivered: false, bounced: false, unsubscribed: true, lastDeliveredAt: null },
+            email: { bounced: false, unsubscribed: true },
           },
         },
       };
@@ -346,7 +291,7 @@ describe("email-gateway-client", () => {
           campaign: { ...emptyScoped, contacted: true },
           brand: emptyScoped,
           global: {
-            email: { contacted: false, delivered: false, bounced: true, unsubscribed: false, lastDeliveredAt: null },
+            email: { bounced: true, unsubscribed: false },
           },
         },
       };

--- a/tests/unit/leads.test.ts
+++ b/tests/unit/leads.test.ts
@@ -55,13 +55,14 @@ function makeServedLead(overrides: Partial<{
   brandIds: string[];
   campaignId: string;
   metadata: unknown;
+  apolloPersonId: string | null;
 }> = {}) {
   return {
     id: "row-1",
     leadId: "lead-1",
     namespace: "apollo",
     email: "alice@acme.com",
-    externalId: null,
+    apolloPersonId: null,
     metadata: null,
     parentRunId: null,
     runId: null,
@@ -79,13 +80,13 @@ function makeBroadcastStatus(overrides: {
   brand?: Record<string, unknown>;
 }) {
   const defaultScoped = {
-    contacted: false, delivered: false, opened: false, replied: false,
+    contacted: false, sent: false, delivered: false, opened: false, clicked: false, replied: false,
     replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null,
   };
   return {
     campaign: { ...defaultScoped, ...overrides.campaign },
     brand: { ...defaultScoped, ...overrides.brand },
-    global: { email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null } },
+    global: { email: { bounced: false, unsubscribed: false } },
   };
 }
 
@@ -161,10 +162,10 @@ describe("GET /orgs/leads", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFindMany.mockResolvedValue([]);
-    mockCheckDeliveryStatus.mockResolvedValue(null);
+    mockCheckDeliveryStatus.mockResolvedValue({ results: [] });
   });
 
-  it("returns leads with default status when no brandId/campaignId", async () => {
+  it("returns leads with default status including new fields when no brandId/campaignId", async () => {
     mockFindMany.mockResolvedValue([makeServedLead()]);
 
     const app = createApp();
@@ -173,11 +174,18 @@ describe("GET /orgs/leads", () => {
     expect(res.body.leads).toHaveLength(1);
     expect(res.body.leads[0]).toMatchObject({
       contacted: false,
+      sent: false,
       delivered: false,
+      opened: false,
+      clicked: false,
       bounced: false,
+      unsubscribed: false,
       replied: false,
       replyClassification: null,
       lastDeliveredAt: null,
+      global: { bounced: false, unsubscribed: false },
+      apolloPersonId: null,
+      emailStatus: null,
     });
     expect(mockCheckDeliveryStatus).not.toHaveBeenCalled();
   });
@@ -193,7 +201,7 @@ describe("GET /orgs/leads", () => {
         {
           email: "alice@acme.com",
           broadcast: makeBroadcastStatus({
-            campaign: { contacted: true, delivered: true, replied: true, replyClassification: "positive", lastDeliveredAt: "2026-03-29T10:00:00Z" },
+            campaign: { contacted: true, sent: true, delivered: true, opened: true, clicked: true, replied: true, replyClassification: "positive", lastDeliveredAt: "2026-03-29T10:00:00Z" },
           }),
         },
         {
@@ -211,7 +219,10 @@ describe("GET /orgs/leads", () => {
 
     const alice = res.body.leads.find((l: any) => l.email === "alice@acme.com");
     expect(alice.contacted).toBe(true);
+    expect(alice.sent).toBe(true);
     expect(alice.delivered).toBe(true);
+    expect(alice.opened).toBe(true);
+    expect(alice.clicked).toBe(true);
     expect(alice.replied).toBe(true);
     expect(alice.replyClassification).toBe("positive");
     expect(alice.lastDeliveredAt).toBe("2026-03-29T10:00:00Z");
@@ -249,22 +260,48 @@ describe("GET /orgs/leads", () => {
     expect(alice.replyClassification).toBe("negative");
   });
 
-  it("returns default status when email-gateway is unreachable", async () => {
+  it("includes global bounced/unsubscribed from email-gateway", async () => {
     mockFindMany.mockResolvedValue([
       makeServedLead({ leadId: "lead-1", email: "alice@acme.com" }),
     ]);
-    mockCheckDeliveryStatus.mockResolvedValue(null);
+
+    mockCheckDeliveryStatus.mockResolvedValue({
+      results: [
+        {
+          email: "alice@acme.com",
+          broadcast: {
+            campaign: { contacted: false, sent: false, delivered: false, opened: false, clicked: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+            brand: { contacted: false, sent: false, delivered: false, opened: false, clicked: false, replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null },
+            global: { email: { bounced: true, unsubscribed: true } },
+          },
+        },
+      ],
+    });
 
     const app = createApp();
     const res = await request(app).get("/orgs/leads?campaignId=c1");
     expect(res.status).toBe(200);
-    expect(res.body.leads[0]).toMatchObject({
-      contacted: false,
-      delivered: false,
-      bounced: false,
-      replied: false,
-      replyClassification: null,
-    });
+
+    const alice = res.body.leads[0];
+    expect(alice.global.bounced).toBe(true);
+    expect(alice.global.unsubscribed).toBe(true);
+  });
+
+  it("returns apolloPersonId and emailStatus from enrichment", async () => {
+    mockFindMany.mockResolvedValue([
+      makeServedLead({
+        leadId: "lead-1",
+        email: "alice@acme.com",
+        apolloPersonId: "apollo-person-123",
+        metadata: { firstName: "Alice", emailStatus: "verified" },
+      }),
+    ]);
+
+    const app = createApp();
+    const res = await request(app).get("/orgs/leads");
+    expect(res.status).toBe(200);
+    expect(res.body.leads[0].apolloPersonId).toBe("apollo-person-123");
+    expect(res.body.leads[0].emailStatus).toBe("verified");
   });
 
   it("groups email-gateway calls by first brandId", async () => {
@@ -293,7 +330,6 @@ describe("GET /orgs/leads", () => {
     const res = await request(app).get("/orgs/leads?campaignId=c1");
     expect(res.body.leads).toHaveLength(2);
 
-    // Only lead-1's email should be sent to email-gateway (items no longer have leadId)
     const items = mockCheckDeliveryStatus.mock.calls[0][2];
     expect(items).toHaveLength(1);
     expect(items[0].email).toBe("alice@acme.com");
@@ -316,24 +352,28 @@ describe("GET /orgs/leads", () => {
 // --- flattenCampaignStatus unit tests ---
 
 describe("flattenCampaignStatus", () => {
-  it("detects replied and replyClassification from broadcast campaign", () => {
+  it("detects all status fields from broadcast campaign", () => {
     const result = flattenCampaignStatus({
       email: "a@b.com",
       broadcast: makeBroadcastStatus({
-        campaign: { contacted: true, delivered: true, replied: true, replyClassification: "positive", lastDeliveredAt: "2026-03-29T10:00:00Z" },
+        campaign: { contacted: true, sent: true, delivered: true, opened: true, clicked: true, replied: true, replyClassification: "positive", lastDeliveredAt: "2026-03-29T10:00:00Z" },
       }),
     });
 
+    expect(result.contacted).toBe(true);
+    expect(result.sent).toBe(true);
+    expect(result.delivered).toBe(true);
+    expect(result.opened).toBe(true);
+    expect(result.clicked).toBe(true);
     expect(result.replied).toBe(true);
     expect(result.replyClassification).toBe("positive");
-    expect(result.delivered).toBe(true);
-    expect(result.contacted).toBe(true);
     expect(result.lastDeliveredAt).toBe("2026-03-29T10:00:00Z");
+    expect(result.global).toEqual({ bounced: false, unsubscribed: false });
   });
 
   it("detects transactional delivery", () => {
     const defaultScoped = {
-      contacted: false, delivered: false, opened: false, replied: false,
+      contacted: false, sent: false, delivered: false, opened: false, clicked: false, replied: false,
       replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null,
     };
     const result = flattenCampaignStatus({
@@ -341,9 +381,7 @@ describe("flattenCampaignStatus", () => {
       transactional: {
         campaign: { ...defaultScoped, contacted: true, delivered: true, lastDeliveredAt: "2026-03-28T08:00:00Z" },
         brand: defaultScoped,
-        global: {
-          email: { contacted: false, delivered: false, bounced: false, unsubscribed: false, lastDeliveredAt: null },
-        },
+        global: { email: { bounced: false, unsubscribed: false } },
       },
     });
 
@@ -353,10 +391,31 @@ describe("flattenCampaignStatus", () => {
   });
 
   it("returns all false when no providers present", () => {
-    const result = flattenCampaignStatus({ leadId: "l1", email: "a@b.com" });
+    const result = flattenCampaignStatus({ email: "a@b.com" });
     expect(result).toEqual({
-      contacted: false, delivered: false, bounced: false, replied: false, replyClassification: null, lastDeliveredAt: null,
+      contacted: false, sent: false, delivered: false, opened: false, clicked: false,
+      bounced: false, unsubscribed: false, replied: false, replyClassification: null, lastDeliveredAt: null,
+      global: { bounced: false, unsubscribed: false },
     });
+  });
+
+  it("picks up global bounced/unsubscribed", () => {
+    const result = flattenCampaignStatus({
+      email: "a@b.com",
+      broadcast: {
+        campaign: {
+          contacted: false, sent: false, delivered: false, opened: false, clicked: false,
+          replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null,
+        },
+        brand: {
+          contacted: false, sent: false, delivered: false, opened: false, clicked: false,
+          replied: false, replyClassification: null, bounced: false, unsubscribed: false, lastDeliveredAt: null,
+        },
+        global: { email: { bounced: true, unsubscribed: true } },
+      },
+    });
+    expect(result.global.bounced).toBe(true);
+    expect(result.global.unsubscribed).toBe(true);
   });
 });
 
@@ -375,21 +434,15 @@ describe("flattenBrandStatus", () => {
     expect(result.delivered).toBe(true);
     expect(result.replied).toBe(true);
     expect(result.lastDeliveredAt).toBe("2026-03-29T10:00:00Z");
-  });
-
-  it("handles missing scopes in provider (partial response)", () => {
-    const result = flattenBrandStatus({
-      email: "a@b.com",
-      broadcast: { global: { email: { contacted: true, delivered: true, bounced: false, unsubscribed: false, lastDeliveredAt: null } } } as any,
-    });
-    expect(result.contacted).toBe(true);
-    expect(result.delivered).toBe(false);
+    expect(result.global).toEqual({ bounced: false, unsubscribed: false });
   });
 
   it("returns all false when no providers present", () => {
-    const result = flattenBrandStatus({ leadId: "l1", email: "a@b.com" });
+    const result = flattenBrandStatus({ email: "a@b.com" });
     expect(result).toEqual({
-      contacted: false, delivered: false, bounced: false, replied: false, replyClassification: null, lastDeliveredAt: null,
+      contacted: false, sent: false, delivered: false, opened: false, clicked: false,
+      bounced: false, unsubscribed: false, replied: false, replyClassification: null, lastDeliveredAt: null,
+      global: { bounced: false, unsubscribed: false },
     });
   });
 });

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Response } from "express";
 
 // Mock db — where() returns whatever mockWhere returns
 const mockFrom = vi.fn();
@@ -25,20 +24,9 @@ vi.mock("../../src/db/index.js", () => ({
   },
 }));
 
-vi.mock("../../src/lib/apollo-client.js", () => ({
-  fetchApolloStats: vi.fn().mockResolvedValue({
-    enrichedLeadsCount: 0,
-    searchCount: 0,
-    fetchedPeopleCount: 0,
-    totalMatchingPeople: 0,
-  }),
-}));
-
-const mockCheckDeliveryStatus = vi.fn();
+const mockFetchEmailGatewayStats = vi.fn();
 vi.mock("../../src/lib/email-gateway-client.js", () => ({
-  checkDeliveryStatus: (...args: unknown[]) => mockCheckDeliveryStatus(...args),
-  isContacted: (result: { broadcast?: { campaign: { contacted: boolean } } }) =>
-    !!(result.broadcast?.campaign.contacted),
+  fetchEmailGatewayStats: (...args: unknown[]) => mockFetchEmailGatewayStats(...args),
 }));
 
 const mockResolveFeatureDynastySlugs = vi.fn();
@@ -91,12 +79,22 @@ function queryResult(data: unknown[]) {
   };
 }
 
+const ZERO_RECIPIENT_STATS = {
+  contacted: 0, sent: 0, delivered: 0, opened: 0, bounced: 0, clicked: 0,
+  unsubscribed: 0, repliesPositive: 0, repliesNegative: 0, repliesNeutral: 0,
+  repliesAutoReply: 0,
+  repliesDetail: {
+    interested: 0, meetingBooked: 0, closed: 0, notInterested: 0,
+    wrongPerson: 0, unsubscribe: 0, neutral: 0, autoReply: 0, outOfOffice: 0,
+  },
+};
+
 describe("GET /stats", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Default: all queries return zero/empty
     mockWhere.mockReturnValue(queryResult([{ count: 0 }]));
-    mockCheckDeliveryStatus.mockResolvedValue(null);
+    mockFetchEmailGatewayStats.mockResolvedValue({});
     mockExecute.mockResolvedValue([]);
     // Default dynasty mocks
     mockResolveFeatureDynastySlugs.mockResolvedValue([]);
@@ -114,6 +112,7 @@ describe("GET /stats", () => {
 
   it("accepts groupBy=campaignId", async () => {
     const app = createApp();
+    mockFetchEmailGatewayStats.mockResolvedValue({ groups: [] });
     const res = await request(app).get("/orgs/stats?groupBy=campaignId");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
@@ -122,6 +121,7 @@ describe("GET /stats", () => {
 
   it("accepts groupBy=brandId", async () => {
     const app = createApp();
+    mockFetchEmailGatewayStats.mockResolvedValue({ groups: [] });
     const res = await request(app).get("/orgs/stats?groupBy=brandId");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
@@ -129,6 +129,7 @@ describe("GET /stats", () => {
 
   it("accepts groupBy=workflowSlug", async () => {
     const app = createApp();
+    mockFetchEmailGatewayStats.mockResolvedValue({ groups: [] });
     const res = await request(app).get("/orgs/stats?groupBy=workflowSlug");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
@@ -136,98 +137,58 @@ describe("GET /stats", () => {
 
   it("accepts groupBy=featureSlug", async () => {
     const app = createApp();
+    mockFetchEmailGatewayStats.mockResolvedValue({ groups: [] });
     const res = await request(app).get("/orgs/stats?groupBy=featureSlug");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
   });
 
-  it("returns flat response without groupBy including contacted=0", async () => {
+  it("returns flat response with new shape (totalLeads, byOutreachStatus, repliesDetail)", async () => {
     const app = createApp();
+
+    mockFetchEmailGatewayStats.mockResolvedValue({
+      broadcast: {
+        recipientStats: {
+          ...ZERO_RECIPIENT_STATS,
+          contacted: 5,
+          sent: 10,
+          delivered: 8,
+        },
+      },
+    });
+
     const res = await request(app).get("/orgs/stats");
     expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty("served");
-    expect(res.body).toHaveProperty("contacted");
+    expect(res.body).toHaveProperty("totalLeads");
+    expect(res.body).toHaveProperty("byOutreachStatus");
+    expect(res.body).toHaveProperty("repliesDetail");
     expect(res.body).toHaveProperty("buffered");
     expect(res.body).toHaveProperty("skipped");
-    expect(res.body).toHaveProperty("apollo");
+    expect(res.body).not.toHaveProperty("served");
+    expect(res.body).not.toHaveProperty("contacted");
+    expect(res.body).not.toHaveProperty("apollo");
     expect(res.body).not.toHaveProperty("groups");
-    expect(res.body.contacted).toBe(0);
+    expect(res.body.byOutreachStatus.contacted).toBe(5);
+    expect(res.body.byOutreachStatus.sent).toBe(10);
+    expect(res.body.byOutreachStatus.delivered).toBe(8);
   });
 
-  it("counts contacted leads via email-gateway", async () => {
+  it("merges broadcast + transactional recipientStats", async () => {
     const app = createApp();
 
-    const servedLeadRows = [
-      { leadId: "lead-1", email: "alice@acme.com", brandIds: ["b1"], campaignId: "c1" },
-      { leadId: "lead-2", email: "bob@acme.com", brandIds: ["b1"], campaignId: "c1" },
-    ];
-
-    // Flat response Promise.all order:
-    //   1. served count: .where().then(([r]) => r)
-    //   2. countContacted: await .where()
-    //   3. buffer: .where().groupBy()
-    let whereCall = 0;
-    mockWhere.mockImplementation(() => {
-      whereCall++;
-      const c = whereCall;
-      if (c === 1) return queryResult([{ count: 2 }]);
-      if (c === 2) return queryResult(servedLeadRows);
-      return queryResult([]);
-    });
-
-    mockCheckDeliveryStatus.mockResolvedValue({
-      results: [
-        {
-          email: "alice@acme.com",
-          broadcast: {
-            campaign: { contacted: true },
-            brand: { contacted: false },
-            global: { email: { contacted: false } },
-          },
-        },
-        {
-          email: "bob@acme.com",
-          broadcast: {
-            campaign: { contacted: false },
-            brand: { contacted: false },
-            global: { email: { contacted: false } },
-          },
-        },
-      ],
+    mockFetchEmailGatewayStats.mockResolvedValue({
+      broadcast: {
+        recipientStats: { ...ZERO_RECIPIENT_STATS, contacted: 3, sent: 5 },
+      },
+      transactional: {
+        recipientStats: { ...ZERO_RECIPIENT_STATS, contacted: 2, sent: 1 },
+      },
     });
 
     const res = await request(app).get("/orgs/stats");
     expect(res.status).toBe(200);
-    expect(res.body.served).toBe(2);
-    expect(res.body.contacted).toBe(1);
-    expect(mockCheckDeliveryStatus).toHaveBeenCalledWith(
-      "b1", "c1",
-      [{ email: "alice@acme.com" }, { email: "bob@acme.com" }],
-      expect.objectContaining({ orgId: "org-1" }),
-    );
-  });
-
-  it("returns contacted=0 when email-gateway is unreachable", async () => {
-    const app = createApp();
-
-    let whereCall = 0;
-    mockWhere.mockImplementation(() => {
-      whereCall++;
-      if (whereCall === 1) return queryResult([{ count: 1 }]);
-      if (whereCall === 2) {
-        return queryResult([
-          { leadId: "lead-1", email: "alice@acme.com", brandIds: ["b1"], campaignId: "c1" },
-        ]);
-      }
-      return queryResult([]);
-    });
-
-    mockCheckDeliveryStatus.mockResolvedValue(null);
-
-    const res = await request(app).get("/orgs/stats");
-    expect(res.status).toBe(200);
-    expect(res.body.served).toBe(1);
-    expect(res.body.contacted).toBe(0);
+    expect(res.body.byOutreachStatus.contacted).toBe(5);
+    expect(res.body.byOutreachStatus.sent).toBe(6);
   });
 
   // --- Dynasty slug filtering ---
@@ -236,7 +197,6 @@ describe("GET /stats", () => {
     const app = createApp();
     const res = await request(app).get("/orgs/stats?workflowSlug=cold-email-v2");
     expect(res.status).toBe(200);
-    // Verify dynasty resolver was NOT called (exact slug, not dynasty)
     expect(mockResolveWorkflowDynastySlugs).not.toHaveBeenCalled();
   });
 
@@ -272,13 +232,12 @@ describe("GET /stats", () => {
     const res = await request(app).get("/orgs/stats?workflowDynastySlug=nonexistent");
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
-      served: 0,
-      contacted: 0,
+      totalLeads: 0,
+      byOutreachStatus: ZERO_RECIPIENT_STATS,
+      repliesDetail: ZERO_RECIPIENT_STATS.repliesDetail,
       buffered: 0,
       skipped: 0,
-      apollo: { enrichedLeadsCount: 0, searchCount: 0, fetchedPeopleCount: 0, totalMatchingPeople: 0 },
     });
-    // Should NOT hit the database
     expect(mockWhere).not.toHaveBeenCalled();
   });
 
@@ -288,7 +247,7 @@ describe("GET /stats", () => {
     const app = createApp();
     const res = await request(app).get("/orgs/stats?featureDynastySlug=nonexistent");
     expect(res.status).toBe(200);
-    expect(res.body.served).toBe(0);
+    expect(res.body.totalLeads).toBe(0);
     expect(mockWhere).not.toHaveBeenCalled();
   });
 
@@ -307,7 +266,6 @@ describe("GET /stats", () => {
     const app = createApp();
     const res = await request(app).get("/orgs/stats?workflowSlugs=cold-email-v1,cold-email-v2");
     expect(res.status).toBe(200);
-    // Dynasty resolver should NOT be called
     expect(mockResolveWorkflowDynastySlugs).not.toHaveBeenCalled();
   });
 
@@ -322,7 +280,6 @@ describe("GET /stats", () => {
     const app = createApp();
     const res = await request(app).get("/orgs/stats?workflowSlugs=v1,v2&workflowSlug=v3");
     expect(res.status).toBe(200);
-    // Should use the plural param, not the singular
     expect(mockResolveWorkflowDynastySlugs).not.toHaveBeenCalled();
   });
 
@@ -337,6 +294,7 @@ describe("GET /stats", () => {
 
   it("groupBy=workflowSlug with workflowSlugs filter returns grouped stats", async () => {
     const app = createApp();
+    mockFetchEmailGatewayStats.mockResolvedValue({ groups: [] });
     const res = await request(app).get("/orgs/stats?groupBy=workflowSlug&workflowSlugs=slug1,slug2");
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("groups");
@@ -348,7 +306,6 @@ describe("GET /stats", () => {
     const app = createApp();
     const res = await request(app).get("/orgs/stats?workflowDynastySlug=cold-email&workflowSlug=cold-email-v2");
     expect(res.status).toBe(200);
-    // Dynasty resolver should be called (takes priority)
     expect(mockResolveWorkflowDynastySlugs).toHaveBeenCalledWith("cold-email", expect.any(Object));
   });
 
@@ -361,6 +318,7 @@ describe("GET /stats", () => {
         ["cold-email-v2", "cold-email"],
       ]),
     );
+    mockFetchEmailGatewayStats.mockResolvedValue({ groups: [] });
 
     const app = createApp();
     const res = await request(app).get("/orgs/stats?groupBy=workflowDynastySlug");
@@ -376,6 +334,7 @@ describe("GET /stats", () => {
         ["feat-alpha-v2", "feat-alpha"],
       ]),
     );
+    mockFetchEmailGatewayStats.mockResolvedValue({ groups: [] });
 
     const app = createApp();
     const res = await request(app).get("/orgs/stats?groupBy=featureDynastySlug");
@@ -391,5 +350,16 @@ describe("GET /stats", () => {
     const res = await request(app).get("/orgs/stats?workflowDynastySlug=cold-email&brandId=b1&campaignId=c1");
     expect(res.status).toBe(200);
     expect(mockResolveWorkflowDynastySlugs).toHaveBeenCalled();
+  });
+
+  it("calls fetchEmailGatewayStats instead of N+1 checkDeliveryStatus", async () => {
+    const app = createApp();
+    mockFetchEmailGatewayStats.mockResolvedValue({
+      broadcast: { recipientStats: ZERO_RECIPIENT_STATS },
+    });
+
+    const res = await request(app).get("/orgs/stats");
+    expect(res.status).toBe(200);
+    expect(mockFetchEmailGatewayStats).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary
- **Rename externalId → apolloPersonId** throughout code, DB schema, tests
- **Brand dedup TTL**: 6-month window (was infinite)
- **Enrichment cache TTL**: 6 months (email found), 1 day (no email)
- **Email status filtering**: only accept `verified` and `extrapolated` from Apollo
- **Pre-enrichment dedup**: check apolloPersonId in served_leads BEFORE calling Apollo enrichment (saves API credits)
- **Email-gateway fail loud**: throw on HTTP errors instead of returning null
- **Stats refactor**: replace N+1 `checkDeliveryStatus` with single `fetchEmailGatewayStats` call. New response shape: `totalLeads`, `byOutreachStatus` (full recipientStats), `repliesDetail`, `buffered`, `skipped`. Removed `apollo` stats.
- **Leads refactor**: add `sent`, `opened`, `clicked`, `unsubscribed`, `global` scope (bounced/unsubscribed), `apolloPersonId`, `emailStatus` to response
- **OpenAPI regenerated** with new schemas

## Breaking Changes
- **Stats response shape changed**: `served` → `totalLeads`, `contacted` moved into `byOutreachStatus`, `apollo` removed, new `byOutreachStatus` and `repliesDetail` objects
- **Leads response shape changed**: new fields `sent`, `opened`, `clicked`, `unsubscribed`, `global`, `apolloPersonId`, `emailStatus`. Removed `externalId`.
- **DB column renamed**: `external_id` → `apollo_person_id` in `served_leads` and `lead_buffer` tables (migration needed)

## Test plan
- [x] All 180 unit tests pass
- [x] TypeScript build succeeds
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)