### PR TITLE
hotfix(apollo): close strategy validation loop

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -212,16 +212,37 @@ export async function topUpApolloLeadBuffer(params: IngestParams, signal?: Abort
       freshStrategy = true;
     }
 
-    const page = await apolloFetchPage({
-      campaignId: params.campaignId,
-      brandId: brandIdCsv,
-      searchParams: freshStrategy ? activeStrategy : undefined,
-      runId: params.pushRunId ?? null,
-      orgId: params.orgId,
-      userId: params.userId ?? null,
-      workflowSlug: params.workflowSlug,
-      featureSlug: params.featureSlug,
-    });
+    let page: Awaited<ReturnType<typeof apolloFetchPage>>;
+    try {
+      page = await apolloFetchPage({
+        campaignId: params.campaignId,
+        brandId: brandIdCsv,
+        searchParams: freshStrategy ? activeStrategy : undefined,
+        runId: params.pushRunId ?? null,
+        orgId: params.orgId,
+        userId: params.userId ?? null,
+        workflowSlug: params.workflowSlug,
+        featureSlug: params.featureSlug,
+      });
+    } catch (err) {
+      // Apollo rejected the persisted strategy (e.g. validation error after schema tightening,
+      // or LLM previously confirmed an invalid filter). Don't propagate — invalidate the strategy
+      // and feed the error back to the LLM loop so it can converge on a valid filter set.
+      const lastApolloError = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[lead-service] apolloFetchPage failed for campaign=${params.campaignId}, advancing strategy: ${lastApolloError}`,
+      );
+      const next = await advanceStrategyOrGenerate(ctx, lastApolloError);
+      if ("exhausted" in next) {
+        console.log(
+          `[lead-service] topUp strategies exhausted after Apollo rejection campaign=${params.campaignId} reason=${next.reason}`,
+        );
+        return { filled: totalInserted };
+      }
+      activeStrategy = next.strategy;
+      freshStrategy = true;
+      continue;
+    }
     freshStrategy = false;
 
     let pageInserted = 0;

--- a/src/lib/strategy-generator.ts
+++ b/src/lib/strategy-generator.ts
@@ -44,19 +44,31 @@ ABSOLUTE RULES:
 WORKFLOW:
 You operate in a multi-turn loop. On each turn, respond with EXACTLY ONE JSON object.
 The user will tell you the result of any "test" you propose, then ask for the next action.
+If a test returns validation errors, you MUST keep iterating with new test actions; do NOT confirm a filter set that has unresolved validation errors.
 
 OUTPUT FORMAT (JSON):
 
 To propose filters for testing:
 {"action": "test", "filters": {<Apollo search filter object>}, "reasoning": "<one sentence>"}
 
-To confirm the last tested filter set is good (you must have tested at least one filter set before confirming):
+To confirm the last tested filter set is good (only allowed when the last test returned zero validation errors):
 {"action": "confirm", "reasoning": "<one sentence>"}
 
 To declare no viable alternative exists in scope:
 {"action": "exhausted", "reason": "<why no viable alternative exists>"}
 
-Apollo filter shape (camelCase): personTitles, organizationLocations, organizationIndustries, organizationNumEmployeesRanges, qOrganizationKeywordTags, qOrganizationIndustryTagIds, qKeywords. All optional.`;
+Apollo filter shape (camelCase, all optional):
+- personTitles: string[] — free-form job titles, e.g. ["Dentist", "Orthodontist"].
+- organizationLocations: string[] — free-form locations, e.g. ["United States", "California, US"].
+- organizationIndustries: string[] — Apollo industry labels, e.g. ["health, wellness & fitness", "financial services"].
+- organizationNumEmployeesRanges: string[] — MUST use ONLY the following exact bucket strings (no other values are accepted):
+    "1,10", "11,20", "21,50", "51,100", "101,200", "201,500", "501,1000", "1001,2000", "2001,5000", "5001,10000", "10001,"
+  You may pass multiple buckets (e.g. ["1,10", "11,20"]) to cover a range; you cannot invent custom ranges like "1,50" or "100,500".
+- qOrganizationKeywordTags: string[] — free-form company keyword tags.
+- qOrganizationIndustryTagIds: string[] — Apollo industry tag IDs.
+- qKeywords: string[] — free-form keyword search terms.`;
+
+export const __SYSTEM_PROMPT__ = SYSTEM_PROMPT;
 
 interface LlmAction {
   action?: unknown;
@@ -88,9 +100,16 @@ function buildSeedMessage(brandCampaignDescription: string, previousStrategies: 
 export async function generateNextStrategy(
   ctx: StrategyContext,
   previousStrategies: ApolloSearchParams[],
+  apolloError?: string,
 ): Promise<StrategyOutcome> {
   const transcript: string[] = [buildSeedMessage(ctx.brandCampaignDescription, previousStrategies)];
+  if (apolloError) {
+    transcript.push(
+      `PRIOR APOLLO ERROR (the last persisted strategy was rejected by Apollo at fetch time, treat as a validation failure to avoid):\n${apolloError}`,
+    );
+  }
   let lastTestedFilters: ApolloSearchParams | null = null;
+  let lastTestedHadErrors = false;
 
   const tracking = {
     orgId: ctx.orgId,
@@ -130,24 +149,44 @@ export async function generateNextStrategy(
         continue;
       }
       const filters = action.filters as ApolloSearchParams;
-      const dry = await apolloDryRun({
-        filters,
-        orgId: ctx.orgId,
-        userId: ctx.userId ?? null,
-        runId: ctx.runId ?? null,
-        brandId: ctx.brandId,
-        campaignId: ctx.campaignId,
-        workflowSlug: ctx.workflowSlug,
-        featureSlug: ctx.featureSlug,
-      });
-      lastTestedFilters = filters;
-      transcript.push(
-        [
-          `Round ${round + 1}: tested filters=${JSON.stringify(filters)}`,
-          `Result: totalEntries=${dry.totalEntries}, validationErrors=${JSON.stringify(dry.validationErrors)}.`,
-          `Either confirm this set, propose another test, or declare exhausted.`,
-        ].join("\n"),
-      );
+      try {
+        const dry = await apolloDryRun({
+          filters,
+          orgId: ctx.orgId,
+          userId: ctx.userId ?? null,
+          runId: ctx.runId ?? null,
+          brandId: ctx.brandId,
+          campaignId: ctx.campaignId,
+          workflowSlug: ctx.workflowSlug,
+          featureSlug: ctx.featureSlug,
+        });
+        lastTestedFilters = filters;
+        lastTestedHadErrors = (dry.validationErrors ?? []).length > 0;
+        transcript.push(
+          [
+            `Round ${round + 1}: tested filters=${JSON.stringify(filters)}`,
+            `Result: totalEntries=${dry.totalEntries}, validationErrors=${JSON.stringify(dry.validationErrors)}.`,
+            lastTestedHadErrors
+              ? `Validation errors present — you MUST propose another "test" with corrected filters; "confirm" will be rejected until validationErrors is empty.`
+              : `Either confirm this set, propose another test, or declare exhausted.`,
+          ].join("\n"),
+        );
+      } catch (err) {
+        lastTestedFilters = null;
+        lastTestedHadErrors = true;
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[lead-service] strategy dryRun threw, feeding error back to LLM round=${round + 1}: ${message}`,
+        );
+        transcript.push(
+          [
+            `Round ${round + 1}: tested filters=${JSON.stringify(filters)}`,
+            `Result: Apollo rejected the request with an error. Treat this as a validation failure to avoid:`,
+            message,
+            `Propose another "test" with corrected filters, or declare exhausted.`,
+          ].join("\n"),
+        );
+      }
       continue;
     }
 
@@ -155,6 +194,12 @@ export async function generateNextStrategy(
       if (!lastTestedFilters) {
         transcript.push(
           `Round ${round + 1}: you tried to confirm without testing any filters yet. You must test at least one filter set first.`,
+        );
+        continue;
+      }
+      if (lastTestedHadErrors) {
+        transcript.push(
+          `Round ${round + 1}: confirm rejected — the last tested filter set had validation errors. Propose a new "test" with corrected filters.`,
         );
         continue;
       }
@@ -283,11 +328,13 @@ export async function getCurrentStrategy(
 }
 
 /**
- * Mark the current strategy as exhausted (Apollo returned no more leads) and try to generate
- * the next strategy. Used by buffer fill when a page returns 0 candidates.
+ * Mark the current strategy as exhausted (Apollo returned no more leads, or Apollo rejected
+ * the persisted filter set) and try to generate the next strategy. Used by buffer fill when a
+ * page returns 0 candidates or Apollo throws a validation error on the persisted strategy.
  */
 export async function advanceStrategyOrGenerate(
   ctx: StrategyContext,
+  apolloError?: string,
 ): Promise<{ strategy: ApolloSearchParams } | { exhausted: true; reason: string }> {
   const existing = await loadRow(ctx.orgId, ctx.campaignId);
 
@@ -297,7 +344,7 @@ export async function advanceStrategyOrGenerate(
 
   // Bump index past current strategy; subsequent generateNextStrategy uses all known strategies as the "tried" set.
   const triedStrategies = existing?.strategies ?? [];
-  const outcome = await generateNextStrategy(ctx, triedStrategies);
+  const outcome = await generateNextStrategy(ctx, triedStrategies, apolloError);
   return persistOutcome({
     orgId: ctx.orgId,
     campaignId: ctx.campaignId,

--- a/tests/unit/buffer-simplification.test.ts
+++ b/tests/unit/buffer-simplification.test.ts
@@ -23,4 +23,9 @@ describe("buffer.ts simplification invariants", () => {
   it("releases the claim back to 'buffered' on exception via try/finally", () => {
     expect(bufferSrc).toMatch(/finally\s*\{[\s\S]*claimSettled[\s\S]*status:\s*"buffered"/);
   });
+
+  it("wraps apolloFetchPage in try/catch and routes Apollo validation errors back into the strategy loop", () => {
+    expect(bufferSrc).toMatch(/try\s*\{[\s\S]*apolloFetchPage[\s\S]*\}\s*catch/);
+    expect(bufferSrc).toMatch(/advanceStrategyOrGenerate[\s\S]*lastApolloError/);
+  });
 });

--- a/tests/unit/strategy-generator.test.ts
+++ b/tests/unit/strategy-generator.test.ts
@@ -176,6 +176,119 @@ describe("strategy-generator", () => {
       expect(chatComplete).toHaveBeenCalledTimes(3);
     });
 
+    it("rejects confirm when last dryRun returned validationErrors and forces another test", async () => {
+      apolloDryRun
+        .mockResolvedValueOnce({
+          totalEntries: 0,
+          validationErrors: [
+            'organizationNumEmployeesRanges: Invalid option: expected one of "1,10"|"11,20"|...',
+          ],
+        })
+        .mockResolvedValueOnce({ totalEntries: 500, validationErrors: [] });
+      chatComplete
+        .mockResolvedValueOnce({
+          json: {
+            action: "test",
+            filters: {
+              personTitles: ["Dentist"],
+              organizationNumEmployeesRanges: ["1,50"],
+            },
+            reasoning: "trying",
+          },
+          tokensInput: 0,
+          tokensOutput: 0,
+          model: "gemini-pro",
+          content: "",
+        })
+        .mockResolvedValueOnce({
+          json: { action: "confirm", reasoning: "ignoring errors" },
+          tokensInput: 0,
+          tokensOutput: 0,
+          model: "gemini-pro",
+          content: "",
+        })
+        .mockResolvedValueOnce({
+          json: {
+            action: "test",
+            filters: {
+              personTitles: ["Dentist"],
+              organizationNumEmployeesRanges: ["1,10", "11,20"],
+            },
+            reasoning: "fixed bucket",
+          },
+          tokensInput: 0,
+          tokensOutput: 0,
+          model: "gemini-pro",
+          content: "",
+        })
+        .mockResolvedValueOnce({
+          json: { action: "confirm", reasoning: "now valid" },
+          tokensInput: 0,
+          tokensOutput: 0,
+          model: "gemini-pro",
+          content: "",
+        });
+
+      const result = await generateNextStrategy(baseCtx, []);
+      expect("strategy" in result).toBe(true);
+      const strategy = (result as { strategy: { organizationNumEmployeesRanges: string[] } }).strategy;
+      expect(strategy.organizationNumEmployeesRanges).toEqual(["1,10", "11,20"]);
+      expect(apolloDryRun).toHaveBeenCalledTimes(2);
+    });
+
+    it("catches Apollo 400 thrown by dryRun, feeds error to LLM, continues loop", async () => {
+      apolloDryRun
+        .mockRejectedValueOnce(
+          new Error(
+            'Apollo service call failed: 400 - {"type":"validation","error":"Invalid request","details":{"fieldErrors":{"searchParams":["bad bucket"]}}}',
+          ),
+        )
+        .mockResolvedValueOnce({ totalEntries: 100, validationErrors: [] });
+      chatComplete
+        .mockResolvedValueOnce({
+          json: {
+            action: "test",
+            filters: { organizationNumEmployeesRanges: ["1,50"] },
+            reasoning: "first",
+          },
+          tokensInput: 0,
+          tokensOutput: 0,
+          model: "gemini-pro",
+          content: "",
+        })
+        .mockResolvedValueOnce({
+          json: {
+            action: "test",
+            filters: { organizationNumEmployeesRanges: ["1,10"] },
+            reasoning: "fixed",
+          },
+          tokensInput: 0,
+          tokensOutput: 0,
+          model: "gemini-pro",
+          content: "",
+        })
+        .mockResolvedValueOnce({
+          json: { action: "confirm", reasoning: "ok" },
+          tokensInput: 0,
+          tokensOutput: 0,
+          model: "gemini-pro",
+          content: "",
+        });
+
+      const result = await generateNextStrategy(baseCtx, []);
+      expect("strategy" in result).toBe(true);
+      expect(apolloDryRun).toHaveBeenCalledTimes(2);
+    });
+
+    it("SYSTEM_PROMPT enumerates allowed organizationNumEmployeesRanges buckets", async () => {
+      const sysPrompt = await import("../../src/lib/strategy-generator.js").then(
+        (m: { __SYSTEM_PROMPT__?: string }) => m.__SYSTEM_PROMPT__ ?? "",
+      );
+      expect(sysPrompt).toMatch(/"1,10"/);
+      expect(sysPrompt).toMatch(/"11,20"/);
+      expect(sysPrompt).toMatch(/"10001,"/);
+    });
+
     it("returns Max rounds reached after MAX_STRATEGY_GENERATION_ROUNDS", async () => {
       // Always test, never confirm.
       apolloDryRun.mockResolvedValue({ totalEntries: 10, validationErrors: [] });


### PR DESCRIPTION
## Summary

Production runs were failing with `POST lead/orgs/buffer/next failed (500)` because the persisted Apollo strategy held an invalid `organizationNumEmployeesRanges` bucket (e.g. `"1,50"`). `apollo-service /search/next` rejects unknown buckets with a 400 and the error was bubbling out as a 500 to workflow-service / windmill.

Three reinforcing fixes so an Apollo validation rejection never propagates to the caller:

- **Prompt:** `SYSTEM_PROMPT` now enumerates the exact allowed `organizationNumEmployeesRanges` buckets (`"1,10"|"11,20"|...|"10001,"`) and documents every filter field's shape — the LLM can no longer hallucinate custom ranges like `"1,50"`.
- **Strategy loop:** `generateNextStrategy` catches a 400 thrown by `apolloDryRun`, feeds the error back into the transcript, and refuses `confirm` whenever the last test had `validationErrors`. The LLM keeps iterating until the filter set is valid.
- **Buffer fallback:** `topUpApolloLeadBuffer` wraps `apolloFetchPage` in try/catch. A 400 invalidates the persisted strategy, calls `advanceStrategyOrGenerate` with the Apollo error injected into the LLM context, and resumes the fill loop. Apollo validation errors no longer surface as 500s; the worst case is `filled: 0` after `MAX_STRATEGY_GENERATION_ROUNDS`.

## Test plan
- [x] `npm run test:unit` — 101/101 passing, including 5 new tests covering: prompt enum content, dryRun-throw recovery, confirm-rejection on validation errors, and buffer try/catch wiring
- [x] `npm run build` — compiles + openapi regen clean
- [ ] Post-deploy: confirm campaign `c04f3950-4218-4c3c-ab4c-75bc6185705e` recovers (next pullNext should advance the bad strategy automatically rather than 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)