### PR TITLE
Add skip_reason + skip_details to lead_buffer

### DIFF
--- a/drizzle/0015_add_skip_reason_details.sql
+++ b/drizzle/0015_add_skip_reason_details.sql
@@ -1,0 +1,3 @@
+-- Add skip_reason and skip_details columns to lead_buffer for observability
+ALTER TABLE "lead_buffer" ADD COLUMN IF NOT EXISTS "skip_reason" text;--> statement-breakpoint
+ALTER TABLE "lead_buffer" ADD COLUMN IF NOT EXISTS "skip_details" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1775635200000,
       "tag": "0014_rename_external_id_to_apollo_person_id",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1775894400000,
+      "tag": "0015_add_skip_reason_details",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -77,6 +77,8 @@ export const leadBuffer = pgTable(
     userId: text("user_id"),
     workflowSlug: text("workflow_slug"),
     featureSlug: text("feature_slug"),
+    skipReason: text("skip_reason"),
+    skipDetails: text("skip_details"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -365,7 +365,11 @@ export async function pullNext(params: {
         console.log(`[lead-service] pullNext skip (pre-enrich brand dedup): ${preCheck.reason} apolloPersonId=${row.apolloPersonId}`);
         await db
           .update(leadBuffer)
-          .set({ status: "skipped" })
+          .set({
+            status: "skipped",
+            skipReason: "pre_enrich_brand_dedup",
+            skipDetails: `Already served for brand (pre-enrich check), apolloPersonId=${row.apolloPersonId}, campaignId=${params.campaignId}, brandIds=${params.brandIds.join(",")}, reason=${preCheck.reason}`,
+          })
           .where(eq(leadBuffer.id, row.id));
         continue;
       }
@@ -388,7 +392,11 @@ export async function pullNext(params: {
             console.log(`[lead-service] pullNext skip (invalid emailStatus: ${cached.emailStatus}) apolloPersonId=${row.apolloPersonId}`);
             await db
               .update(leadBuffer)
-              .set({ status: "skipped" })
+              .set({
+                status: "skipped",
+                skipReason: "invalid_email_status",
+                skipDetails: `Cached email status "${cached.emailStatus}" is not valid (requires verified/extrapolated), email=${cached.email}, apolloPersonId=${row.apolloPersonId}, campaignId=${params.campaignId}`,
+              })
               .where(eq(leadBuffer.id, row.id));
             continue;
           }
@@ -399,7 +407,11 @@ export async function pullNext(params: {
           // Previously enriched but no email found, cache still fresh — skip without calling Apollo
           await db
             .update(leadBuffer)
-            .set({ status: "skipped" })
+            .set({
+              status: "skipped",
+              skipReason: "no_email_cached",
+              skipDetails: `Previously enriched but no email found (cache still fresh), apolloPersonId=${row.apolloPersonId}, campaignId=${params.campaignId}`,
+            })
             .where(eq(leadBuffer.id, row.id));
           continue;
         }
@@ -432,7 +444,11 @@ export async function pullNext(params: {
           }).onConflictDoNothing();
           await db
             .update(leadBuffer)
-            .set({ status: "skipped" })
+            .set({
+              status: "skipped",
+              skipReason: "no_email",
+              skipDetails: `Apollo enrichment returned no email, apolloPersonId=${row.apolloPersonId}, campaignId=${params.campaignId}`,
+            })
             .where(eq(leadBuffer.id, row.id));
           continue;
         }
@@ -458,7 +474,11 @@ export async function pullNext(params: {
           }).onConflictDoNothing();
           await db
             .update(leadBuffer)
-            .set({ status: "skipped" })
+            .set({
+              status: "skipped",
+              skipReason: "invalid_email_status",
+              skipDetails: `Fresh enrichment email status "${freshEmailStatus}" is not valid (requires verified/extrapolated), email=${enrichResult.person.email}, apolloPersonId=${row.apolloPersonId}, campaignId=${params.campaignId}`,
+            })
             .where(eq(leadBuffer.id, row.id));
           continue;
         }
@@ -494,7 +514,11 @@ export async function pullNext(params: {
     if (!email) {
       await db
         .update(leadBuffer)
-        .set({ status: "skipped" })
+        .set({
+          status: "skipped",
+          skipReason: "no_email",
+          skipDetails: `No email available after all enrichment attempts, apolloPersonId=${row.apolloPersonId ?? "none"}, bufferId=${row.id}, campaignId=${params.campaignId}`,
+        })
         .where(eq(leadBuffer.id, row.id));
       continue;
     }
@@ -519,7 +543,11 @@ export async function pullNext(params: {
       console.log(`[lead-service] pullNext skip (brand dedup): ${brandCheck.reason} email=${email}`);
       await db
         .update(leadBuffer)
-        .set({ status: "skipped" })
+        .set({
+          status: "skipped",
+          skipReason: "brand_dedup",
+          skipDetails: `Already served for brand (post-enrich check), email=${email}, apolloPersonId=${row.apolloPersonId ?? "none"}, leadId=${leadId}, brandIds=${params.brandIds.join(",")}, campaignId=${params.campaignId}, reason=${brandCheck.reason}`,
+        })
         .where(eq(leadBuffer.id, row.id));
       continue;
     }
@@ -536,7 +564,11 @@ export async function pullNext(params: {
       console.log(`[lead-service] pullNext skip (race window) email=${email}`);
       await db
         .update(leadBuffer)
-        .set({ status: "skipped" })
+        .set({
+          status: "skipped",
+          skipReason: "race_window",
+          skipDetails: `Another buffer row for same brand was recently claimed/served, email=${email}, apolloPersonId=${row.apolloPersonId ?? "none"}, brandIds=${params.brandIds.join(",")}, campaignId=${params.campaignId}`,
+        })
         .where(eq(leadBuffer.id, row.id));
       continue;
     }
@@ -558,7 +590,11 @@ export async function pullNext(params: {
     if (emailStatus?.contacted) {
       await db
         .update(leadBuffer)
-        .set({ status: "skipped" })
+        .set({
+          status: "skipped",
+          skipReason: "contacted",
+          skipDetails: `Already contacted via email-gateway, email=${email}, apolloPersonId=${row.apolloPersonId ?? "none"}, leadId=${leadId}, campaignId=${params.campaignId}, brandIds=${params.brandIds.join(",")}`,
+        })
         .where(eq(leadBuffer.id, row.id));
       continue;
     }
@@ -566,7 +602,11 @@ export async function pullNext(params: {
       console.log(`[lead-service] pullNext skip (bounced) email=${email}`);
       await db
         .update(leadBuffer)
-        .set({ status: "skipped" })
+        .set({
+          status: "skipped",
+          skipReason: "bounced",
+          skipDetails: `Email previously bounced, email=${email}, apolloPersonId=${row.apolloPersonId ?? "none"}, leadId=${leadId}, campaignId=${params.campaignId}, brandIds=${params.brandIds.join(",")}`,
+        })
         .where(eq(leadBuffer.id, row.id));
       continue;
     }
@@ -574,7 +614,11 @@ export async function pullNext(params: {
       console.log(`[lead-service] pullNext skip (unsubscribed) email=${email}`);
       await db
         .update(leadBuffer)
-        .set({ status: "skipped" })
+        .set({
+          status: "skipped",
+          skipReason: "unsubscribed",
+          skipDetails: `Email unsubscribed, email=${email}, apolloPersonId=${row.apolloPersonId ?? "none"}, leadId=${leadId}, campaignId=${params.campaignId}, brandIds=${params.brandIds.join(",")}`,
+        })
         .where(eq(leadBuffer.id, row.id));
       continue;
     }
@@ -599,7 +643,11 @@ export async function pullNext(params: {
       // Another request already served this email for this org+campaign — skip
       await db
         .update(leadBuffer)
-        .set({ status: "skipped" })
+        .set({
+          status: "skipped",
+          skipReason: "serve_dedup",
+          skipDetails: `Another request already served this email for org+campaign, email=${email}, apolloPersonId=${row.apolloPersonId ?? "none"}, leadId=${leadId}, campaignId=${params.campaignId}`,
+        })
         .where(eq(leadBuffer.id, row.id));
       continue;
     }

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -104,7 +104,7 @@ router.post("/orgs/buffer/next", apiKeyAuth, requireOrgId, async (req: Authentic
 
     traceEvent(serveRunId, { service: "lead-service", event: "buffer-next-done", detail: `found=${result.found}`, data: { found: result.found } }, req.headers).catch(() => {});
 
-    const runStatus = result.found ? "completed" : "failed";
+    const runStatus = "completed";
     await updateRun(serveRunId, runStatus, runMeta);
 
     res.json(result);

--- a/tests/unit/buffer-route.test.ts
+++ b/tests/unit/buffer-route.test.ts
@@ -68,7 +68,7 @@ describe("POST /buffer/next run status", () => {
     mockUpdateRun.mockResolvedValue(undefined);
   });
 
-  it("marks run as failed when pullNext returns found: false", async () => {
+  it("marks run as completed when pullNext returns found: false (buffer exhausted is not a failure)", async () => {
     mockPullNext.mockResolvedValue({ found: false });
 
     const app = createApp();
@@ -82,7 +82,7 @@ describe("POST /buffer/next run status", () => {
     expect(res.body.found).toBe(false);
     expect(mockUpdateRun).toHaveBeenCalledWith(
       "mock-run-id",
-      "failed",
+      "completed",
       expect.objectContaining({ campaignId: "c1", brandId: "b1" })
     );
   });


### PR DESCRIPTION
## Summary

- **Added `skip_reason` (TEXT) and `skip_details` (TEXT) columns** to `lead_buffer` table via Drizzle migration
- **All 12 skip paths in `pullNext()`** now set both `skipReason` (category) and `skipDetails` (human-readable string with all relevant IDs)
- **Fixed run status bug**: `found: false` now marks run as `"completed"` instead of `"failed"` — buffer exhaustion is not a failure

### Skip reason categories
`pre_enrich_brand_dedup`, `invalid_email_status`, `no_email_cached`, `no_email`, `brand_dedup`, `race_window`, `contacted`, `bounced`, `unsubscribed`, `serve_dedup`

### Example skipDetails
`Already served for brand (pre-enrich check), apolloPersonId=abc123, campaignId=10a43f92, brandIds=75d7e3e8, reason=already served for overlapping brand`

## Test plan
- [x] All 186 unit tests pass (15 suites)
- [x] Zero bare `.set({ status: "skipped" })` remaining in src/ (grep verified)
- [x] buffer-route test updated: found:false → "completed" status
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)