### PR TITLE
Add statusReason/statusDetails to GET /orgs/leads

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -620,6 +620,16 @@
             ],
             "description": "Classification of the most recent reply from email-gateway. 'positive' = interested or willing to meet, 'negative' = not interested, 'neutral' = ambiguous or informational. null when no reply detected."
           },
+          "statusReason": {
+            "type": "string",
+            "nullable": true,
+            "description": "Why this lead was skipped or placed in its current status (e.g. 'already_contacted', 'bounced'). Only set for buffer leads."
+          },
+          "statusDetails": {
+            "type": "string",
+            "nullable": true,
+            "description": "Human-readable details about the status reason. Only set for buffer leads."
+          },
           "lastDeliveredAt": {
             "type": "string",
             "nullable": true
@@ -667,6 +677,8 @@
           "unsubscribed",
           "replied",
           "replyClassification",
+          "statusReason",
+          "statusDetails",
           "lastDeliveredAt",
           "global"
         ]

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -214,6 +214,8 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
         apolloPersonId: lead.apolloPersonId ?? null,
         emailStatus,
         enrichment,
+        statusReason: null,
+        statusDetails: null,
         ...deliveryStatus,
       };
     });
@@ -242,6 +244,8 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
         status: row.status as "buffered" | "skipped" | "claimed",
         emailStatus,
         enrichment,
+        statusReason: row.statusReason ?? null,
+        statusDetails: row.statusDetails ?? null,
         ...DEFAULT_STATUS,
       };
     });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -317,6 +317,12 @@ const LeadDetailSchema = z
           "'neutral' = ambiguous or informational. " +
           "null when no reply detected.",
       }),
+    statusReason: z.string().nullable().openapi({
+      description: "Why this lead was skipped or placed in its current status (e.g. 'already_contacted', 'bounced'). Only set for buffer leads.",
+    }),
+    statusDetails: z.string().nullable().openapi({
+      description: "Human-readable details about the status reason. Only set for buffer leads.",
+    }),
     lastDeliveredAt: z.string().nullable(),
     global: z.object({
       bounced: z.boolean(),

--- a/tests/unit/leads.test.ts
+++ b/tests/unit/leads.test.ts
@@ -340,6 +340,70 @@ describe("GET /orgs/leads", () => {
     expect(items[0].email).toBe("alice@acme.com");
   });
 
+  it("returns statusReason and statusDetails as null for served leads", async () => {
+    mockFindMany.mockResolvedValue([makeServedLead()]);
+
+    const app = createApp();
+    const res = await request(app).get("/orgs/leads");
+    expect(res.status).toBe(200);
+    expect(res.body.leads[0].statusReason).toBeNull();
+    expect(res.body.leads[0].statusDetails).toBeNull();
+  });
+
+  it("returns statusReason and statusDetails from buffer leads", async () => {
+    mockBufferFindMany.mockResolvedValue([{
+      id: "buf-1",
+      namespace: "apollo",
+      email: "bob@acme.com",
+      apolloPersonId: null,
+      data: null,
+      status: "skipped",
+      pushRunId: null,
+      brandIds: ["b1"],
+      campaignId: "c1",
+      orgId: "org-1",
+      userId: null,
+      workflowSlug: null,
+      featureSlug: null,
+      statusReason: "already_contacted",
+      statusDetails: "Contacted via campaign c0 on 2026-03-15",
+      createdAt: "2026-04-01T00:00:00Z",
+    }]);
+
+    const app = createApp();
+    const res = await request(app).get("/orgs/leads");
+    expect(res.status).toBe(200);
+    expect(res.body.leads[0].statusReason).toBe("already_contacted");
+    expect(res.body.leads[0].statusDetails).toBe("Contacted via campaign c0 on 2026-03-15");
+  });
+
+  it("returns statusReason and statusDetails as null when buffer lead has no values", async () => {
+    mockBufferFindMany.mockResolvedValue([{
+      id: "buf-2",
+      namespace: "apollo",
+      email: "carol@acme.com",
+      apolloPersonId: null,
+      data: null,
+      status: "buffered",
+      pushRunId: null,
+      brandIds: ["b1"],
+      campaignId: "c1",
+      orgId: "org-1",
+      userId: null,
+      workflowSlug: null,
+      featureSlug: null,
+      statusReason: null,
+      statusDetails: null,
+      createdAt: "2026-04-01T00:00:00Z",
+    }]);
+
+    const app = createApp();
+    const res = await request(app).get("/orgs/leads");
+    expect(res.status).toBe(200);
+    expect(res.body.leads[0].statusReason).toBeNull();
+    expect(res.body.leads[0].statusDetails).toBeNull();
+  });
+
   it("still returns enrichment alongside status", async () => {
     const metadata = { firstName: "Alice", lastName: "Smith", email: "alice@acme.com" };
     mockFindMany.mockResolvedValue([


### PR DESCRIPTION
## Summary
- Adds `statusReason` (string | null) and `statusDetails` (string | null) to every lead object in GET /orgs/leads
- Buffer leads expose their `status_reason`/`status_details` column values
- Served leads always return `null` for both fields
- Zod schema (`LeadDetail`) updated, `openapi.json` regenerated

## Test plan
- [x] Unit test: served leads return `statusReason: null`, `statusDetails: null`
- [x] Unit test: buffer leads with values return them correctly
- [x] Unit test: buffer leads without values return `null`
- [x] All 189 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)