### PR TITLE
hotfix: Bump LLM round + buffer-fill timeouts so Gemini Pro multi-round strategy generation completes; fail-loud on missing orgId/campaignId in getCurrentStrategy

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -55,4 +55,4 @@ export const CHAT_SERVICE_API_KEY = required("CHAT_SERVICE_API_KEY");
 // --- Buffer / strategy tuning ---
 export const TARGET_BUFFER_SIZE = 20;
 export const MAX_STRATEGY_GENERATION_ROUNDS = 15;
-export const PULL_NEXT_TIMEOUT_MS = 60_000;
+export const PULL_NEXT_TIMEOUT_MS = 600_000;

--- a/src/lib/chat-client.ts
+++ b/src/lib/chat-client.ts
@@ -60,7 +60,7 @@ export async function chatComplete(
     method: "POST",
     headers,
     body: JSON.stringify(body),
-    signal: AbortSignal.timeout(120_000),
+    signal: AbortSignal.timeout(300_000),
   });
 
   if (!response.ok) {

--- a/src/lib/strategy-generator.ts
+++ b/src/lib/strategy-generator.ts
@@ -255,6 +255,12 @@ async function persistOutcome(params: {
 export async function getCurrentStrategy(
   ctx: StrategyContext,
 ): Promise<{ strategy: ApolloSearchParams } | { exhausted: true; reason: string }> {
+  if (!ctx.orgId) {
+    throw new Error("[lead-service] getCurrentStrategy: orgId is required");
+  }
+  if (!ctx.campaignId) {
+    throw new Error("[lead-service] getCurrentStrategy: campaignId is required");
+  }
   const existing = await loadRow(ctx.orgId, ctx.campaignId);
 
   if (existing?.exhausted) {

--- a/tests/unit/chat-client.test.ts
+++ b/tests/unit/chat-client.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { chatComplete } from "../../src/lib/chat-client.js";
+
+const fetchMock = vi.fn();
+const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  timeoutSpy.mockClear();
+  // @ts-expect-error global fetch override for test
+  global.fetch = fetchMock;
+});
+
+describe("chat-client timeout", () => {
+  it("uses AbortSignal.timeout >= 300_000 ms on the fetch call", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ content: "", tokensInput: 0, tokensOutput: 0, model: "pro" }),
+    });
+
+    await chatComplete(
+      {
+        message: "hi",
+        systemPrompt: "sys",
+        provider: "google",
+        model: "pro",
+      },
+      { orgId: "org-1" },
+    );
+
+    expect(timeoutSpy).toHaveBeenCalled();
+    const ms = timeoutSpy.mock.calls[0][0] as number;
+    expect(ms).toBeGreaterThanOrEqual(300_000);
+  });
+});

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -42,4 +42,9 @@ describe("config", () => {
       process.env.APOLLO_SERVICE_API_KEY = original;
     }
   });
+
+  it("PULL_NEXT_TIMEOUT_MS is at least 600_000 to accommodate multi-round Pro strategy generation", async () => {
+    const config = await import("../../src/config.js");
+    expect(config.PULL_NEXT_TIMEOUT_MS).toBeGreaterThanOrEqual(600_000);
+  });
 });

--- a/tests/unit/strategy-generator.test.ts
+++ b/tests/unit/strategy-generator.test.ts
@@ -225,6 +225,18 @@ describe("strategy-generator", () => {
       expect(chatComplete).not.toHaveBeenCalled();
     });
 
+    it("throws fail-loud when orgId is missing", async () => {
+      await expect(
+        getCurrentStrategy({ ...baseCtx, orgId: "" } as StrategyContext),
+      ).rejects.toThrow(/orgId/);
+    });
+
+    it("throws fail-loud when campaignId is missing", async () => {
+      await expect(
+        getCurrentStrategy({ ...baseCtx, campaignId: "" } as StrategyContext),
+      ).rejects.toThrow(/campaignId/);
+    });
+
     it("generates and persists when no row exists yet", async () => {
       findFirst.mockResolvedValueOnce(null);
       apolloDryRun.mockResolvedValueOnce({ totalEntries: 1000, validationErrors: [] });


### PR DESCRIPTION
Automated by release.sh