### PR TITLE
feat(apollo): fetch filter-shape doc from apollo-service /search/filters-prompt

### DIFF
--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -144,6 +144,22 @@ export interface ApolloPersonResult {
   [key: string]: unknown;
 }
 
+// --- Filters Prompt (server-generated LLM doc for SearchFiltersSchema) ---
+
+export interface ApolloFiltersPrompt {
+  prompt: string;
+  schemaVersion: string;
+}
+
+export async function fetchApolloFiltersPrompt(opts: {
+  orgId: string;
+  userId?: string | null;
+}): Promise<ApolloFiltersPrompt> {
+  const headers: Record<string, string> = { "x-org-id": opts.orgId };
+  if (opts.userId) headers["x-user-id"] = opts.userId;
+  return callApolloService<ApolloFiltersPrompt>("/search/filters-prompt", { headers });
+}
+
 // --- Fetch Page (server-managed pagination via apollo-service /search/next) ---
 
 export interface ApolloFetchPageResult {

--- a/src/lib/strategy-generator.ts
+++ b/src/lib/strategy-generator.ts
@@ -3,7 +3,11 @@ import { db } from "../db/index.js";
 import { campaignsApolloStrategies } from "../db/schema.js";
 import { MAX_STRATEGY_GENERATION_ROUNDS } from "../config.js";
 import { chatComplete } from "./chat-client.js";
-import { apolloDryRun, type ApolloSearchParams } from "./apollo-client.js";
+import {
+  apolloDryRun,
+  fetchApolloFiltersPrompt,
+  type ApolloSearchParams,
+} from "./apollo-client.js";
 
 export interface StrategyContext {
   orgId: string;
@@ -21,7 +25,9 @@ export type StrategyOutcome =
   | { strategy: ApolloSearchParams }
   | { exhausted: true; reason: string };
 
-const SYSTEM_PROMPT = `You are an Apollo.io search filter generator for a B2B outreach campaign.
+// Static portion of the system prompt. The Apollo filter shape doc is appended
+// per-call from apollo-service GET /search/filters-prompt (single source of truth).
+const SYSTEM_PROMPT_STATIC = `You are an Apollo.io search filter generator for a B2B outreach campaign.
 
 CONTEXT YOU RECEIVE:
 - Brand: name, industry, target geography, ideal lead type, target job titles, offerings
@@ -55,66 +61,33 @@ To confirm the last tested filter set is good (only allowed when the last test r
 {"action": "confirm", "reasoning": "<one sentence>"}
 
 To declare no viable alternative exists in scope:
-{"action": "exhausted", "reason": "<why no viable alternative exists>"}
+{"action": "exhausted", "reason": "<why no viable alternative exists>"}`;
 
-Apollo filter shape (camelCase, all optional). Use ONLY these field names — any other key is silently dropped by the search service:
+function buildSystemPrompt(filtersPrompt: string): string {
+  return `${SYSTEM_PROMPT_STATIC}\n\n${filtersPrompt}`;
+}
 
-- personTitles: string[]
-  ex: ["CEO", "CTO", "VP Engineering", "Dentist"]
-  Filter by job titles. Free-form.
+let cachedFiltersPrompt: { schemaVersion: string; prompt: string } | null = null;
 
-- personLocations: string[]
-  ex: ["San Francisco, California, US", "New York, US", "London, UK"]
-  Filter by the person's location (city, state, country). Different from organizationLocations.
+async function getFiltersPrompt(orgId: string, userId: string | null): Promise<string> {
+  const fresh = await fetchApolloFiltersPrompt({ orgId, userId });
+  if (!cachedFiltersPrompt || cachedFiltersPrompt.schemaVersion !== fresh.schemaVersion) {
+    if (cachedFiltersPrompt && cachedFiltersPrompt.schemaVersion !== fresh.schemaVersion) {
+      console.log(
+        `[lead-service] apollo filters-prompt schemaVersion changed: ${cachedFiltersPrompt.schemaVersion} -> ${fresh.schemaVersion}`,
+      );
+    }
+    cachedFiltersPrompt = { schemaVersion: fresh.schemaVersion, prompt: fresh.prompt };
+  }
+  return cachedFiltersPrompt.prompt;
+}
 
-- personSeniorities: string[]
-  enum: entry | senior | manager | director | vp | c_suite | owner | founder | partner
-  ex: ["director", "vp", "c_suite"]
-  Filter by seniority level. Use ONLY the listed enum values.
+// Test-only: lets unit tests reset the module-level cache between cases.
+export function __resetFiltersPromptCache(): void {
+  cachedFiltersPrompt = null;
+}
 
-- organizationLocations: string[]
-  ex: ["United States", "California, US", "Germany"]
-  Filter by company HQ location.
-
-- organizationNumEmployeesRanges: string[]
-  enum: "1,10" | "11,20" | "21,50" | "51,100" | "101,200" | "201,500" | "501,1000" | "1001,2000" | "2001,5000" | "5001,10000" | "10001,"
-  ex: ["11,20", "21,50", "51,100"]
-  Company headcount buckets. MUST use the exact enum strings — do NOT invent custom ranges like "1,50" or "100,500". You may pass multiple buckets to cover a range.
-
-- qOrganizationKeywordTags: string[]
-  ex: ["SaaS", "fintech", "developer tools"]
-  Free-form company keyword tags.
-
-- qOrganizationIndustryTagIds: string[]
-  ex: ["Information Technology and Services", "Computer Software"]
-  Apollo industry labels (use the canonical Apollo strings, not arbitrary words).
-
-- qOrganizationDomains: string[]
-  ex: ["google.com", "stripe.com"]
-  Filter by specific company domains.
-
-- contactEmailStatus: string[]
-  enum: verified | unverified | "likely to engage" | unavailable
-  ex: ["verified"]
-  Email verification status.
-
-- currentlyUsingAnyOfTechnologyUids: string[]
-  ex: ["salesforce", "hubspot", "segment"]
-  Filter by technology stack (Apollo technology UIDs).
-
-- revenueRange: string[]
-  ex: ["1000000,10000000", "10000000,50000000"]
-  Annual revenue buckets, "min,max" format in raw dollars.
-
-- organizationIds: string[]
-  ex: ["5f5e100a01d6b1000169c754"]
-  Filter by specific Apollo organization IDs.
-
-- qKeywords: string
-  ex: "machine learning OR data science OR AI"
-  Single OR-joined free-text keyword string. NOT an array. Combine alternatives with " OR ".`;
-
-export const __SYSTEM_PROMPT__ = SYSTEM_PROMPT;
+export const __SYSTEM_PROMPT_STATIC__ = SYSTEM_PROMPT_STATIC;
 
 interface LlmAction {
   action?: unknown;
@@ -167,11 +140,14 @@ export async function generateNextStrategy(
     featureSlug: ctx.featureSlug ?? null,
   };
 
+  const filtersPrompt = await getFiltersPrompt(ctx.orgId, ctx.userId ?? null);
+  const systemPrompt = buildSystemPrompt(filtersPrompt);
+
   for (let round = 0; round < MAX_STRATEGY_GENERATION_ROUNDS; round++) {
     const completion = await chatComplete(
       {
         message: transcript.join("\n\n---\n\n"),
-        systemPrompt: SYSTEM_PROMPT,
+        systemPrompt,
         provider: "google",
         model: "pro",
         responseFormat: "json",

--- a/tests/unit/apollo-client.test.ts
+++ b/tests/unit/apollo-client.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fetchApolloStats, apolloEnrich } from "../../src/lib/apollo-client.js";
+import {
+  fetchApolloStats,
+  apolloEnrich,
+  fetchApolloFiltersPrompt,
+} from "../../src/lib/apollo-client.js";
 
 type CapturedRequest = { url: string; init: RequestInit };
 
@@ -83,6 +87,44 @@ describe("apollo-client", () => {
       const result = await apolloEnrich("p1");
 
       expect(result).toEqual({ person, cached: false });
+    });
+  });
+
+  describe("fetchApolloFiltersPrompt", () => {
+    it("GETs /search/filters-prompt with x-org-id and x-user-id headers", async () => {
+      const { calls } = mockFetch({ prompt: "DOC", schemaVersion: "v1" });
+
+      const out = await fetchApolloFiltersPrompt({ orgId: "org-9", userId: "user-9" });
+
+      expect(out).toEqual({ prompt: "DOC", schemaVersion: "v1" });
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toBe("http://apollo:3003/search/filters-prompt");
+      expect(calls[0].init.method ?? "GET").toBe("GET");
+      const headers = calls[0].init.headers as Record<string, string>;
+      expect(headers["x-org-id"]).toBe("org-9");
+      expect(headers["x-user-id"]).toBe("user-9");
+      expect(headers["X-API-Key"]).toBeDefined();
+    });
+
+    it("omits x-user-id when userId is null", async () => {
+      const { calls } = mockFetch({ prompt: "DOC", schemaVersion: "v1" });
+
+      await fetchApolloFiltersPrompt({ orgId: "org-9", userId: null });
+
+      const headers = calls[0].init.headers as Record<string, string>;
+      expect(headers["x-org-id"]).toBe("org-9");
+      expect(headers["x-user-id"]).toBeUndefined();
+    });
+
+    it("throws on non-2xx response (no silent fallback)", async () => {
+      const fetchSpy = vi.fn(async () =>
+        new Response("apollo down", { status: 503 }),
+      );
+      vi.stubGlobal("fetch", fetchSpy);
+
+      await expect(
+        fetchApolloFiltersPrompt({ orgId: "org-1", userId: null }),
+      ).rejects.toThrow(/Apollo service call failed: 503/);
     });
   });
 });

--- a/tests/unit/strategy-generator.test.ts
+++ b/tests/unit/strategy-generator.test.ts
@@ -7,8 +7,10 @@ vi.mock("../../src/lib/chat-client.js", () => ({
 }));
 
 const apolloDryRun = vi.fn();
+const fetchApolloFiltersPrompt = vi.fn();
 vi.mock("../../src/lib/apollo-client.js", () => ({
   apolloDryRun: (...args: unknown[]) => apolloDryRun(...args),
+  fetchApolloFiltersPrompt: (...args: unknown[]) => fetchApolloFiltersPrompt(...args),
 }));
 
 // Mock the DB layer used by getCurrentStrategy / advanceStrategyOrGenerate / persistOutcome.
@@ -39,7 +41,8 @@ import {
   generateNextStrategy,
   getCurrentStrategy,
   advanceStrategyOrGenerate,
-  __SYSTEM_PROMPT__,
+  __SYSTEM_PROMPT_STATIC__,
+  __resetFiltersPromptCache,
   type StrategyContext,
 } from "../../src/lib/strategy-generator.js";
 
@@ -55,9 +58,16 @@ const baseCtx: StrategyContext = {
 beforeEach(() => {
   chatComplete.mockReset();
   apolloDryRun.mockReset();
+  fetchApolloFiltersPrompt.mockReset();
   findFirst.mockReset();
   insertReturning.mockReset();
   updateWhere.mockReset();
+  __resetFiltersPromptCache();
+  // Default: filter-shape doc fetch returns a stable shape so existing tests don't have to opt in.
+  fetchApolloFiltersPrompt.mockResolvedValue({
+    prompt: "DEFAULT FILTERS PROMPT BLOCK",
+    schemaVersion: "default-v1",
+  });
 });
 
 describe("strategy-generator", () => {
@@ -281,15 +291,6 @@ describe("strategy-generator", () => {
       expect(apolloDryRun).toHaveBeenCalledTimes(2);
     });
 
-    it("SYSTEM_PROMPT enumerates allowed organizationNumEmployeesRanges buckets", async () => {
-      const sysPrompt = await import("../../src/lib/strategy-generator.js").then(
-        (m: { __SYSTEM_PROMPT__?: string }) => m.__SYSTEM_PROMPT__ ?? "",
-      );
-      expect(sysPrompt).toMatch(/"1,10"/);
-      expect(sysPrompt).toMatch(/"11,20"/);
-      expect(sysPrompt).toMatch(/"10001,"/);
-    });
-
     it("returns Max rounds reached after MAX_STRATEGY_GENERATION_ROUNDS", async () => {
       // Always test, never confirm.
       apolloDryRun.mockResolvedValue({ totalEntries: 10, validationErrors: [] });
@@ -436,52 +437,96 @@ describe("strategy-generator", () => {
     });
   });
 
-  describe("SYSTEM_PROMPT — Apollo filter shape doc", () => {
-    it("documents qKeywords as string (not string[]) with OR-joined example", () => {
-      expect(__SYSTEM_PROMPT__).toMatch(/qKeywords:\s*string\b(?!\[\])/);
-      expect(__SYSTEM_PROMPT__).not.toMatch(/qKeywords:\s*string\[\]/);
-      expect(__SYSTEM_PROMPT__).toMatch(/qKeywords[\s\S]{0,300}?\bOR\b/);
+  describe("SYSTEM_PROMPT — static portion", () => {
+    it("contains the absolute rules + workflow framing but not the filter shape doc", () => {
+      expect(__SYSTEM_PROMPT_STATIC__).toContain("ABSOLUTE RULES");
+      expect(__SYSTEM_PROMPT_STATIC__).toContain("OUTPUT FORMAT");
+      // Filter shape lines must NOT appear in the static block — they're fetched from apollo-service.
+      expect(__SYSTEM_PROMPT_STATIC__).not.toMatch(/^- personTitles:/m);
+      expect(__SYSTEM_PROMPT_STATIC__).not.toMatch(/qKeywords/);
+    });
+  });
+
+  describe("filters-prompt fetch + cache", () => {
+    function nextActionsForOneTestThenConfirm() {
+      apolloDryRun.mockResolvedValueOnce({ totalEntries: 100, validationErrors: [] });
+      chatComplete
+        .mockResolvedValueOnce({
+          json: { action: "test", filters: { personTitles: ["Dentist"] }, reasoning: "primary" },
+          tokensInput: 0,
+          tokensOutput: 0,
+          model: "gemini-pro",
+          content: "",
+        })
+        .mockResolvedValueOnce({
+          json: { action: "confirm", reasoning: "ok" },
+          tokensInput: 0,
+          tokensOutput: 0,
+          model: "gemini-pro",
+          content: "",
+        });
+    }
+
+    it("fetches filter-shape doc and injects it into the chatComplete systemPrompt", async () => {
+      fetchApolloFiltersPrompt.mockReset();
+      fetchApolloFiltersPrompt.mockResolvedValue({
+        prompt: "MOCK_FILTER_DOC_X",
+        schemaVersion: "v-abc",
+      });
+      nextActionsForOneTestThenConfirm();
+
+      await generateNextStrategy(baseCtx, []);
+
+      expect(fetchApolloFiltersPrompt).toHaveBeenCalledWith({ orgId: "org-1", userId: "user-1" });
+      const firstCall = chatComplete.mock.calls[0][0] as { systemPrompt: string };
+      expect(firstCall.systemPrompt).toContain("MOCK_FILTER_DOC_X");
+      expect(firstCall.systemPrompt).toContain("ABSOLUTE RULES");
     });
 
-    it("lists personSeniorities enum values", () => {
-      const enums = ["entry", "senior", "manager", "director", "vp", "c_suite", "owner", "founder", "partner"];
-      const block = __SYSTEM_PROMPT__.match(/personSeniorities[\s\S]{0,400}/)?.[0] ?? "";
-      for (const v of enums) {
-        expect(block).toContain(v);
-      }
+    it("re-fetches each invocation but reuses cached prompt when schemaVersion is unchanged", async () => {
+      fetchApolloFiltersPrompt.mockReset();
+      fetchApolloFiltersPrompt.mockResolvedValue({
+        prompt: "STABLE_DOC",
+        schemaVersion: "stable-v1",
+      });
+
+      nextActionsForOneTestThenConfirm();
+      await generateNextStrategy(baseCtx, []);
+      nextActionsForOneTestThenConfirm();
+      await generateNextStrategy(baseCtx, []);
+
+      expect(fetchApolloFiltersPrompt).toHaveBeenCalledTimes(2);
+      const promptA = (chatComplete.mock.calls[0][0] as { systemPrompt: string }).systemPrompt;
+      const promptC = (chatComplete.mock.calls[2][0] as { systemPrompt: string }).systemPrompt;
+      expect(promptA).toContain("STABLE_DOC");
+      expect(promptC).toContain("STABLE_DOC");
     });
 
-    it("lists contactEmailStatus enum values", () => {
-      const enums = ["verified", "unverified", "likely to engage", "unavailable"];
-      const block = __SYSTEM_PROMPT__.match(/contactEmailStatus[\s\S]{0,400}/)?.[0] ?? "";
-      for (const v of enums) {
-        expect(block).toContain(v);
-      }
+    it("swaps cache and uses new prompt when schemaVersion changes", async () => {
+      fetchApolloFiltersPrompt.mockReset();
+      fetchApolloFiltersPrompt
+        .mockResolvedValueOnce({ prompt: "DOC_OLD", schemaVersion: "v1" })
+        .mockResolvedValueOnce({ prompt: "DOC_NEW", schemaVersion: "v2" });
+
+      nextActionsForOneTestThenConfirm();
+      await generateNextStrategy(baseCtx, []);
+      nextActionsForOneTestThenConfirm();
+      await generateNextStrategy(baseCtx, []);
+
+      const firstSystem = (chatComplete.mock.calls[0][0] as { systemPrompt: string }).systemPrompt;
+      const thirdSystem = (chatComplete.mock.calls[2][0] as { systemPrompt: string }).systemPrompt;
+      expect(firstSystem).toContain("DOC_OLD");
+      expect(firstSystem).not.toContain("DOC_NEW");
+      expect(thirdSystem).toContain("DOC_NEW");
+      expect(thirdSystem).not.toContain("DOC_OLD");
     });
 
-    it("lists organizationNumEmployeesRanges enum values", () => {
-      const buckets = [
-        "1,10",
-        "11,20",
-        "21,50",
-        "51,100",
-        "101,200",
-        "201,500",
-        "501,1000",
-        "1001,2000",
-        "2001,5000",
-        "5001,10000",
-        "10001,",
-      ];
-      const block = __SYSTEM_PROMPT__.match(/organizationNumEmployeesRanges[\s\S]{0,800}/)?.[0] ?? "";
-      for (const b of buckets) {
-        expect(block).toContain(b);
-      }
-    });
+    it("propagates fetch errors (no silent fallback)", async () => {
+      fetchApolloFiltersPrompt.mockReset();
+      fetchApolloFiltersPrompt.mockRejectedValue(new Error("apollo-service down"));
 
-    it("does not list silently-dropped fields (organizationIndustries, keywords)", () => {
-      expect(__SYSTEM_PROMPT__).not.toMatch(/^- organizationIndustries:/m);
-      expect(__SYSTEM_PROMPT__).not.toMatch(/^- keywords:/m);
+      await expect(generateNextStrategy(baseCtx, [])).rejects.toThrow(/apollo-service down/);
+      expect(chatComplete).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Single source of truth for the Apollo filter doc lives in apollo-service (`SearchFiltersSchema`, exposed via `GET /search/filters-prompt` as of [apollo-service PR #115](https://github.com/shamanic-technologies/apollo-service/pull/115)). This PR replaces the hand-rolled filter block shipped in lead-service v0.13.2 with a fetched-and-cached version. Future schema changes on apollo-service propagate without redeploying lead-service.

## Changes

- `fetchApolloFiltersPrompt()` in `apollo-client.ts`. Sends `x-org-id` + `x-user-id` per repo header convention.
- `strategy-generator.ts`:
  - `SYSTEM_PROMPT` split into static framing (intro / rules / workflow / output format) and a dynamic filter-shape block fetched per call.
  - `buildSystemPrompt(filtersPrompt)` composes both.
  - Module-level cache keyed by `schemaVersion`. Every `generateNextStrategy` call hits `/search/filters-prompt` (cheap GET); reuses cached prompt string when `schemaVersion` matches, swaps + logs once on change. No TTL, no background refresh, no extra state.
  - Fail loud: a fetch error rejects out of `generateNextStrategy` rather than running on stale doc.
- Tests: drop the v0.13.2 `__SYSTEM_PROMPT__` content assertions (no longer source of truth); replace with mocked-fetch tests that verify the composed `systemPrompt` argument to `chatComplete`. New `apollo-client` tests for happy path, missing `userId`, and 5xx fail-loud behavior.

## Deployment ordering

✅ Cleared. Apollo-service main HEAD is `9d8e8e5` (PR #115 merge), Railway production status `success` for `Distribute.you - apollo-service`. Endpoint live before this PR merges.

## Test plan

- [x] `npm test` — 108/108 pass (added 7 new, removed 6 obsolete)
- [x] `npm run build` — green, openapi.json regenerated (no API surface change → no diff)
- [ ] Post-deploy: trigger a campaign, tail logs, confirm strategy-generator runs without error and apollo accepts first attempt's `searchParams`
- [ ] Post-deploy: optional, change a description in apollo-service `SearchFiltersSchema` (without redeploying lead-service); confirm next campaign's composed prompt picks up the change (proves cache is keyed by `schemaVersion`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)