### PR TITLE
fix(apollo): align strategy-generator prompt with apollo-service contract

### DIFF
--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -25,15 +25,22 @@ async function callApolloService<T>(
   return response.json() as Promise<T>;
 }
 
+// Mirrors apollo-service `SearchFiltersSchema` (see apollo-service/src/schemas.ts).
+// qKeywords is a single OR-joined string per Apollo's contract — array shapes are rejected with 400.
 export interface ApolloSearchParams {
   personTitles?: string[];
+  personLocations?: string[];
+  personSeniorities?: string[];
   organizationLocations?: string[];
-  organizationIndustries?: string[];
   organizationNumEmployeesRanges?: string[];
   qOrganizationKeywordTags?: string[];
   qOrganizationIndustryTagIds?: string[];
-  qKeywords?: string[];
-  keywords?: string[];
+  qOrganizationDomains?: string[];
+  contactEmailStatus?: string[];
+  currentlyUsingAnyOfTechnologyUids?: string[];
+  revenueRange?: string[];
+  organizationIds?: string[];
+  qKeywords?: string;
   [key: string]: unknown;
 }
 

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -228,14 +228,12 @@ export async function topUpApolloLeadBuffer(params: IngestParams, signal?: Abort
       // Apollo rejected the persisted strategy (e.g. validation error after schema tightening,
       // or LLM previously confirmed an invalid filter). Don't propagate — invalidate the strategy
       // and feed the error back to the LLM loop so it can converge on a valid filter set.
+      // Stay quiet on per-attempt failures; only surface a log when all strategies are exhausted.
       const lastApolloError = err instanceof Error ? err.message : String(err);
-      console.warn(
-        `[lead-service] apolloFetchPage failed for campaign=${params.campaignId}, advancing strategy: ${lastApolloError}`,
-      );
       const next = await advanceStrategyOrGenerate(ctx, lastApolloError);
       if ("exhausted" in next) {
-        console.log(
-          `[lead-service] topUp strategies exhausted after Apollo rejection campaign=${params.campaignId} reason=${next.reason}`,
+        console.warn(
+          `[lead-service] topUp strategies exhausted after Apollo rejection campaign=${params.campaignId} reason=${next.reason} lastError=${lastApolloError}`,
         );
         return { filled: totalInserted };
       }

--- a/src/lib/strategy-generator.ts
+++ b/src/lib/strategy-generator.ts
@@ -57,16 +57,62 @@ To confirm the last tested filter set is good (only allowed when the last test r
 To declare no viable alternative exists in scope:
 {"action": "exhausted", "reason": "<why no viable alternative exists>"}
 
-Apollo filter shape (camelCase, all optional):
-- personTitles: string[] — free-form job titles, e.g. ["Dentist", "Orthodontist"].
-- organizationLocations: string[] — free-form locations, e.g. ["United States", "California, US"].
-- organizationIndustries: string[] — Apollo industry labels, e.g. ["health, wellness & fitness", "financial services"].
-- organizationNumEmployeesRanges: string[] — MUST use ONLY the following exact bucket strings (no other values are accepted):
-    "1,10", "11,20", "21,50", "51,100", "101,200", "201,500", "501,1000", "1001,2000", "2001,5000", "5001,10000", "10001,"
-  You may pass multiple buckets (e.g. ["1,10", "11,20"]) to cover a range; you cannot invent custom ranges like "1,50" or "100,500".
-- qOrganizationKeywordTags: string[] — free-form company keyword tags.
-- qOrganizationIndustryTagIds: string[] — Apollo industry tag IDs.
-- qKeywords: string[] — free-form keyword search terms.`;
+Apollo filter shape (camelCase, all optional). Use ONLY these field names — any other key is silently dropped by the search service:
+
+- personTitles: string[]
+  ex: ["CEO", "CTO", "VP Engineering", "Dentist"]
+  Filter by job titles. Free-form.
+
+- personLocations: string[]
+  ex: ["San Francisco, California, US", "New York, US", "London, UK"]
+  Filter by the person's location (city, state, country). Different from organizationLocations.
+
+- personSeniorities: string[]
+  enum: entry | senior | manager | director | vp | c_suite | owner | founder | partner
+  ex: ["director", "vp", "c_suite"]
+  Filter by seniority level. Use ONLY the listed enum values.
+
+- organizationLocations: string[]
+  ex: ["United States", "California, US", "Germany"]
+  Filter by company HQ location.
+
+- organizationNumEmployeesRanges: string[]
+  enum: "1,10" | "11,20" | "21,50" | "51,100" | "101,200" | "201,500" | "501,1000" | "1001,2000" | "2001,5000" | "5001,10000" | "10001,"
+  ex: ["11,20", "21,50", "51,100"]
+  Company headcount buckets. MUST use the exact enum strings — do NOT invent custom ranges like "1,50" or "100,500". You may pass multiple buckets to cover a range.
+
+- qOrganizationKeywordTags: string[]
+  ex: ["SaaS", "fintech", "developer tools"]
+  Free-form company keyword tags.
+
+- qOrganizationIndustryTagIds: string[]
+  ex: ["Information Technology and Services", "Computer Software"]
+  Apollo industry labels (use the canonical Apollo strings, not arbitrary words).
+
+- qOrganizationDomains: string[]
+  ex: ["google.com", "stripe.com"]
+  Filter by specific company domains.
+
+- contactEmailStatus: string[]
+  enum: verified | unverified | "likely to engage" | unavailable
+  ex: ["verified"]
+  Email verification status.
+
+- currentlyUsingAnyOfTechnologyUids: string[]
+  ex: ["salesforce", "hubspot", "segment"]
+  Filter by technology stack (Apollo technology UIDs).
+
+- revenueRange: string[]
+  ex: ["1000000,10000000", "10000000,50000000"]
+  Annual revenue buckets, "min,max" format in raw dollars.
+
+- organizationIds: string[]
+  ex: ["5f5e100a01d6b1000169c754"]
+  Filter by specific Apollo organization IDs.
+
+- qKeywords: string
+  ex: "machine learning OR data science OR AI"
+  Single OR-joined free-text keyword string. NOT an array. Combine alternatives with " OR ".`;
 
 export const __SYSTEM_PROMPT__ = SYSTEM_PROMPT;
 

--- a/tests/unit/strategy-generator.test.ts
+++ b/tests/unit/strategy-generator.test.ts
@@ -39,6 +39,7 @@ import {
   generateNextStrategy,
   getCurrentStrategy,
   advanceStrategyOrGenerate,
+  __SYSTEM_PROMPT__,
   type StrategyContext,
 } from "../../src/lib/strategy-generator.js";
 
@@ -432,6 +433,55 @@ describe("strategy-generator", () => {
 
       const result = await advanceStrategyOrGenerate(baseCtx);
       expect("strategy" in result && result.strategy).toEqual({ personTitles: ["Orthodontist"] });
+    });
+  });
+
+  describe("SYSTEM_PROMPT — Apollo filter shape doc", () => {
+    it("documents qKeywords as string (not string[]) with OR-joined example", () => {
+      expect(__SYSTEM_PROMPT__).toMatch(/qKeywords:\s*string\b(?!\[\])/);
+      expect(__SYSTEM_PROMPT__).not.toMatch(/qKeywords:\s*string\[\]/);
+      expect(__SYSTEM_PROMPT__).toMatch(/qKeywords[\s\S]{0,300}?\bOR\b/);
+    });
+
+    it("lists personSeniorities enum values", () => {
+      const enums = ["entry", "senior", "manager", "director", "vp", "c_suite", "owner", "founder", "partner"];
+      const block = __SYSTEM_PROMPT__.match(/personSeniorities[\s\S]{0,400}/)?.[0] ?? "";
+      for (const v of enums) {
+        expect(block).toContain(v);
+      }
+    });
+
+    it("lists contactEmailStatus enum values", () => {
+      const enums = ["verified", "unverified", "likely to engage", "unavailable"];
+      const block = __SYSTEM_PROMPT__.match(/contactEmailStatus[\s\S]{0,400}/)?.[0] ?? "";
+      for (const v of enums) {
+        expect(block).toContain(v);
+      }
+    });
+
+    it("lists organizationNumEmployeesRanges enum values", () => {
+      const buckets = [
+        "1,10",
+        "11,20",
+        "21,50",
+        "51,100",
+        "101,200",
+        "201,500",
+        "501,1000",
+        "1001,2000",
+        "2001,5000",
+        "5001,10000",
+        "10001,",
+      ];
+      const block = __SYSTEM_PROMPT__.match(/organizationNumEmployeesRanges[\s\S]{0,800}/)?.[0] ?? "";
+      for (const b of buckets) {
+        expect(block).toContain(b);
+      }
+    });
+
+    it("does not list silently-dropped fields (organizationIndustries, keywords)", () => {
+      expect(__SYSTEM_PROMPT__).not.toMatch(/^- organizationIndustries:/m);
+      expect(__SYSTEM_PROMPT__).not.toMatch(/^- keywords:/m);
     });
   });
 });


### PR DESCRIPTION
## Summary

Production hotfix. Lead-service's `topUpApolloLeadBuffer` was logging an Apollo `400 - searchParams.qKeywords expected string, received array` on every campaign's first attempt. Self-heal loop (a837727) hid the user-facing impact but burned LLM/Apollo round-trips per campaign and noised up the logs.

Root cause: lead-service's `ApolloSearchParams` interface and the LLM `SYSTEM_PROMPT` declared `qKeywords: string[]`. Apollo and apollo-service expect a single OR-joined string. The prompt also listed two fields (`organizationIndustries`, `keywords`) that apollo-service silently drops, and was missing several fields apollo-service actually accepts.

## Changes

- `qKeywords?: string` (was `string[]`) in `src/lib/apollo-client.ts`.
- Prompt rewritten in `src/lib/strategy-generator.ts` from Apollo's official People Search API doc + apollo-service `SearchFiltersSchema`. Each field now has type, enum (where applicable), and a concrete example.
- `ApolloSearchParams` aligned with apollo-service `SearchFiltersSchema`: drop unsupported `organizationIndustries` / `keywords`; add `personLocations`, `personSeniorities`, `contactEmailStatus`, `qOrganizationDomains`, `currentlyUsingAnyOfTechnologyUids`, `revenueRange`, `organizationIds`.
- `src/lib/buffer.ts` no longer warns per failed attempt; only warns once when `advanceStrategyOrGenerate` returns `exhausted`, including the last error.

## Followup (separate workspace, in flight)

apollo-service exposing `GET /search/filters-prompt` so the prompt block above is generated from `SearchFiltersSchema` and served to callers — kills the drift this PR just patched. Once that lands, this hand-rolled prompt can be replaced by a fetch.

## Test plan

- [x] `npm test` — 106/106 pass (5 new prompt-content assertions added)
- [x] `npm run build` — green, openapi.json regenerated (no API surface change here, no diff)
- [ ] Post-deploy: trigger a campaign, tail logs — expect zero `apolloFetchPage failed ... advancing strategy` warns; expect first-attempt `searchParams` to be accepted by apollo-service

🤖 Generated with [Claude Code](https://claude.com/claude-code)