### PR TITLE
fix(leads): return canonical FullLead shape on every endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -36,76 +36,103 @@
         "type": "object",
         "properties": {
           "found": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True when a lead was claimed and returned. False when the campaign buffer is empty.",
+            "example": true
           },
           "lead": {
-            "type": "object",
-            "properties": {
-              "leadId": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "email": {
-                "type": "string"
-              },
-              "data": {
-                "$ref": "#/components/schemas/ApolloPersonData"
-              },
-              "brandIds": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "orgId": {
-                "type": "string",
-                "nullable": true
-              },
-              "userId": {
-                "type": "string",
-                "nullable": true
-              },
-              "apolloPersonId": {
-                "type": "string",
-                "nullable": true,
-                "description": "Apollo person ID from enrichment. Present when the lead was sourced or enriched via Apollo.",
-                "example": "5f2a3b4c5d6e7f8a9b0c1d2e"
-              }
-            },
-            "required": [
-              "leadId",
-              "email",
-              "data",
-              "brandIds",
-              "orgId",
-              "userId"
-            ]
+            "$ref": "#/components/schemas/ServedLead"
           }
         },
         "required": [
           "found"
         ],
-        "description": "Response from pulling the next lead. When found is true, lead contains the served lead with typed IDs.",
+        "description": "Response from POST /orgs/buffer/next. When found is true, lead contains the served lead with full canonical FullLead payload under `lead.data`.",
         "examples": [
           {
             "summary": "Apollo lead",
             "value": {
               "found": true,
               "lead": {
-                "leadId": "c1d2e3f4-a5b6-7890-abcd-ef1234567890",
-                "email": "jane.doe@acme.com",
+                "leadId": "00000000-0000-0000-0000-000000000001",
+                "email": "sara@cascobay.com",
                 "data": {
-                  "firstName": "Jane",
-                  "lastName": "Doe",
-                  "title": "VP of Marketing",
-                  "organizationName": "Acme Corp",
-                  "organizationDomain": "acme.com"
+                  "leadId": "00000000-0000-0000-0000-000000000001",
+                  "apolloPersonId": "5f2a3b4c5d6e7f8a9b0c1d2e",
+                  "firstName": "Sara",
+                  "lastName": "Freshley",
+                  "name": "Sara Freshley",
+                  "headline": "Founder at Casco Bay",
+                  "linkedinUrl": "https://linkedin.com/in/sara-freshley",
+                  "photoUrl": null,
+                  "city": "Portland",
+                  "state": "ME",
+                  "country": "USA",
+                  "seniority": "founder",
+                  "departments": [
+                    "c_suite"
+                  ],
+                  "subdepartments": null,
+                  "functions": null,
+                  "twitterUrl": null,
+                  "githubUrl": null,
+                  "facebookUrl": null,
+                  "enrichedAt": "2026-01-01T00:00:00.000Z",
+                  "organization": {
+                    "id": "10000000-0000-0000-0000-000000000001",
+                    "apolloOrganizationId": "5f2a3b4c5d6e7f8a9b0c1d2e",
+                    "name": "Casco Bay",
+                    "primaryDomain": "cascobay.com",
+                    "websiteUrl": "https://cascobay.com",
+                    "industry": "marketing",
+                    "estimatedNumEmployees": 12,
+                    "annualRevenue": "1000000",
+                    "logoUrl": null,
+                    "shortDescription": null,
+                    "linkedinUrl": null,
+                    "twitterUrl": null,
+                    "facebookUrl": null,
+                    "blogUrl": null,
+                    "crunchbaseUrl": null,
+                    "foundedYear": 2018,
+                    "city": "Portland",
+                    "state": "ME",
+                    "country": "USA",
+                    "streetAddress": null,
+                    "postalCode": null,
+                    "technologyNames": [
+                      "GA4"
+                    ],
+                    "industries": [
+                      "marketing"
+                    ],
+                    "secondaryIndustries": null
+                  },
+                  "contacts": [
+                    {
+                      "channel": "email",
+                      "value": "sara@cascobay.com",
+                      "status": "verified",
+                      "source": "apollo"
+                    }
+                  ],
+                  "employmentHistory": [
+                    {
+                      "organizationId": "10000000-0000-0000-0000-000000000001",
+                      "organizationName": "Casco Bay",
+                      "title": "Founder",
+                      "startDate": "2018-01-01",
+                      "endDate": null,
+                      "current": true,
+                      "description": null
+                    }
+                  ]
                 },
                 "brandIds": [
-                  "brand-uuid"
+                  "20000000-0000-0000-0000-000000000001"
                 ],
-                "orgId": "org-uuid",
-                "userId": "user-uuid",
+                "orgId": "30000000-0000-0000-0000-000000000001",
+                "userId": "40000000-0000-0000-0000-000000000001",
                 "apolloPersonId": "5f2a3b4c5d6e7f8a9b0c1d2e"
               }
             }
@@ -118,417 +145,662 @@
           }
         ]
       },
-      "ApolloPersonData": {
+      "ServedLead": {
         "type": "object",
-        "nullable": true,
         "properties": {
-          "id": {
-            "type": "string"
+          "leadId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Internal lead UUID. Same as data.leadId — kept at the top level for backwards compatibility with workflow scripts that read it directly.",
+            "example": "00000000-0000-0000-0000-000000000001"
           },
           "email": {
             "type": "string",
-            "nullable": true
+            "description": "The email address selected for outreach. Always populated when found=true. Same address appears in data.contacts for the 'email' channel.",
+            "example": "sara@cascobay.com"
           },
-          "emailStatus": {
+          "data": {
+            "$ref": "#/components/schemas/FullLead"
+          },
+          "brandIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Brand UUIDs this lead was buffered for (echoed back from x-brand-id header).",
+            "example": [
+              "20000000-0000-0000-0000-000000000001"
+            ]
+          },
+          "orgId": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Internal organization UUID owning the campaign.",
+            "example": "30000000-0000-0000-0000-000000000001"
+          },
+          "userId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Internal user UUID who triggered the campaign run.",
+            "example": "40000000-0000-0000-0000-000000000001"
+          },
+          "apolloPersonId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Apollo person ID — same value as data.apolloPersonId.",
+            "example": "5f2a3b4c5d6e7f8a9b0c1d2e"
+          }
+        },
+        "required": [
+          "leadId",
+          "email",
+          "data",
+          "brandIds",
+          "orgId",
+          "userId"
+        ],
+        "description": "A single lead served from the campaign buffer. The full lead payload lives under `data` (FullLead shape)."
+      },
+      "FullLead": {
+        "type": "object",
+        "properties": {
+          "leadId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Internal lead UUID (lead-service registry). Stable across enrichment refreshes.",
+            "example": "00000000-0000-0000-0000-000000000001"
+          },
+          "apolloPersonId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Apollo person ID — present when the lead was sourced or enriched via Apollo.",
+            "example": "5f2a3b4c5d6e7f8a9b0c1d2e"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "Lead's first name. Required — lead-service refuses to register a lead without one. Use this for recipientFirstName on outbound email.",
+            "example": "Sara"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "Lead's last name. Required. Use this for recipientLastName on outbound email.",
+            "example": "Freshley"
           },
           "name": {
             "type": "string",
-            "nullable": true
-          },
-          "firstName": {
-            "type": "string"
-          },
-          "lastName": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string",
-            "nullable": true
-          },
-          "linkedinUrl": {
-            "type": "string",
-            "nullable": true
-          },
-          "photoUrl": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Full display name as provided by source (often 'firstName lastName' but not always).",
+            "example": "Sara Freshley"
           },
           "headline": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Lead's professional headline / current role line (e.g. LinkedIn-style headline).",
+            "example": "Founder at Casco Bay"
+          },
+          "linkedinUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Lead's LinkedIn profile URL.",
+            "example": "https://linkedin.com/in/sara-freshley"
+          },
+          "photoUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Lead's profile photo URL.",
+            "example": "https://media.licdn.com/photo.jpg"
           },
           "city": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Lead's city.",
+            "example": "Portland"
           },
           "state": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Lead's state / province.",
+            "example": "ME"
           },
           "country": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Lead's country.",
+            "example": "USA"
           },
           "seniority": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Seniority bucket from enrichment (e.g. 'founder', 'director', 'vp').",
+            "example": "founder"
           },
           "departments": {
             "type": "array",
+            "nullable": true,
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Department classifications.",
+            "example": [
+              "c_suite"
+            ]
           },
           "subdepartments": {
             "type": "array",
+            "nullable": true,
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Subdepartment classifications.",
+            "example": [
+              "founders"
+            ]
           },
           "functions": {
             "type": "array",
+            "nullable": true,
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Job function classifications.",
+            "example": [
+              "entrepreneurship"
+            ]
           },
           "twitterUrl": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Lead's Twitter / X profile URL.",
+            "example": "https://twitter.com/sara"
           },
           "githubUrl": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Lead's GitHub profile URL.",
+            "example": "https://github.com/sara"
           },
           "facebookUrl": {
             "type": "string",
-            "nullable": true
-          },
-          "personalEmails": {
-            "type": "array",
             "nullable": true,
-            "items": {
-              "type": "string"
-            }
+            "description": "Lead's Facebook profile URL.",
+            "example": "https://facebook.com/sara"
           },
-          "mobilePhone": {
+          "enrichedAt": {
             "type": "string",
-            "nullable": true
-          },
-          "phoneNumbers": {
-            "type": "array",
             "nullable": true,
+            "description": "ISO 8601 timestamp of last successful enrichment. null when the lead was registered without enrichment.",
+            "example": "2026-01-01T00:00:00.000Z"
+          },
+          "organization": {
+            "$ref": "#/components/schemas/OrganizationView"
+          },
+          "contacts": {
+            "type": "array",
             "items": {
-              "type": "object",
-              "properties": {
-                "rawNumber": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "sanitizedNumber": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "type": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "position": {
-                  "type": "number",
-                  "nullable": true
-                },
-                "status": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "dncStatus": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "dncOtherInfo": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "dialerFlags": {
-                  "type": "object",
-                  "nullable": true,
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
+              "$ref": "#/components/schemas/ContactMethodView"
+            },
+            "description": "All contact methods attached to this lead — email, phone, etc. May be empty.",
+            "example": [
+              {
+                "channel": "email",
+                "value": "sara@cascobay.com",
+                "status": "verified",
+                "source": "apollo"
               }
-            }
+            ]
           },
           "employmentHistory": {
             "type": "array",
             "items": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "organizationName": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "startDate": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "endDate": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "description": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "current": {
-                  "type": "boolean"
-                }
+              "$ref": "#/components/schemas/EmploymentEntryView"
+            },
+            "description": "Full employment history (current + past). Returned in insertion order; check the `current` flag to find the present role.",
+            "example": [
+              {
+                "organizationId": "10000000-0000-0000-0000-000000000001",
+                "organizationName": "Casco Bay",
+                "title": "Founder",
+                "startDate": "2018-01-01",
+                "endDate": null,
+                "current": true,
+                "description": null
               }
-            }
-          },
-          "organizationId": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationName": {
-            "type": "string"
-          },
-          "organizationDomain": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationIndustry": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationSize": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationRawAddress": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationRevenueUsd": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationWebsiteUrl": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationLogoUrl": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationShortDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationSeoDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationLinkedinUrl": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationTwitterUrl": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationFacebookUrl": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationBlogUrl": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationCrunchbaseUrl": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationAngellistUrl": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationFoundedYear": {
-            "type": "number",
-            "nullable": true
-          },
-          "organizationPrimaryPhone": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationPubliclyTradedSymbol": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationPubliclyTradedExchange": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationAnnualRevenuePrinted": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationTotalFunding": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationTotalFundingPrinted": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationLatestFundingRoundDate": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationLatestFundingStage": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationFundingEvents": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "date": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "type": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "investors": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "amount": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "nullable": true
-                    }
-                  ]
-                },
-                "currency": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "news_url": {
-                  "type": "string",
-                  "nullable": true
-                }
-              }
-            }
-          },
-          "organizationCity": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationState": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationCountry": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationStreetAddress": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationPostalCode": {
-            "type": "string",
-            "nullable": true
-          },
-          "organizationTechnologyNames": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "organizationCurrentTechnologies": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "uid": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "name": {
-                  "type": "string",
-                  "nullable": true
-                },
-                "category": {
-                  "type": "string",
-                  "nullable": true
-                }
-              }
-            }
-          },
-          "organizationKeywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "organizationIndustries": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "organizationSecondaryIndustries": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "organizationNumSuborganizations": {
-            "type": "number",
-            "nullable": true
-          },
-          "organizationRetailLocationCount": {
-            "type": "number",
-            "nullable": true
-          },
-          "organizationAlexaRanking": {
-            "type": "number",
-            "nullable": true
-          },
-          "raw": {
-            "type": "object",
-            "nullable": true,
-            "additionalProperties": {
-              "nullable": true
-            }
+            ]
           }
         },
         "required": [
+          "leadId",
+          "apolloPersonId",
           "firstName",
           "lastName",
-          "organizationName"
+          "name",
+          "headline",
+          "linkedinUrl",
+          "photoUrl",
+          "city",
+          "state",
+          "country",
+          "seniority",
+          "departments",
+          "subdepartments",
+          "functions",
+          "twitterUrl",
+          "githubUrl",
+          "facebookUrl",
+          "enrichedAt",
+          "organization",
+          "contacts",
+          "employmentHistory"
         ],
-        "description": "Apollo person + organization data in flat camelCase format. Organization fields are prefixed with 'organization' (e.g. organizationDomain, organizationName) — there is NO nested 'organization' object."
+        "description": "Canonical lead representation returned by every lead-bearing endpoint. Built entirely from structured columns — there is no `metadata` or `raw` Apollo passthrough. Field names are stable regardless of upstream enrichment provider.",
+        "example": {
+          "leadId": "00000000-0000-0000-0000-000000000001",
+          "apolloPersonId": "5f2a3b4c5d6e7f8a9b0c1d2e",
+          "firstName": "Sara",
+          "lastName": "Freshley",
+          "name": "Sara Freshley",
+          "headline": "Founder at Casco Bay",
+          "linkedinUrl": "https://linkedin.com/in/sara-freshley",
+          "photoUrl": null,
+          "city": "Portland",
+          "state": "ME",
+          "country": "USA",
+          "seniority": "founder",
+          "departments": [
+            "c_suite"
+          ],
+          "subdepartments": [
+            "founders"
+          ],
+          "functions": [
+            "entrepreneurship"
+          ],
+          "twitterUrl": null,
+          "githubUrl": null,
+          "facebookUrl": null,
+          "enrichedAt": "2026-01-01T00:00:00.000Z",
+          "organization": {
+            "id": "10000000-0000-0000-0000-000000000001",
+            "apolloOrganizationId": "5f2a3b4c5d6e7f8a9b0c1d2e",
+            "name": "Casco Bay",
+            "primaryDomain": "cascobay.com",
+            "websiteUrl": "https://cascobay.com",
+            "industry": "marketing",
+            "estimatedNumEmployees": 12,
+            "annualRevenue": "1000000",
+            "logoUrl": "https://logo.clearbit.com/cascobay.com",
+            "shortDescription": "Boutique digital marketing agency in Portland, ME.",
+            "linkedinUrl": "https://linkedin.com/company/cascobay",
+            "twitterUrl": null,
+            "facebookUrl": null,
+            "blogUrl": null,
+            "crunchbaseUrl": null,
+            "foundedYear": 2018,
+            "city": "Portland",
+            "state": "ME",
+            "country": "USA",
+            "streetAddress": null,
+            "postalCode": "04101",
+            "technologyNames": [
+              "GA4",
+              "HubSpot"
+            ],
+            "industries": [
+              "marketing",
+              "advertising"
+            ],
+            "secondaryIndustries": null
+          },
+          "contacts": [
+            {
+              "channel": "email",
+              "value": "sara@cascobay.com",
+              "status": "verified",
+              "source": "apollo"
+            }
+          ],
+          "employmentHistory": [
+            {
+              "organizationId": "10000000-0000-0000-0000-000000000001",
+              "organizationName": "Casco Bay",
+              "title": "Founder",
+              "startDate": "2018-01-01",
+              "endDate": null,
+              "current": true,
+              "description": null
+            }
+          ]
+        }
+      },
+      "OrganizationView": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Internal organization UUID (lead-service registry).",
+            "example": "10000000-0000-0000-0000-000000000001"
+          },
+          "apolloOrganizationId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Apollo organization ID — present when sourced from Apollo enrichment.",
+            "example": "5f2a3b4c5d6e7f8a9b0c1d2e"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "description": "Company name as registered. Use this for recipientCompany on outbound email.",
+            "example": "Casco Bay"
+          },
+          "primaryDomain": {
+            "type": "string",
+            "nullable": true,
+            "description": "Primary domain of the company (no protocol). Useful for domain-level deliverability or matching.",
+            "example": "cascobay.com"
+          },
+          "websiteUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Canonical company website URL (with protocol).",
+            "example": "https://cascobay.com"
+          },
+          "industry": {
+            "type": "string",
+            "nullable": true,
+            "description": "Primary industry classification.",
+            "example": "marketing"
+          },
+          "estimatedNumEmployees": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Estimated employee count.",
+            "example": 12
+          },
+          "annualRevenue": {
+            "type": "string",
+            "nullable": true,
+            "description": "Annual revenue (USD), serialized as a numeric string to avoid float precision loss for very large companies.",
+            "example": "1000000"
+          },
+          "logoUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Logo image URL.",
+            "example": "https://logo.clearbit.com/cascobay.com"
+          },
+          "shortDescription": {
+            "type": "string",
+            "nullable": true,
+            "description": "Short marketing-style description of the company.",
+            "example": "Boutique digital marketing agency in Portland, ME."
+          },
+          "linkedinUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Company LinkedIn URL.",
+            "example": "https://linkedin.com/company/cascobay"
+          },
+          "twitterUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Company Twitter/X URL.",
+            "example": "https://twitter.com/cascobay"
+          },
+          "facebookUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Company Facebook URL.",
+            "example": "https://facebook.com/cascobay"
+          },
+          "blogUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Company blog URL.",
+            "example": "https://cascobay.com/blog"
+          },
+          "crunchbaseUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Crunchbase profile URL.",
+            "example": "https://crunchbase.com/organization/cascobay"
+          },
+          "foundedYear": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Year the company was founded.",
+            "example": 2018
+          },
+          "city": {
+            "type": "string",
+            "nullable": true,
+            "description": "Company HQ city.",
+            "example": "Portland"
+          },
+          "state": {
+            "type": "string",
+            "nullable": true,
+            "description": "Company HQ state / province (ISO subdivision when available).",
+            "example": "ME"
+          },
+          "country": {
+            "type": "string",
+            "nullable": true,
+            "description": "Company HQ country.",
+            "example": "USA"
+          },
+          "streetAddress": {
+            "type": "string",
+            "nullable": true,
+            "description": "Company HQ street address.",
+            "example": "123 Main St"
+          },
+          "postalCode": {
+            "type": "string",
+            "nullable": true,
+            "description": "Company HQ postal / ZIP code.",
+            "example": "04101"
+          },
+          "technologyNames": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            },
+            "description": "Technologies the company is known to use (e.g. 'GA4', 'Salesforce').",
+            "example": [
+              "GA4",
+              "HubSpot"
+            ]
+          },
+          "industries": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            },
+            "description": "All industry classifications attached to this company.",
+            "example": [
+              "marketing",
+              "advertising"
+            ]
+          },
+          "secondaryIndustries": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            },
+            "description": "Secondary industry classifications.",
+            "example": [
+              "digital-marketing"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "apolloOrganizationId",
+          "name",
+          "primaryDomain",
+          "websiteUrl",
+          "industry",
+          "estimatedNumEmployees",
+          "annualRevenue",
+          "logoUrl",
+          "shortDescription",
+          "linkedinUrl",
+          "twitterUrl",
+          "facebookUrl",
+          "blogUrl",
+          "crunchbaseUrl",
+          "foundedYear",
+          "city",
+          "state",
+          "country",
+          "streetAddress",
+          "postalCode",
+          "technologyNames",
+          "industries",
+          "secondaryIndustries"
+        ],
+        "description": "Snapshot of the lead's CURRENT employer organization, joined from leads_organizations where current=true. All fields are nullable because organization enrichment is best-effort. null at the parent level means the lead has no current employment record.",
+        "example": {
+          "id": "10000000-0000-0000-0000-000000000001",
+          "apolloOrganizationId": "5f2a3b4c5d6e7f8a9b0c1d2e",
+          "name": "Casco Bay",
+          "primaryDomain": "cascobay.com",
+          "websiteUrl": "https://cascobay.com",
+          "industry": "marketing",
+          "estimatedNumEmployees": 12,
+          "annualRevenue": "1000000",
+          "logoUrl": "https://logo.clearbit.com/cascobay.com",
+          "shortDescription": "Boutique digital marketing agency in Portland, ME.",
+          "linkedinUrl": "https://linkedin.com/company/cascobay",
+          "twitterUrl": null,
+          "facebookUrl": null,
+          "blogUrl": null,
+          "crunchbaseUrl": null,
+          "foundedYear": 2018,
+          "city": "Portland",
+          "state": "ME",
+          "country": "USA",
+          "streetAddress": null,
+          "postalCode": "04101",
+          "technologyNames": [
+            "GA4",
+            "HubSpot"
+          ],
+          "industries": [
+            "marketing",
+            "advertising"
+          ],
+          "secondaryIndustries": null
+        }
+      },
+      "ContactMethodView": {
+        "type": "object",
+        "properties": {
+          "channel": {
+            "type": "string",
+            "description": "Contact channel kind. Currently used: 'email', 'phone'. Stable identifier — case-sensitive.",
+            "example": "email"
+          },
+          "value": {
+            "type": "string",
+            "description": "Contact value (the actual email address, phone number, etc.). Unique per (leadId, channel).",
+            "example": "sara@cascobay.com"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true,
+            "description": "Provider-reported status of the contact value (e.g. 'verified', 'unverified', 'extrapolated' for emails). null when not classified.",
+            "example": "verified"
+          },
+          "source": {
+            "type": "string",
+            "description": "Where this contact method originated (e.g. 'apollo', 'manual', 'csv-upload').",
+            "example": "apollo"
+          }
+        },
+        "required": [
+          "channel",
+          "value",
+          "status",
+          "source"
+        ],
+        "description": "One contact endpoint attached to a lead — email, phone, or any other channel. Multiple rows per lead are possible.",
+        "example": {
+          "channel": "email",
+          "value": "sara@cascobay.com",
+          "status": "verified",
+          "source": "apollo"
+        }
+      },
+      "EmploymentEntryView": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Internal organization UUID for this employment row.",
+            "example": "10000000-0000-0000-0000-000000000001"
+          },
+          "organizationName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Organization name at time of join. May differ from current name if company was renamed.",
+            "example": "Casco Bay"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true,
+            "description": "Role title held during this employment.",
+            "example": "Founder"
+          },
+          "startDate": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO date (YYYY-MM-DD) when this employment started. null when unknown.",
+            "example": "2018-01-01"
+          },
+          "endDate": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO date (YYYY-MM-DD) when this employment ended. null when current or unknown.",
+            "example": null
+          },
+          "current": {
+            "type": "boolean",
+            "description": "True when this is the lead's current employment.",
+            "example": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "description": "Free-form description of the role.",
+            "example": "Leads strategy and operations."
+          }
+        },
+        "required": [
+          "organizationId",
+          "organizationName",
+          "title",
+          "startDate",
+          "endDate",
+          "current",
+          "description"
+        ],
+        "description": "One employment row from the lead's career history. All rows from leads_organizations are returned (past + current).",
+        "example": {
+          "organizationId": "10000000-0000-0000-0000-000000000001",
+          "organizationName": "Casco Bay",
+          "title": "Founder",
+          "startDate": "2018-01-01",
+          "endDate": null,
+          "current": true,
+          "description": "Leads strategy and operations."
+        }
       },
       "ErrorResponse": {
         "type": "object",
@@ -552,40 +824,40 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/LeadDetail"
-            }
+            },
+            "description": "All leads_campaigns rows matching the query, with full canonical lead payload + delivery overlay."
           }
         },
         "required": [
           "leads"
-        ]
+        ],
+        "description": "Response shape for GET /orgs/leads."
       },
       "LeadDetail": {
         "type": "object",
         "properties": {
           "id": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "leads_campaigns row UUID (per-campaign per-lead lifecycle row, NOT the lead itself).",
+            "example": "50000000-0000-0000-0000-000000000001"
           },
           "leadId": {
             "type": "string",
             "nullable": true,
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Internal lead UUID. Null only when the row references a lead that was deleted.",
+            "example": "00000000-0000-0000-0000-000000000001"
           },
           "namespace": {
-            "type": "string"
+            "type": "string",
+            "description": "Namespace this lead was sourced from. Currently always 'apollo'.",
+            "example": "apollo"
           },
           "email": {
-            "type": "string"
-          },
-          "apolloPersonId": {
             "type": "string",
-            "nullable": true,
-            "description": "Apollo person ID from enrichment"
-          },
-          "emailStatus": {
-            "type": "string",
-            "nullable": true,
-            "description": "Email verification status from Apollo (verified, extrapolated, etc.)"
+            "description": "The email address tied to this leads_campaigns row.",
+            "example": "sara@cascobay.com"
           },
           "status": {
             "type": "string",
@@ -595,66 +867,138 @@
               "claimed",
               "served"
             ],
-            "description": "Lead lifecycle status. 'buffered'/'skipped'/'claimed'/'served' all live in leads_campaigns; 'served' = pulled and served to a workflow."
+            "description": "Lead lifecycle status in this campaign. 'buffered'/'skipped'/'claimed'/'served' all live in leads_campaigns; 'served' = pulled and served to a workflow.",
+            "example": "served"
           },
-          "metadata": {
-            "$ref": "#/components/schemas/ApolloPersonData"
+          "statusReason": {
+            "type": "string",
+            "nullable": true,
+            "description": "Why this lead is in its current status (e.g. 'already_contacted', 'bounced'). Set for skipped/buffered leads.",
+            "example": "already_contacted"
+          },
+          "statusDetails": {
+            "type": "string",
+            "nullable": true,
+            "description": "Human-readable details about the status reason.",
+            "example": "Lead was contacted in campaign abc-123 on 2026-01-01."
           },
           "parentRunId": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Run ID of the workflow that pulled / processed this lead.",
+            "example": "run-uuid"
           },
           "runId": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Run ID for the campaign-tick that produced this lead.",
+            "example": "run-uuid"
           },
           "brandIds": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Brand UUIDs this lead was buffered for.",
+            "example": [
+              "20000000-0000-0000-0000-000000000001"
+            ]
           },
           "campaignId": {
-            "type": "string"
+            "type": "string",
+            "description": "Campaign ID owning this leads_campaigns row.",
+            "example": "60000000-0000-0000-0000-000000000001"
           },
           "orgId": {
-            "type": "string"
+            "type": "string",
+            "description": "Internal organization UUID.",
+            "example": "30000000-0000-0000-0000-000000000001"
           },
           "userId": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Internal user UUID who triggered the campaign run.",
+            "example": "40000000-0000-0000-0000-000000000001"
+          },
+          "workflowSlug": {
+            "type": "string",
+            "nullable": true,
+            "description": "Workflow slug that processed this lead (e.g. 'sales-cold-email-outreach-helium').",
+            "example": "sales-cold-email-outreach-helium"
+          },
+          "featureSlug": {
+            "type": "string",
+            "nullable": true,
+            "description": "Feature slug for tracking.",
+            "example": "outreach"
           },
           "servedAt": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "ISO timestamp when this lead was served. null for buffered/skipped/claimed rows.",
+            "example": "2026-01-01T00:00:00.000Z"
           },
-          "enrichment": {
-            "$ref": "#/components/schemas/ApolloPersonData"
+          "apolloPersonId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Apollo person ID — convenience copy of lead.apolloPersonId.",
+            "example": "5f2a3b4c5d6e7f8a9b0c1d2e"
+          },
+          "emailStatus": {
+            "type": "string",
+            "nullable": true,
+            "description": "Email verification status from Apollo (verified, unverified, extrapolated, etc.).",
+            "example": "verified"
+          },
+          "lead": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FullLead"
+              },
+              {
+                "nullable": true
+              }
+            ]
           },
           "contacted": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Lead has been contacted at least once in this scope (campaign or brand depending on query).",
+            "example": true
           },
           "sent": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "An email send has been attempted.",
+            "example": true
           },
           "delivered": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Provider confirmed delivery.",
+            "example": true
           },
           "opened": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Lead has opened at least one email.",
+            "example": false
           },
           "clicked": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Lead has clicked at least one tracked link.",
+            "example": false
           },
           "bounced": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Email bounced.",
+            "example": false
           },
           "unsubscribed": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Lead unsubscribed in this scope.",
+            "example": false
           },
           "replied": {
             "type": "boolean",
-            "description": "Whether the lead replied (any reply, regardless of sentiment)"
+            "description": "Whether the lead replied (any reply, regardless of sentiment).",
+            "example": false
           },
           "replyClassification": {
             "type": "string",
@@ -665,30 +1009,27 @@
               "neutral",
               null
             ],
-            "description": "Classification of the most recent reply from email-gateway. 'positive' = interested or willing to meet, 'negative' = not interested, 'neutral' = ambiguous or informational. null when no reply detected."
-          },
-          "statusReason": {
-            "type": "string",
-            "nullable": true,
-            "description": "Why this lead was skipped or placed in its current status (e.g. 'already_contacted', 'bounced'). Only set for buffer leads."
-          },
-          "statusDetails": {
-            "type": "string",
-            "nullable": true,
-            "description": "Human-readable details about the status reason. Only set for buffer leads."
+            "description": "Classification of the most recent reply from email-gateway. 'positive' = interested or willing to meet, 'negative' = not interested, 'neutral' = ambiguous or informational. null when no reply detected.",
+            "example": null
           },
           "lastDeliveredAt": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "ISO timestamp of the last delivered message in this scope.",
+            "example": "2026-01-02T00:00:00.000Z"
           },
           "global": {
             "type": "object",
             "properties": {
               "bounced": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Lead has bounced anywhere across the platform.",
+                "example": false
               },
               "unsubscribed": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Lead has unsubscribed anywhere across the platform.",
+                "example": false
               }
             },
             "required": [
@@ -703,18 +1044,21 @@
           "leadId",
           "namespace",
           "email",
-          "apolloPersonId",
-          "emailStatus",
           "status",
-          "metadata",
+          "statusReason",
+          "statusDetails",
           "parentRunId",
           "runId",
           "brandIds",
           "campaignId",
           "orgId",
           "userId",
+          "workflowSlug",
+          "featureSlug",
           "servedAt",
-          "enrichment",
+          "apolloPersonId",
+          "emailStatus",
+          "lead",
           "contacted",
           "sent",
           "delivered",
@@ -724,11 +1068,10 @@
           "unsubscribed",
           "replied",
           "replyClassification",
-          "statusReason",
-          "statusDetails",
           "lastDeliveredAt",
           "global"
-        ]
+        ],
+        "description": "One leads_campaigns row enriched with the full canonical lead payload (FullLead) and delivery status from email-gateway."
       },
       "StatsResponse": {
         "type": "object",
@@ -1155,6 +1498,7 @@
     "/orgs/buffer/next": {
       "post": {
         "summary": "Pull the next lead from the buffer",
+        "description": "Claims and returns the next available lead from the campaign buffer. Response contains the full canonical lead payload (FullLead) under `lead.data` — use `data.firstName`, `data.lastName`, `data.organization.name` for outbound recipient fields.",
         "parameters": [
           {
             "in": "header",
@@ -1240,7 +1584,7 @@
         },
         "responses": {
           "200": {
-            "description": "Next lead from buffer",
+            "description": "Next lead from buffer (or found=false when exhausted)",
             "content": {
               "application/json": {
                 "schema": {
@@ -1267,8 +1611,8 @@
     },
     "/orgs/leads": {
       "get": {
-        "summary": "List leads with enrichment and delivery status",
-        "description": "Returns leads from leads_campaigns. Each lead includes a 'status' field: 'served' (pulled and served), 'buffered'/'skipped'/'claimed' (still pending). Served leads include Apollo enrichment data, apolloPersonId, emailStatus, and full delivery status (contacted, sent, delivered, opened, clicked, bounced, unsubscribed, replied, replyClassification, lastDeliveredAt, global). Buffer entries have delivery fields defaulted to false/null. Delivery status is fetched from email-gateway when brandId or campaignId is provided. With campaignId: campaign-scoped status. With brandId only: brand-scoped (cross-campaign). Without either: status fields default to false/null.",
+        "summary": "List leads with full enrichment and delivery status",
+        "description": "Returns leads_campaigns rows. Each row includes the full canonical lead payload (FullLead — see schema) under `lead`, plus delivery status (contacted, sent, delivered, opened, clicked, bounced, unsubscribed, replied, replyClassification, lastDeliveredAt, global). Delivery status is fetched from email-gateway when brandId or campaignId is provided. With campaignId: campaign-scoped status. With brandId only: brand-scoped (cross-campaign). Without either: status fields default to false/null.",
         "parameters": [
           {
             "in": "header",
@@ -1377,7 +1721,7 @@
         ],
         "responses": {
           "200": {
-            "description": "List of served leads",
+            "description": "List of leads with full canonical payload + delivery overlay",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -15,6 +15,7 @@ import {
   leadHasEmail,
   getPrimaryEmail,
 } from "./leads-registry.js";
+import { buildFullLead } from "./lead-shape.js";
 import {
   checkContacted,
   isAlreadyServedForBrand,
@@ -549,11 +550,7 @@ export async function pullNext(
         .where(eq(leadsCampaigns.id, claimed.leadCampaignId));
       claimSettled = true;
 
-      const leadRow = await db.query.leads.findFirst({ where: eq(leads.id, claimed.leadId) });
-      const finalData: Record<string, unknown> = {
-        ...(leadRow?.metadata && typeof leadRow.metadata === "object" ? (leadRow.metadata as Record<string, unknown>) : {}),
-        email,
-      };
+      const fullLead = await buildFullLead(claimed.leadId);
 
       console.log(
         `[lead-service] pullNext found=true campaign=${params.campaignId} email=${email} leadId=${claimed.leadId}`,
@@ -563,7 +560,7 @@ export async function pullNext(
         lead: {
           leadId: claimed.leadId,
           email,
-          data: finalData,
+          data: fullLead,
           brandIds: params.brandIds,
           orgId: params.orgId,
           userId: params.userId ?? null,

--- a/src/lib/lead-shape.ts
+++ b/src/lib/lead-shape.ts
@@ -1,0 +1,186 @@
+import { eq, and } from "drizzle-orm";
+import { db } from "../db/index.js";
+import {
+  leads,
+  leadsOrganizations,
+  organizations,
+  leadContactMethods,
+} from "../db/schema.js";
+
+export interface OrganizationView {
+  id: string;
+  apolloOrganizationId: string | null;
+  name: string | null;
+  primaryDomain: string | null;
+  websiteUrl: string | null;
+  industry: string | null;
+  estimatedNumEmployees: number | null;
+  annualRevenue: string | null;
+  logoUrl: string | null;
+  shortDescription: string | null;
+  linkedinUrl: string | null;
+  twitterUrl: string | null;
+  facebookUrl: string | null;
+  blogUrl: string | null;
+  crunchbaseUrl: string | null;
+  foundedYear: number | null;
+  city: string | null;
+  state: string | null;
+  country: string | null;
+  streetAddress: string | null;
+  postalCode: string | null;
+  technologyNames: string[] | null;
+  industries: string[] | null;
+  secondaryIndustries: string[] | null;
+}
+
+export interface ContactMethodView {
+  channel: string;
+  value: string;
+  status: string | null;
+  source: string;
+}
+
+export interface EmploymentEntryView {
+  organizationId: string;
+  organizationName: string | null;
+  title: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  current: boolean;
+  description: string | null;
+}
+
+export interface FullLead {
+  leadId: string;
+  apolloPersonId: string | null;
+  firstName: string;
+  lastName: string;
+  name: string | null;
+  headline: string | null;
+  linkedinUrl: string | null;
+  photoUrl: string | null;
+  city: string | null;
+  state: string | null;
+  country: string | null;
+  seniority: string | null;
+  departments: string[] | null;
+  subdepartments: string[] | null;
+  functions: string[] | null;
+  twitterUrl: string | null;
+  githubUrl: string | null;
+  facebookUrl: string | null;
+  enrichedAt: string | null;
+  organization: OrganizationView | null;
+  contacts: ContactMethodView[];
+  employmentHistory: EmploymentEntryView[];
+}
+
+function mapOrganizationView(row: typeof organizations.$inferSelect): OrganizationView {
+  return {
+    id: row.id,
+    apolloOrganizationId: row.apolloOrganizationId ?? null,
+    name: row.name ?? null,
+    primaryDomain: row.primaryDomain ?? null,
+    websiteUrl: row.websiteUrl ?? null,
+    industry: row.industry ?? null,
+    estimatedNumEmployees: row.estimatedNumEmployees ?? null,
+    annualRevenue: row.annualRevenue ?? null,
+    logoUrl: row.logoUrl ?? null,
+    shortDescription: row.shortDescription ?? null,
+    linkedinUrl: row.linkedinUrl ?? null,
+    twitterUrl: row.twitterUrl ?? null,
+    facebookUrl: row.facebookUrl ?? null,
+    blogUrl: row.blogUrl ?? null,
+    crunchbaseUrl: row.crunchbaseUrl ?? null,
+    foundedYear: row.foundedYear ?? null,
+    city: row.city ?? null,
+    state: row.state ?? null,
+    country: row.country ?? null,
+    streetAddress: row.streetAddress ?? null,
+    postalCode: row.postalCode ?? null,
+    technologyNames: row.technologyNames ?? null,
+    industries: row.industries ?? null,
+    secondaryIndustries: row.secondaryIndustries ?? null,
+  };
+}
+
+export async function buildFullLead(leadId: string): Promise<FullLead> {
+  const lead = await db.query.leads.findFirst({ where: eq(leads.id, leadId) });
+  if (!lead) {
+    throw new Error(`[lead-service] buildFullLead: lead ${leadId} not found`);
+  }
+
+  const currentEmployment = await db.query.leadsOrganizations.findFirst({
+    where: and(eq(leadsOrganizations.leadId, leadId), eq(leadsOrganizations.current, true)),
+  });
+
+  let organization: OrganizationView | null = null;
+  if (currentEmployment) {
+    const orgRow = await db.query.organizations.findFirst({
+      where: eq(organizations.id, currentEmployment.organizationId),
+    });
+    if (orgRow) organization = mapOrganizationView(orgRow);
+  }
+
+  const contactRows = await db.query.leadContactMethods.findMany({
+    where: eq(leadContactMethods.leadId, leadId),
+    orderBy: (table, { asc: ascFn }) => [ascFn(table.createdAt)],
+  });
+  const contacts: ContactMethodView[] = contactRows.map((row) => ({
+    channel: row.channel,
+    value: row.value,
+    status: row.status ?? null,
+    source: row.source,
+  }));
+
+  const employmentRows = await db
+    .select({
+      organizationId: leadsOrganizations.organizationId,
+      organizationName: organizations.name,
+      title: leadsOrganizations.title,
+      startDate: leadsOrganizations.startDate,
+      endDate: leadsOrganizations.endDate,
+      current: leadsOrganizations.current,
+      description: leadsOrganizations.description,
+    })
+    .from(leadsOrganizations)
+    .leftJoin(organizations, eq(organizations.id, leadsOrganizations.organizationId))
+    .where(eq(leadsOrganizations.leadId, leadId));
+
+  const employmentHistory: EmploymentEntryView[] = employmentRows.map((row) => ({
+    organizationId: row.organizationId,
+    organizationName: row.organizationName ?? null,
+    title: row.title ?? null,
+    startDate: row.startDate ?? null,
+    endDate: row.endDate ?? null,
+    current: row.current,
+    description: row.description ?? null,
+  }));
+
+  return {
+    leadId: lead.id,
+    apolloPersonId: lead.apolloPersonId ?? null,
+    firstName: lead.firstName ?? "",
+    lastName: lead.lastName ?? "",
+    name: lead.name ?? null,
+    headline: lead.headline ?? null,
+    linkedinUrl: lead.linkedinUrl ?? null,
+    photoUrl: lead.photoUrl ?? null,
+    city: lead.city ?? null,
+    state: lead.state ?? null,
+    country: lead.country ?? null,
+    seniority: lead.seniority ?? null,
+    departments: lead.departments ?? null,
+    subdepartments: lead.subdepartments ?? null,
+    functions: lead.functions ?? null,
+    twitterUrl: lead.twitterUrl ?? null,
+    githubUrl: lead.githubUrl ?? null,
+    facebookUrl: lead.facebookUrl ?? null,
+    enrichedAt: lead.enrichedAt ? lead.enrichedAt.toISOString() : null,
+    organization,
+    contacts,
+    employmentHistory,
+  };
+}
+

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { eq, and, sql, type SQL } from "drizzle-orm";
 import { type AuthenticatedRequest, apiKeyAuth, requireOrgId, getServiceContext } from "../middleware/auth.js";
 import { db } from "../db/index.js";
-import { leadsCampaigns, leads, leadContactMethods } from "../db/schema.js";
+import { leadsCampaigns, leads } from "../db/schema.js";
 import {
   checkDeliveryStatus,
   type StatusResult,
@@ -11,6 +11,7 @@ import {
   type GlobalStatus,
 } from "../lib/email-gateway-client.js";
 import { traceEvent } from "../lib/trace-event.js";
+import { buildFullLead, type FullLead } from "../lib/lead-shape.js";
 
 const router = Router();
 
@@ -127,35 +128,25 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
         workflowSlug: leadsCampaigns.workflowSlug,
         featureSlug: leadsCampaigns.featureSlug,
         leadApolloPersonId: leads.apolloPersonId,
-        leadFirstName: leads.firstName,
-        leadLastName: leads.lastName,
-        leadName: leads.name,
-        leadHeadline: leads.headline,
-        leadLinkedinUrl: leads.linkedinUrl,
-        leadCity: leads.city,
-        leadState: leads.state,
-        leadCountry: leads.country,
-        leadMetadata: leads.metadata,
       })
       .from(leadsCampaigns)
       .leftJoin(leads, eq(leads.id, leadsCampaigns.leadId))
       .where(and(...conditions));
 
-    // Fetch primary email per leadId in a single query
     const leadIds = Array.from(new Set(rows.map((r) => r.leadId)));
-    const emailRows = leadIds.length === 0
-      ? []
-      : await db.execute<{ lead_id: string; value: string; status: string | null }>(sql`
-          SELECT DISTINCT ON (lead_id) lead_id, value, status
-          FROM lead_contact_methods
-          WHERE channel = 'email'
-            AND lead_id = ANY(${sql.raw(`ARRAY[${leadIds.map((id) => `'${id.replace(/'/g, "''")}'`).join(",") || "NULL"}]::uuid[]`)})
-          ORDER BY lead_id, created_at DESC
-        `);
-    const emailByLead = new Map<string, { value: string; status: string | null }>();
-    for (const row of emailRows as unknown as Array<{ lead_id: string; value: string; status: string | null }>) {
-      emailByLead.set(row.lead_id, { value: row.value, status: row.status });
-    }
+    const fullLeadByLeadId = new Map<string, FullLead>();
+    await Promise.all(
+      leadIds.map(async (leadId) => {
+        const fullLead = await buildFullLead(leadId);
+        fullLeadByLeadId.set(leadId, fullLead);
+      }),
+    );
+
+    const primaryEmail = (lead: FullLead | undefined): { value: string; status: string | null } | null => {
+      if (!lead) return null;
+      const email = lead.contacts.find((c) => c.channel === "email");
+      return email ? { value: email.value, status: email.status } : null;
+    };
 
     const campaignIdStr = typeof campaignId === "string" ? campaignId : undefined;
     const brandIdStr = typeof brandId === "string" ? brandId : undefined;
@@ -168,7 +159,8 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
       const groups = new Map<string, { brandId: string; items: DeliveryStatusItem[] }>();
       for (const row of rows) {
         if (row.status !== "served") continue;
-        const email = emailByLead.get(row.leadId)?.value;
+        const fullLead = fullLeadByLeadId.get(row.leadId);
+        const email = primaryEmail(fullLead)?.value;
         if (!email) continue;
         const primaryBrandId = row.brandIds[0] ?? "unknown";
         if (!groups.has(primaryBrandId)) {
@@ -185,7 +177,8 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
     }
 
     const allLeads = rows.map((row) => {
-      const email = emailByLead.get(row.leadId);
+      const fullLead = fullLeadByLeadId.get(row.leadId) ?? null;
+      const email = primaryEmail(fullLead ?? undefined);
       const emailValue = email?.value ?? "";
       const emailStatus = email?.status ?? null;
       const statusResult = statusMap.get(emailValue);
@@ -193,29 +186,12 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
         ? (statusResult ? flatten(statusResult) : DEFAULT_STATUS)
         : DEFAULT_STATUS;
 
-      const enrichment = row.leadFirstName || row.leadLastName || row.leadHeadline || row.leadMetadata
-        ? {
-            firstName: row.leadFirstName ?? undefined,
-            lastName: row.leadLastName ?? undefined,
-            name: row.leadName ?? undefined,
-            headline: row.leadHeadline ?? undefined,
-            linkedinUrl: row.leadLinkedinUrl ?? undefined,
-            city: row.leadCity ?? undefined,
-            state: row.leadState ?? undefined,
-            country: row.leadCountry ?? undefined,
-            ...(row.leadMetadata && typeof row.leadMetadata === "object"
-              ? (row.leadMetadata as Record<string, unknown>)
-              : {}),
-          }
-        : null;
-
       return {
         id: row.id,
         leadId: row.leadId,
         namespace: "apollo",
         email: emailValue,
         apolloPersonId: row.leadApolloPersonId ?? null,
-        metadata: row.leadMetadata,
         parentRunId: row.parentRunId,
         runId: row.runId,
         brandIds: row.brandIds,
@@ -227,7 +203,7 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
         servedAt: row.servedAt ? row.servedAt.toISOString() : null,
         status: row.status as "buffered" | "skipped" | "claimed" | "served",
         emailStatus,
-        enrichment,
+        lead: fullLead,
         statusReason: row.statusReason ?? null,
         statusDetails: row.statusDetails ?? null,
         ...deliveryStatus,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -89,121 +89,556 @@ const HealthResponseSchema = z
   })
   .openapi("HealthResponse");
 
-// --- Apollo Person Data (flat camelCase — matches Apollo enrichment API) ---
+// --- Canonical lead views ---
+//
+// Every lead-bearing endpoint returns the same canonical FullLead shape.
+// Built from structured DB columns only — no Apollo raw blob, no metadata
+// passthrough. Clients can rely on field names + types being stable across
+// upstream provider changes.
 
-const EmploymentHistorySchema = z.object({
-  title: z.string().nullable().optional(),
-  organizationName: z.string().nullable().optional(),
-  startDate: z.string().nullable().optional(),
-  endDate: z.string().nullable().optional(),
-  description: z.string().nullable().optional(),
-  current: z.boolean().optional(),
-});
-
-const FundingEventSchema = z.object({
-  id: z.string().nullable().optional(),
-  date: z.string().nullable().optional(),
-  type: z.string().nullable().optional(),
-  investors: z.string().nullable().optional(),
-  amount: z.union([z.number(), z.string()]).nullable().optional(),
-  currency: z.string().nullable().optional(),
-  news_url: z.string().nullable().optional(),
-});
-
-const TechnologySchema = z.object({
-  uid: z.string().nullable().optional(),
-  name: z.string().nullable().optional(),
-  category: z.string().nullable().optional(),
-});
-
-const PhoneNumberSchema = z.object({
-  rawNumber: z.string().nullable().optional(),
-  sanitizedNumber: z.string().nullable().optional(),
-  type: z.string().nullable().optional(),
-  position: z.number().nullable().optional(),
-  status: z.string().nullable().optional(),
-  dncStatus: z.string().nullable().optional(),
-  dncOtherInfo: z.string().nullable().optional(),
-  dialerFlags: z.record(z.string(), z.unknown()).nullable().optional(),
-});
-
-export const ApolloPersonDataSchema = z
+const ContactMethodViewSchema = z
   .object({
-    // Person identifiers
-    id: z.string().optional(),
-    email: z.string().nullable().optional(),
-    emailStatus: z.string().nullable().optional(),
-    name: z.string().nullable().optional(),
-    firstName: z.string(),
-    lastName: z.string(),
-    title: z.string().nullable().optional(),
-    linkedinUrl: z.string().nullable().optional(),
-    // Person details
-    photoUrl: z.string().nullable().optional(),
-    headline: z.string().nullable().optional(),
-    city: z.string().nullable().optional(),
-    state: z.string().nullable().optional(),
-    country: z.string().nullable().optional(),
-    seniority: z.string().nullable().optional(),
-    departments: z.array(z.string()).optional(),
-    subdepartments: z.array(z.string()).optional(),
-    functions: z.array(z.string()).optional(),
-    twitterUrl: z.string().nullable().optional(),
-    githubUrl: z.string().nullable().optional(),
-    facebookUrl: z.string().nullable().optional(),
-    personalEmails: z.array(z.string()).nullable().optional(),
-    mobilePhone: z.string().nullable().optional(),
-    phoneNumbers: z.array(PhoneNumberSchema).nullable().optional(),
-    employmentHistory: z.array(EmploymentHistorySchema).optional(),
-    // Organization details (flat, NOT nested)
-    organizationId: z.string().nullable().optional(),
-    organizationName: z.string(),
-    organizationDomain: z.string().nullable().optional(),
-    organizationIndustry: z.string().nullable().optional(),
-    organizationSize: z.string().nullable().optional(),
-    organizationRawAddress: z.string().nullable().optional(),
-    organizationRevenueUsd: z.string().nullable().optional(),
-    organizationWebsiteUrl: z.string().nullable().optional(),
-    organizationLogoUrl: z.string().nullable().optional(),
-    organizationShortDescription: z.string().nullable().optional(),
-    organizationSeoDescription: z.string().nullable().optional(),
-    organizationLinkedinUrl: z.string().nullable().optional(),
-    organizationTwitterUrl: z.string().nullable().optional(),
-    organizationFacebookUrl: z.string().nullable().optional(),
-    organizationBlogUrl: z.string().nullable().optional(),
-    organizationCrunchbaseUrl: z.string().nullable().optional(),
-    organizationAngellistUrl: z.string().nullable().optional(),
-    organizationFoundedYear: z.number().nullable().optional(),
-    organizationPrimaryPhone: z.string().nullable().optional(),
-    organizationPubliclyTradedSymbol: z.string().nullable().optional(),
-    organizationPubliclyTradedExchange: z.string().nullable().optional(),
-    organizationAnnualRevenuePrinted: z.string().nullable().optional(),
-    organizationTotalFunding: z.string().nullable().optional(),
-    organizationTotalFundingPrinted: z.string().nullable().optional(),
-    organizationLatestFundingRoundDate: z.string().nullable().optional(),
-    organizationLatestFundingStage: z.string().nullable().optional(),
-    organizationFundingEvents: z.array(FundingEventSchema).optional(),
-    organizationCity: z.string().nullable().optional(),
-    organizationState: z.string().nullable().optional(),
-    organizationCountry: z.string().nullable().optional(),
-    organizationStreetAddress: z.string().nullable().optional(),
-    organizationPostalCode: z.string().nullable().optional(),
-    organizationTechnologyNames: z.array(z.string()).optional(),
-    organizationCurrentTechnologies: z.array(TechnologySchema).optional(),
-    organizationKeywords: z.array(z.string()).optional(),
-    organizationIndustries: z.array(z.string()).optional(),
-    organizationSecondaryIndustries: z.array(z.string()).optional(),
-    organizationNumSuborganizations: z.number().nullable().optional(),
-    organizationRetailLocationCount: z.number().nullable().optional(),
-    organizationAlexaRanking: z.number().nullable().optional(),
-    // Verbatim Apollo person payload (snake_case, includes any field Apollo returns)
-    raw: z.record(z.string(), z.unknown()).nullable().optional(),
+    channel: z
+      .string()
+      .openapi({
+        description:
+          "Contact channel kind. Currently used: 'email', 'phone'. Stable identifier — case-sensitive.",
+        example: "email",
+      }),
+    value: z
+      .string()
+      .openapi({
+        description:
+          "Contact value (the actual email address, phone number, etc.). Unique per (leadId, channel).",
+        example: "sara@cascobay.com",
+      }),
+    status: z
+      .string()
+      .nullable()
+      .openapi({
+        description:
+          "Provider-reported status of the contact value (e.g. 'verified', 'unverified', 'extrapolated' for emails). null when not classified.",
+        example: "verified",
+      }),
+    source: z
+      .string()
+      .openapi({
+        description:
+          "Where this contact method originated (e.g. 'apollo', 'manual', 'csv-upload').",
+        example: "apollo",
+      }),
   })
-  .openapi("ApolloPersonData", {
+  .openapi("ContactMethodView", {
     description:
-      "Apollo person + organization data in flat camelCase format. " +
-      "Organization fields are prefixed with 'organization' (e.g. organizationDomain, organizationName) — " +
-      "there is NO nested 'organization' object.",
+      "One contact endpoint attached to a lead — email, phone, or any other channel. Multiple rows per lead are possible.",
+    example: {
+      channel: "email",
+      value: "sara@cascobay.com",
+      status: "verified",
+      source: "apollo",
+    },
+  });
+
+const OrganizationViewSchema = z
+  .object({
+    id: z
+      .string()
+      .uuid()
+      .openapi({
+        description: "Internal organization UUID (lead-service registry).",
+        example: "10000000-0000-0000-0000-000000000001",
+      }),
+    apolloOrganizationId: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Apollo organization ID — present when sourced from Apollo enrichment.",
+        example: "5f2a3b4c5d6e7f8a9b0c1d2e",
+      }),
+    name: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Company name as registered. Use this for recipientCompany on outbound email.",
+        example: "Casco Bay",
+      }),
+    primaryDomain: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Primary domain of the company (no protocol). Useful for domain-level deliverability or matching.",
+        example: "cascobay.com",
+      }),
+    websiteUrl: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Canonical company website URL (with protocol).",
+        example: "https://cascobay.com",
+      }),
+    industry: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Primary industry classification.",
+        example: "marketing",
+      }),
+    estimatedNumEmployees: z
+      .number()
+      .int()
+      .nullable()
+      .openapi({
+        description: "Estimated employee count.",
+        example: 12,
+      }),
+    annualRevenue: z
+      .string()
+      .nullable()
+      .openapi({
+        description:
+          "Annual revenue (USD), serialized as a numeric string to avoid float precision loss for very large companies.",
+        example: "1000000",
+      }),
+    logoUrl: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Logo image URL.",
+        example: "https://logo.clearbit.com/cascobay.com",
+      }),
+    shortDescription: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Short marketing-style description of the company.",
+        example: "Boutique digital marketing agency in Portland, ME.",
+      }),
+    linkedinUrl: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Company LinkedIn URL.",
+        example: "https://linkedin.com/company/cascobay",
+      }),
+    twitterUrl: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Company Twitter/X URL.",
+        example: "https://twitter.com/cascobay",
+      }),
+    facebookUrl: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Company Facebook URL.",
+        example: "https://facebook.com/cascobay",
+      }),
+    blogUrl: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Company blog URL.",
+        example: "https://cascobay.com/blog",
+      }),
+    crunchbaseUrl: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Crunchbase profile URL.",
+        example: "https://crunchbase.com/organization/cascobay",
+      }),
+    foundedYear: z
+      .number()
+      .int()
+      .nullable()
+      .openapi({
+        description: "Year the company was founded.",
+        example: 2018,
+      }),
+    city: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Company HQ city.",
+        example: "Portland",
+      }),
+    state: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Company HQ state / province (ISO subdivision when available).",
+        example: "ME",
+      }),
+    country: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Company HQ country.",
+        example: "USA",
+      }),
+    streetAddress: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Company HQ street address.",
+        example: "123 Main St",
+      }),
+    postalCode: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Company HQ postal / ZIP code.",
+        example: "04101",
+      }),
+    technologyNames: z
+      .array(z.string())
+      .nullable()
+      .openapi({
+        description: "Technologies the company is known to use (e.g. 'GA4', 'Salesforce').",
+        example: ["GA4", "HubSpot"],
+      }),
+    industries: z
+      .array(z.string())
+      .nullable()
+      .openapi({
+        description: "All industry classifications attached to this company.",
+        example: ["marketing", "advertising"],
+      }),
+    secondaryIndustries: z
+      .array(z.string())
+      .nullable()
+      .openapi({
+        description: "Secondary industry classifications.",
+        example: ["digital-marketing"],
+      }),
+  })
+  .openapi("OrganizationView", {
+    description:
+      "Snapshot of the lead's CURRENT employer organization, joined from leads_organizations where current=true. " +
+      "All fields are nullable because organization enrichment is best-effort. " +
+      "null at the parent level means the lead has no current employment record.",
+    example: {
+      id: "10000000-0000-0000-0000-000000000001",
+      apolloOrganizationId: "5f2a3b4c5d6e7f8a9b0c1d2e",
+      name: "Casco Bay",
+      primaryDomain: "cascobay.com",
+      websiteUrl: "https://cascobay.com",
+      industry: "marketing",
+      estimatedNumEmployees: 12,
+      annualRevenue: "1000000",
+      logoUrl: "https://logo.clearbit.com/cascobay.com",
+      shortDescription: "Boutique digital marketing agency in Portland, ME.",
+      linkedinUrl: "https://linkedin.com/company/cascobay",
+      twitterUrl: null,
+      facebookUrl: null,
+      blogUrl: null,
+      crunchbaseUrl: null,
+      foundedYear: 2018,
+      city: "Portland",
+      state: "ME",
+      country: "USA",
+      streetAddress: null,
+      postalCode: "04101",
+      technologyNames: ["GA4", "HubSpot"],
+      industries: ["marketing", "advertising"],
+      secondaryIndustries: null,
+    },
+  });
+
+const EmploymentEntryViewSchema = z
+  .object({
+    organizationId: z
+      .string()
+      .uuid()
+      .openapi({
+        description: "Internal organization UUID for this employment row.",
+        example: "10000000-0000-0000-0000-000000000001",
+      }),
+    organizationName: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Organization name at time of join. May differ from current name if company was renamed.",
+        example: "Casco Bay",
+      }),
+    title: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Role title held during this employment.",
+        example: "Founder",
+      }),
+    startDate: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "ISO date (YYYY-MM-DD) when this employment started. null when unknown.",
+        example: "2018-01-01",
+      }),
+    endDate: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "ISO date (YYYY-MM-DD) when this employment ended. null when current or unknown.",
+        example: null,
+      }),
+    current: z
+      .boolean()
+      .openapi({
+        description: "True when this is the lead's current employment.",
+        example: true,
+      }),
+    description: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Free-form description of the role.",
+        example: "Leads strategy and operations.",
+      }),
+  })
+  .openapi("EmploymentEntryView", {
+    description:
+      "One employment row from the lead's career history. All rows from leads_organizations are returned (past + current).",
+    example: {
+      organizationId: "10000000-0000-0000-0000-000000000001",
+      organizationName: "Casco Bay",
+      title: "Founder",
+      startDate: "2018-01-01",
+      endDate: null,
+      current: true,
+      description: "Leads strategy and operations.",
+    },
+  });
+
+export const FullLeadSchema = z
+  .object({
+    leadId: z
+      .string()
+      .uuid()
+      .openapi({
+        description: "Internal lead UUID (lead-service registry). Stable across enrichment refreshes.",
+        example: "00000000-0000-0000-0000-000000000001",
+      }),
+    apolloPersonId: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Apollo person ID — present when the lead was sourced or enriched via Apollo.",
+        example: "5f2a3b4c5d6e7f8a9b0c1d2e",
+      }),
+    firstName: z
+      .string()
+      .openapi({
+        description:
+          "Lead's first name. Required — lead-service refuses to register a lead without one. " +
+          "Use this for recipientFirstName on outbound email.",
+        example: "Sara",
+      }),
+    lastName: z
+      .string()
+      .openapi({
+        description:
+          "Lead's last name. Required. Use this for recipientLastName on outbound email.",
+        example: "Freshley",
+      }),
+    name: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Full display name as provided by source (often 'firstName lastName' but not always).",
+        example: "Sara Freshley",
+      }),
+    headline: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Lead's professional headline / current role line (e.g. LinkedIn-style headline).",
+        example: "Founder at Casco Bay",
+      }),
+    linkedinUrl: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Lead's LinkedIn profile URL.",
+        example: "https://linkedin.com/in/sara-freshley",
+      }),
+    photoUrl: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Lead's profile photo URL.",
+        example: "https://media.licdn.com/photo.jpg",
+      }),
+    city: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Lead's city.",
+        example: "Portland",
+      }),
+    state: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Lead's state / province.",
+        example: "ME",
+      }),
+    country: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Lead's country.",
+        example: "USA",
+      }),
+    seniority: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Seniority bucket from enrichment (e.g. 'founder', 'director', 'vp').",
+        example: "founder",
+      }),
+    departments: z
+      .array(z.string())
+      .nullable()
+      .openapi({
+        description: "Department classifications.",
+        example: ["c_suite"],
+      }),
+    subdepartments: z
+      .array(z.string())
+      .nullable()
+      .openapi({
+        description: "Subdepartment classifications.",
+        example: ["founders"],
+      }),
+    functions: z
+      .array(z.string())
+      .nullable()
+      .openapi({
+        description: "Job function classifications.",
+        example: ["entrepreneurship"],
+      }),
+    twitterUrl: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Lead's Twitter / X profile URL.",
+        example: "https://twitter.com/sara",
+      }),
+    githubUrl: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Lead's GitHub profile URL.",
+        example: "https://github.com/sara",
+      }),
+    facebookUrl: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Lead's Facebook profile URL.",
+        example: "https://facebook.com/sara",
+      }),
+    enrichedAt: z
+      .string()
+      .nullable()
+      .openapi({
+        description:
+          "ISO 8601 timestamp of last successful enrichment. null when the lead was registered without enrichment.",
+        example: "2026-01-01T00:00:00.000Z",
+      }),
+    organization: OrganizationViewSchema.nullable(),
+    contacts: z
+      .array(ContactMethodViewSchema)
+      .openapi({
+        description: "All contact methods attached to this lead — email, phone, etc. May be empty.",
+        example: [
+          { channel: "email", value: "sara@cascobay.com", status: "verified", source: "apollo" },
+        ],
+      }),
+    employmentHistory: z
+      .array(EmploymentEntryViewSchema)
+      .openapi({
+        description:
+          "Full employment history (current + past). Returned in insertion order; check the `current` flag to find the present role.",
+        example: [
+          {
+            organizationId: "10000000-0000-0000-0000-000000000001",
+            organizationName: "Casco Bay",
+            title: "Founder",
+            startDate: "2018-01-01",
+            endDate: null,
+            current: true,
+            description: null,
+          },
+        ],
+      }),
+  })
+  .openapi("FullLead", {
+    description:
+      "Canonical lead representation returned by every lead-bearing endpoint. Built entirely from structured columns — there is no `metadata` or `raw` Apollo passthrough. Field names are stable regardless of upstream enrichment provider.",
+    example: {
+      leadId: "00000000-0000-0000-0000-000000000001",
+      apolloPersonId: "5f2a3b4c5d6e7f8a9b0c1d2e",
+      firstName: "Sara",
+      lastName: "Freshley",
+      name: "Sara Freshley",
+      headline: "Founder at Casco Bay",
+      linkedinUrl: "https://linkedin.com/in/sara-freshley",
+      photoUrl: null,
+      city: "Portland",
+      state: "ME",
+      country: "USA",
+      seniority: "founder",
+      departments: ["c_suite"],
+      subdepartments: ["founders"],
+      functions: ["entrepreneurship"],
+      twitterUrl: null,
+      githubUrl: null,
+      facebookUrl: null,
+      enrichedAt: "2026-01-01T00:00:00.000Z",
+      organization: {
+        id: "10000000-0000-0000-0000-000000000001",
+        apolloOrganizationId: "5f2a3b4c5d6e7f8a9b0c1d2e",
+        name: "Casco Bay",
+        primaryDomain: "cascobay.com",
+        websiteUrl: "https://cascobay.com",
+        industry: "marketing",
+        estimatedNumEmployees: 12,
+        annualRevenue: "1000000",
+        logoUrl: "https://logo.clearbit.com/cascobay.com",
+        shortDescription: "Boutique digital marketing agency in Portland, ME.",
+        linkedinUrl: "https://linkedin.com/company/cascobay",
+        twitterUrl: null,
+        facebookUrl: null,
+        blogUrl: null,
+        crunchbaseUrl: null,
+        foundedYear: 2018,
+        city: "Portland",
+        state: "ME",
+        country: "USA",
+        streetAddress: null,
+        postalCode: "04101",
+        technologyNames: ["GA4", "HubSpot"],
+        industries: ["marketing", "advertising"],
+        secondaryIndustries: null,
+      },
+      contacts: [
+        { channel: "email", value: "sara@cascobay.com", status: "verified", source: "apollo" },
+      ],
+      employmentHistory: [
+        {
+          organizationId: "10000000-0000-0000-0000-000000000001",
+          organizationName: "Casco Bay",
+          title: "Founder",
+          startDate: "2018-01-01",
+          endDate: null,
+          current: true,
+          description: null,
+        },
+      ],
+    },
   });
 
 // --- Buffer Next ---
@@ -212,50 +647,143 @@ export const BufferNextRequestSchema = z
   .object({})
   .openapi("BufferNextRequest");
 
-const ServedLeadSchema = z.object({
-  leadId: z.string().uuid(),
-  email: z.string(),
-  data: ApolloPersonDataSchema.nullable(),
-  brandIds: z.array(z.string()),
-  orgId: z.string().nullable(),
-  userId: z.string().nullable(),
-  apolloPersonId: z
-    .string()
-    .nullable()
-    .optional()
-    .openapi({
-      description:
-        "Apollo person ID from enrichment. Present when the lead was sourced or enriched via Apollo.",
-      example: "5f2a3b4c5d6e7f8a9b0c1d2e",
-    }),
-});
-
-const BufferNextResponseSchema = z
+const ServedLeadSchema = z
   .object({
-    found: z.boolean(),
+    leadId: z
+      .string()
+      .uuid()
+      .openapi({
+        description:
+          "Internal lead UUID. Same as data.leadId — kept at the top level for backwards compatibility with workflow scripts that read it directly.",
+        example: "00000000-0000-0000-0000-000000000001",
+      }),
+    email: z
+      .string()
+      .openapi({
+        description:
+          "The email address selected for outreach. Always populated when found=true. Same address appears in data.contacts for the 'email' channel.",
+        example: "sara@cascobay.com",
+      }),
+    data: FullLeadSchema,
+    brandIds: z
+      .array(z.string())
+      .openapi({
+        description: "Brand UUIDs this lead was buffered for (echoed back from x-brand-id header).",
+        example: ["20000000-0000-0000-0000-000000000001"],
+      }),
+    orgId: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Internal organization UUID owning the campaign.",
+        example: "30000000-0000-0000-0000-000000000001",
+      }),
+    userId: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Internal user UUID who triggered the campaign run.",
+        example: "40000000-0000-0000-0000-000000000001",
+      }),
+    apolloPersonId: z
+      .string()
+      .nullable()
+      .optional()
+      .openapi({
+        description: "Apollo person ID — same value as data.apolloPersonId.",
+        example: "5f2a3b4c5d6e7f8a9b0c1d2e",
+      }),
+  })
+  .openapi("ServedLead", {
+    description:
+      "A single lead served from the campaign buffer. The full lead payload lives under `data` (FullLead shape).",
+  });
+
+export const BufferNextResponseSchema = z
+  .object({
+    found: z
+      .boolean()
+      .openapi({
+        description: "True when a lead was claimed and returned. False when the campaign buffer is empty.",
+        example: true,
+      }),
     lead: ServedLeadSchema.optional(),
   })
   .openapi("BufferNextResponse", {
     description:
-      "Response from pulling the next lead. When found is true, lead contains the served lead with typed IDs.",
+      "Response from POST /orgs/buffer/next. When found is true, lead contains the served lead with full canonical FullLead payload under `lead.data`.",
     examples: [
       {
         summary: "Apollo lead",
         value: {
           found: true,
           lead: {
-            leadId: "c1d2e3f4-a5b6-7890-abcd-ef1234567890",
-            email: "jane.doe@acme.com",
+            leadId: "00000000-0000-0000-0000-000000000001",
+            email: "sara@cascobay.com",
             data: {
-              firstName: "Jane",
-              lastName: "Doe",
-              title: "VP of Marketing",
-              organizationName: "Acme Corp",
-              organizationDomain: "acme.com",
+              leadId: "00000000-0000-0000-0000-000000000001",
+              apolloPersonId: "5f2a3b4c5d6e7f8a9b0c1d2e",
+              firstName: "Sara",
+              lastName: "Freshley",
+              name: "Sara Freshley",
+              headline: "Founder at Casco Bay",
+              linkedinUrl: "https://linkedin.com/in/sara-freshley",
+              photoUrl: null,
+              city: "Portland",
+              state: "ME",
+              country: "USA",
+              seniority: "founder",
+              departments: ["c_suite"],
+              subdepartments: null,
+              functions: null,
+              twitterUrl: null,
+              githubUrl: null,
+              facebookUrl: null,
+              enrichedAt: "2026-01-01T00:00:00.000Z",
+              organization: {
+                id: "10000000-0000-0000-0000-000000000001",
+                apolloOrganizationId: "5f2a3b4c5d6e7f8a9b0c1d2e",
+                name: "Casco Bay",
+                primaryDomain: "cascobay.com",
+                websiteUrl: "https://cascobay.com",
+                industry: "marketing",
+                estimatedNumEmployees: 12,
+                annualRevenue: "1000000",
+                logoUrl: null,
+                shortDescription: null,
+                linkedinUrl: null,
+                twitterUrl: null,
+                facebookUrl: null,
+                blogUrl: null,
+                crunchbaseUrl: null,
+                foundedYear: 2018,
+                city: "Portland",
+                state: "ME",
+                country: "USA",
+                streetAddress: null,
+                postalCode: null,
+                technologyNames: ["GA4"],
+                industries: ["marketing"],
+                secondaryIndustries: null,
+              },
+              contacts: [
+                { channel: "email", value: "sara@cascobay.com", status: "verified", source: "apollo" },
+              ],
+              employmentHistory: [
+                {
+                  organizationId: "10000000-0000-0000-0000-000000000001",
+                  organizationName: "Casco Bay",
+                  title: "Founder",
+                  startDate: "2018-01-01",
+                  endDate: null,
+                  current: true,
+                  description: null,
+                },
+              ],
             },
-            brandIds: ["brand-uuid"],
-            orgId: "org-uuid",
-            userId: "user-uuid",
+            brandIds: ["20000000-0000-0000-0000-000000000001"],
+            orgId: "30000000-0000-0000-0000-000000000001",
+            userId: "40000000-0000-0000-0000-000000000001",
             apolloPersonId: "5f2a3b4c5d6e7f8a9b0c1d2e",
           },
         },
@@ -273,38 +801,178 @@ const BufferNextResponseSchema = z
 
 const LeadDetailSchema = z
   .object({
-    id: z.string().uuid(),
-    leadId: z.string().uuid().nullable(),
-    namespace: z.string(),
-    email: z.string(),
-    apolloPersonId: z.string().nullable().openapi({
-      description: "Apollo person ID from enrichment",
-    }),
-    emailStatus: z.string().nullable().openapi({
-      description: "Email verification status from Apollo (verified, extrapolated, etc.)",
-    }),
-    status: z.enum(["buffered", "skipped", "claimed", "served"]).openapi({
-      description: "Lead lifecycle status. 'buffered'/'skipped'/'claimed'/'served' all live in leads_campaigns; 'served' = pulled and served to a workflow.",
-    }),
-    metadata: ApolloPersonDataSchema.nullable(),
-    parentRunId: z.string().nullable(),
-    runId: z.string().nullable(),
-    brandIds: z.array(z.string()),
-    campaignId: z.string(),
-    orgId: z.string(),
-    userId: z.string().nullable(),
-    servedAt: z.string().nullable(),
-    enrichment: ApolloPersonDataSchema.nullable(),
-    contacted: z.boolean(),
-    sent: z.boolean(),
-    delivered: z.boolean(),
-    opened: z.boolean(),
-    clicked: z.boolean(),
-    bounced: z.boolean(),
-    unsubscribed: z.boolean(),
+    id: z
+      .string()
+      .uuid()
+      .openapi({
+        description: "leads_campaigns row UUID (per-campaign per-lead lifecycle row, NOT the lead itself).",
+        example: "50000000-0000-0000-0000-000000000001",
+      }),
+    leadId: z
+      .string()
+      .uuid()
+      .nullable()
+      .openapi({
+        description: "Internal lead UUID. Null only when the row references a lead that was deleted.",
+        example: "00000000-0000-0000-0000-000000000001",
+      }),
+    namespace: z
+      .string()
+      .openapi({
+        description: "Namespace this lead was sourced from. Currently always 'apollo'.",
+        example: "apollo",
+      }),
+    email: z
+      .string()
+      .openapi({
+        description: "The email address tied to this leads_campaigns row.",
+        example: "sara@cascobay.com",
+      }),
+    status: z
+      .enum(["buffered", "skipped", "claimed", "served"])
+      .openapi({
+        description:
+          "Lead lifecycle status in this campaign. 'buffered'/'skipped'/'claimed'/'served' all live in leads_campaigns; 'served' = pulled and served to a workflow.",
+        example: "served",
+      }),
+    statusReason: z
+      .string()
+      .nullable()
+      .openapi({
+        description:
+          "Why this lead is in its current status (e.g. 'already_contacted', 'bounced'). Set for skipped/buffered leads.",
+        example: "already_contacted",
+      }),
+    statusDetails: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Human-readable details about the status reason.",
+        example: "Lead was contacted in campaign abc-123 on 2026-01-01.",
+      }),
+    parentRunId: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Run ID of the workflow that pulled / processed this lead.",
+        example: "run-uuid",
+      }),
+    runId: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Run ID for the campaign-tick that produced this lead.",
+        example: "run-uuid",
+      }),
+    brandIds: z
+      .array(z.string())
+      .openapi({
+        description: "Brand UUIDs this lead was buffered for.",
+        example: ["20000000-0000-0000-0000-000000000001"],
+      }),
+    campaignId: z
+      .string()
+      .openapi({
+        description: "Campaign ID owning this leads_campaigns row.",
+        example: "60000000-0000-0000-0000-000000000001",
+      }),
+    orgId: z
+      .string()
+      .openapi({
+        description: "Internal organization UUID.",
+        example: "30000000-0000-0000-0000-000000000001",
+      }),
+    userId: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Internal user UUID who triggered the campaign run.",
+        example: "40000000-0000-0000-0000-000000000001",
+      }),
+    workflowSlug: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Workflow slug that processed this lead (e.g. 'sales-cold-email-outreach-helium').",
+        example: "sales-cold-email-outreach-helium",
+      }),
+    featureSlug: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Feature slug for tracking.",
+        example: "outreach",
+      }),
+    servedAt: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "ISO timestamp when this lead was served. null for buffered/skipped/claimed rows.",
+        example: "2026-01-01T00:00:00.000Z",
+      }),
+    apolloPersonId: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Apollo person ID — convenience copy of lead.apolloPersonId.",
+        example: "5f2a3b4c5d6e7f8a9b0c1d2e",
+      }),
+    emailStatus: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "Email verification status from Apollo (verified, unverified, extrapolated, etc.).",
+        example: "verified",
+      }),
+    lead: FullLeadSchema.nullable(),
+    contacted: z
+      .boolean()
+      .openapi({
+        description: "Lead has been contacted at least once in this scope (campaign or brand depending on query).",
+        example: true,
+      }),
+    sent: z
+      .boolean()
+      .openapi({
+        description: "An email send has been attempted.",
+        example: true,
+      }),
+    delivered: z
+      .boolean()
+      .openapi({
+        description: "Provider confirmed delivery.",
+        example: true,
+      }),
+    opened: z
+      .boolean()
+      .openapi({
+        description: "Lead has opened at least one email.",
+        example: false,
+      }),
+    clicked: z
+      .boolean()
+      .openapi({
+        description: "Lead has clicked at least one tracked link.",
+        example: false,
+      }),
+    bounced: z
+      .boolean()
+      .openapi({
+        description: "Email bounced.",
+        example: false,
+      }),
+    unsubscribed: z
+      .boolean()
+      .openapi({
+        description: "Lead unsubscribed in this scope.",
+        example: false,
+      }),
     replied: z
       .boolean()
-      .openapi({ description: "Whether the lead replied (any reply, regardless of sentiment)" }),
+      .openapi({
+        description: "Whether the lead replied (any reply, regardless of sentiment).",
+        example: false,
+      }),
     replyClassification: z
       .enum(["positive", "negative", "neutral"])
       .nullable()
@@ -315,28 +983,38 @@ const LeadDetailSchema = z
           "'negative' = not interested, " +
           "'neutral' = ambiguous or informational. " +
           "null when no reply detected.",
+        example: null,
       }),
-    statusReason: z.string().nullable().openapi({
-      description: "Why this lead was skipped or placed in its current status (e.g. 'already_contacted', 'bounced'). Only set for buffer leads.",
-    }),
-    statusDetails: z.string().nullable().openapi({
-      description: "Human-readable details about the status reason. Only set for buffer leads.",
-    }),
-    lastDeliveredAt: z.string().nullable(),
-    global: z.object({
-      bounced: z.boolean(),
-      unsubscribed: z.boolean(),
-    }).openapi({
-      description: "Global-scope status (across all brands/campaigns). bounced and unsubscribed are global flags.",
-    }),
+    lastDeliveredAt: z
+      .string()
+      .nullable()
+      .openapi({
+        description: "ISO timestamp of the last delivered message in this scope.",
+        example: "2026-01-02T00:00:00.000Z",
+      }),
+    global: z
+      .object({
+        bounced: z.boolean().openapi({ description: "Lead has bounced anywhere across the platform.", example: false }),
+        unsubscribed: z.boolean().openapi({ description: "Lead has unsubscribed anywhere across the platform.", example: false }),
+      })
+      .openapi({
+        description: "Global-scope status (across all brands/campaigns). bounced and unsubscribed are global flags.",
+      }),
   })
-  .openapi("LeadDetail");
+  .openapi("LeadDetail", {
+    description:
+      "One leads_campaigns row enriched with the full canonical lead payload (FullLead) and delivery status from email-gateway.",
+  });
 
 const LeadsResponseSchema = z
   .object({
-    leads: z.array(LeadDetailSchema),
+    leads: z.array(LeadDetailSchema).openapi({
+      description: "All leads_campaigns rows matching the query, with full canonical lead payload + delivery overlay.",
+    }),
   })
-  .openapi("LeadsResponse");
+  .openapi("LeadsResponse", {
+    description: "Response shape for GET /orgs/leads.",
+  });
 
 // --- Stats ---
 
@@ -413,6 +1091,10 @@ registry.registerPath({
   method: "post",
   path: "/orgs/buffer/next",
   summary: "Pull the next lead from the buffer",
+  description:
+    "Claims and returns the next available lead from the campaign buffer. " +
+    "Response contains the full canonical lead payload (FullLead) under `lead.data` — " +
+    "use `data.firstName`, `data.lastName`, `data.organization.name` for outbound recipient fields.",
   request: {
     params: z.object({}),
     body: {
@@ -422,7 +1104,7 @@ registry.registerPath({
   parameters: BufferNextHeaders,
   responses: {
     200: {
-      description: "Next lead from buffer",
+      description: "Next lead from buffer (or found=false when exhausted)",
       content: { "application/json": { schema: BufferNextResponseSchema } },
     },
     400: {
@@ -436,13 +1118,10 @@ registry.registerPath({
 registry.registerPath({
   method: "get",
   path: "/orgs/leads",
-  summary: "List leads with enrichment and delivery status",
+  summary: "List leads with full enrichment and delivery status",
   description:
-    "Returns leads from leads_campaigns. Each lead includes a 'status' field: " +
-    "'served' (pulled and served), 'buffered'/'skipped'/'claimed' (still pending). " +
-    "Served leads include Apollo enrichment data, apolloPersonId, emailStatus, and full delivery status " +
-    "(contacted, sent, delivered, opened, clicked, bounced, unsubscribed, replied, replyClassification, lastDeliveredAt, global). " +
-    "Buffer entries have delivery fields defaulted to false/null. " +
+    "Returns leads_campaigns rows. Each row includes the full canonical lead payload (FullLead — see schema) under `lead`, " +
+    "plus delivery status (contacted, sent, delivered, opened, clicked, bounced, unsubscribed, replied, replyClassification, lastDeliveredAt, global). " +
     "Delivery status is fetched from email-gateway when brandId or campaignId is provided. " +
     "With campaignId: campaign-scoped status. With brandId only: brand-scoped (cross-campaign). " +
     "Without either: status fields default to false/null.",
@@ -475,7 +1154,7 @@ registry.registerPath({
   ],
   responses: {
     200: {
-      description: "List of served leads",
+      description: "List of leads with full canonical payload + delivery overlay",
       content: { "application/json": { schema: LeadsResponseSchema } },
     },
     401: { description: "Unauthorized" },

--- a/tests/unit/lead-shape.test.ts
+++ b/tests/unit/lead-shape.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const findFirstLead = vi.fn();
+const findFirstLeadOrg = vi.fn();
+const findFirstOrg = vi.fn();
+const findManyContacts = vi.fn();
+
+const empWhere = vi.fn();
+const empLeftJoin = vi.fn(() => ({ where: empWhere }));
+const empFrom = vi.fn(() => ({ leftJoin: empLeftJoin }));
+const dbSelect = vi.fn(() => ({ from: empFrom }));
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    query: {
+      leads: { findFirst: (...a: unknown[]) => findFirstLead(...a) },
+      leadsOrganizations: { findFirst: (...a: unknown[]) => findFirstLeadOrg(...a) },
+      organizations: { findFirst: (...a: unknown[]) => findFirstOrg(...a) },
+      leadContactMethods: { findMany: (...a: unknown[]) => findManyContacts(...a) },
+    },
+    select: (...a: unknown[]) => dbSelect(...a),
+  },
+}));
+
+describe("buildFullLead", () => {
+  beforeEach(() => {
+    findFirstLead.mockReset();
+    findFirstLeadOrg.mockReset();
+    findFirstOrg.mockReset();
+    findManyContacts.mockReset();
+    empWhere.mockReset();
+    empLeftJoin.mockClear();
+    empFrom.mockClear();
+    dbSelect.mockClear();
+  });
+
+  it("returns canonical shape with current org, contacts, and employment history", async () => {
+    findFirstLead.mockResolvedValue({
+      id: "lead-1",
+      apolloPersonId: "apollo-1",
+      firstName: "Sara",
+      lastName: "Freshley",
+      name: "Sara Freshley",
+      headline: "Founder",
+      linkedinUrl: "https://linkedin.com/in/sara",
+      photoUrl: null,
+      city: "Portland",
+      state: "ME",
+      country: "USA",
+      seniority: "founder",
+      departments: ["c_suite"],
+      subdepartments: null,
+      functions: null,
+      twitterUrl: null,
+      githubUrl: null,
+      facebookUrl: null,
+      enrichedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+    findFirstLeadOrg.mockResolvedValue({ organizationId: "org-1", title: "Founder" });
+    findFirstOrg.mockResolvedValue({
+      id: "org-1",
+      apolloOrganizationId: "apollo-org-1",
+      name: "Casco Bay",
+      primaryDomain: "cascobay.com",
+      websiteUrl: "https://cascobay.com",
+      industry: "marketing",
+      estimatedNumEmployees: 12,
+      annualRevenue: "1000000",
+      logoUrl: null,
+      shortDescription: "boutique agency",
+      linkedinUrl: null,
+      twitterUrl: null,
+      facebookUrl: null,
+      blogUrl: null,
+      crunchbaseUrl: null,
+      foundedYear: 2018,
+      city: "Portland",
+      state: "ME",
+      country: "USA",
+      streetAddress: null,
+      postalCode: null,
+      technologyNames: ["GA4"],
+      industries: ["marketing"],
+      secondaryIndustries: null,
+    });
+    findManyContacts.mockResolvedValue([
+      { channel: "email", value: "sara@cascobay.com", status: "verified", source: "apollo" },
+      { channel: "phone", value: "+15555555555", status: null, source: "apollo" },
+    ]);
+    empWhere.mockResolvedValue([
+      {
+        organizationId: "org-1",
+        organizationName: "Casco Bay",
+        title: "Founder",
+        startDate: "2018-01-01",
+        endDate: null,
+        current: true,
+        description: null,
+      },
+    ]);
+
+    const { buildFullLead } = await import("../../src/lib/lead-shape.js");
+    const result = await buildFullLead("lead-1");
+
+    expect(result.leadId).toBe("lead-1");
+    expect(result.firstName).toBe("Sara");
+    expect(result.lastName).toBe("Freshley");
+    expect(result.name).toBe("Sara Freshley");
+    expect(result.headline).toBe("Founder");
+    expect(result.organization).not.toBeNull();
+    expect(result.organization?.name).toBe("Casco Bay");
+    expect(result.organization?.primaryDomain).toBe("cascobay.com");
+    expect(result.organization?.industry).toBe("marketing");
+    expect(result.contacts).toHaveLength(2);
+    expect(result.contacts[0]).toMatchObject({
+      channel: "email",
+      value: "sara@cascobay.com",
+      status: "verified",
+      source: "apollo",
+    });
+    expect(result.employmentHistory).toHaveLength(1);
+    expect(result.employmentHistory[0]).toMatchObject({
+      organizationName: "Casco Bay",
+      title: "Founder",
+      current: true,
+    });
+    expect(result.enrichedAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("returns organization: null when no current employment row", async () => {
+    findFirstLead.mockResolvedValue({
+      id: "lead-2",
+      apolloPersonId: null,
+      firstName: "X",
+      lastName: "Y",
+      name: null,
+      headline: null,
+      linkedinUrl: null,
+      photoUrl: null,
+      city: null,
+      state: null,
+      country: null,
+      seniority: null,
+      departments: null,
+      subdepartments: null,
+      functions: null,
+      twitterUrl: null,
+      githubUrl: null,
+      facebookUrl: null,
+      enrichedAt: null,
+    });
+    findFirstLeadOrg.mockResolvedValue(undefined);
+    findManyContacts.mockResolvedValue([]);
+    empWhere.mockResolvedValue([]);
+
+    const { buildFullLead } = await import("../../src/lib/lead-shape.js");
+    const result = await buildFullLead("lead-2");
+
+    expect(result.organization).toBeNull();
+    expect(result.contacts).toEqual([]);
+    expect(result.employmentHistory).toEqual([]);
+  });
+
+  it("throws when leadId is not found", async () => {
+    findFirstLead.mockResolvedValue(undefined);
+
+    const { buildFullLead } = await import("../../src/lib/lead-shape.js");
+    await expect(buildFullLead("missing-lead-id")).rejects.toThrow(/not found/);
+  });
+});

--- a/tests/unit/openapi-shape.test.ts
+++ b/tests/unit/openapi-shape.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { OpenApiGeneratorV3 } from "@asteasolutions/zod-to-openapi";
+import { registry } from "../../src/schemas.js";
+
+interface SchemaDef {
+  description?: string;
+  example?: unknown;
+  properties?: Record<string, { description?: string; example?: unknown }>;
+}
+
+const generator = new OpenApiGeneratorV3(registry.definitions);
+const doc = generator.generateDocument({
+  openapi: "3.0.0",
+  info: { title: "test", version: "1.0.0" },
+  servers: [],
+});
+const components = (doc.components as { schemas: Record<string, SchemaDef> }).schemas;
+
+describe("OpenAPI generated document", () => {
+  it("registers FullLead schema", () => {
+    expect(components.FullLead).toBeDefined();
+  });
+
+  it("registers OrganizationView schema", () => {
+    expect(components.OrganizationView).toBeDefined();
+  });
+
+  it("registers ContactMethodView schema", () => {
+    expect(components.ContactMethodView).toBeDefined();
+  });
+
+  it("registers EmploymentEntryView schema", () => {
+    expect(components.EmploymentEntryView).toBeDefined();
+  });
+
+  it("FullLead has description and example", () => {
+    expect(components.FullLead.description).toBeTruthy();
+    expect(components.FullLead.example).toBeTruthy();
+  });
+
+  it("OrganizationView has description and example", () => {
+    expect(components.OrganizationView.description).toBeTruthy();
+    expect(components.OrganizationView.example).toBeTruthy();
+  });
+
+  it("ContactMethodView has description and example", () => {
+    expect(components.ContactMethodView.description).toBeTruthy();
+    expect(components.ContactMethodView.example).toBeTruthy();
+  });
+
+  it("EmploymentEntryView has description and example", () => {
+    expect(components.EmploymentEntryView.description).toBeTruthy();
+    expect(components.EmploymentEntryView.example).toBeTruthy();
+  });
+
+  it("does not expose ApolloPersonData (legacy schema dropped)", () => {
+    expect(components.ApolloPersonData).toBeUndefined();
+  });
+
+  it("FullLead has no metadata or raw property in public contract", () => {
+    const props = components.FullLead.properties ?? {};
+    expect(props.metadata).toBeUndefined();
+    expect(props.raw).toBeUndefined();
+  });
+
+  it("every primitive FullLead property has a description (nested $refs documented on their own schema)", () => {
+    const props = components.FullLead.properties ?? {};
+    for (const [name, prop] of Object.entries(props)) {
+      const isRef = (prop as Record<string, unknown>).$ref !== undefined;
+      const isArrayOfRef =
+        (prop as Record<string, unknown>).type === "array" &&
+        ((prop as Record<string, unknown>).items as Record<string, unknown> | undefined)?.$ref !==
+          undefined;
+      if (isRef || isArrayOfRef) continue;
+      expect(prop.description, `FullLead.${name} missing description`).toBeTruthy();
+    }
+  });
+
+  it("every OrganizationView property has a description", () => {
+    const props = components.OrganizationView.properties ?? {};
+    for (const [name, prop] of Object.entries(props)) {
+      expect(
+        prop.description,
+        `OrganizationView.${name} missing description`,
+      ).toBeTruthy();
+    }
+  });
+});

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -1,113 +1,173 @@
 import { describe, it, expect } from "vitest";
-import { BufferNextRequestSchema, ApolloPersonDataSchema } from "../../src/schemas.js";
+import {
+  BufferNextRequestSchema,
+  FullLeadSchema,
+  BufferNextResponseSchema,
+} from "../../src/schemas.js";
 
-describe("schema validation", () => {
-  describe("BufferNextRequestSchema", () => {
-    it("accepts empty body", () => {
-      const result = BufferNextRequestSchema.safeParse({});
-      expect(result.success).toBe(true);
-    });
-
-    it("rejects unknown fields (strict)", () => {
-      const result = BufferNextRequestSchema.safeParse({
-        sourceType: "apollo",
-      });
-      // Empty object schema accepts extra keys by default in Zod
-      // This is fine — extra fields are stripped
-      expect(result.success).toBe(true);
-    });
+describe("BufferNextRequestSchema", () => {
+  it("accepts empty body", () => {
+    expect(BufferNextRequestSchema.safeParse({}).success).toBe(true);
   });
 
-  describe("ApolloPersonDataSchema", () => {
-    const validPerson = {
-      firstName: "Sara",
-      lastName: "Freshley",
-      organizationName: "Casco Bay",
-    };
+  it("strips unknown fields silently", () => {
+    expect(
+      BufferNextRequestSchema.safeParse({ sourceType: "apollo" }).success,
+    ).toBe(true);
+  });
+});
 
-    it("accepts valid person data with required fields", () => {
-      const result = ApolloPersonDataSchema.safeParse(validPerson);
-      expect(result.success).toBe(true);
+const LEAD_UUID = "11111111-2222-4333-8444-555555555555";
+const ORG_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+const minimalLead = {
+  leadId: LEAD_UUID,
+  apolloPersonId: null,
+  firstName: "Sara",
+  lastName: "Freshley",
+  name: null,
+  headline: null,
+  linkedinUrl: null,
+  photoUrl: null,
+  city: null,
+  state: null,
+  country: null,
+  seniority: null,
+  departments: null,
+  subdepartments: null,
+  functions: null,
+  twitterUrl: null,
+  githubUrl: null,
+  facebookUrl: null,
+  enrichedAt: null,
+  organization: null,
+  contacts: [],
+  employmentHistory: [],
+};
+
+describe("FullLeadSchema", () => {
+  it("accepts a minimal lead with all-null nullable fields", () => {
+    expect(FullLeadSchema.safeParse(minimalLead).success).toBe(true);
+  });
+
+  it("accepts a lead with full nested organization view", () => {
+    const result = FullLeadSchema.safeParse({
+      ...minimalLead,
+      organization: {
+        id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        apolloOrganizationId: "apollo-org-1",
+        name: "Casco Bay",
+        primaryDomain: "cascobay.com",
+        websiteUrl: "https://cascobay.com",
+        industry: "marketing",
+        estimatedNumEmployees: 12,
+        annualRevenue: "1000000",
+        logoUrl: null,
+        shortDescription: "boutique",
+        linkedinUrl: null,
+        twitterUrl: null,
+        facebookUrl: null,
+        blogUrl: null,
+        crunchbaseUrl: null,
+        foundedYear: 2018,
+        city: "Portland",
+        state: "ME",
+        country: "USA",
+        streetAddress: null,
+        postalCode: null,
+        technologyNames: ["GA4"],
+        industries: ["marketing"],
+        secondaryIndustries: null,
+      },
     });
+    expect(result.success).toBe(true);
+  });
 
-    it("rejects missing firstName", () => {
-      const { firstName, ...rest } = validPerson;
-      const result = ApolloPersonDataSchema.safeParse(rest);
-      expect(result.success).toBe(false);
-    });
-
-    it("rejects missing lastName", () => {
-      const { lastName, ...rest } = validPerson;
-      const result = ApolloPersonDataSchema.safeParse(rest);
-      expect(result.success).toBe(false);
-    });
-
-    it("rejects missing organizationName", () => {
-      const { organizationName, ...rest } = validPerson;
-      const result = ApolloPersonDataSchema.safeParse(rest);
-      expect(result.success).toBe(false);
-    });
-
-    it("rejects null firstName", () => {
-      const result = ApolloPersonDataSchema.safeParse({ ...validPerson, firstName: null });
-      expect(result.success).toBe(false);
-    });
-
-    it("rejects null lastName", () => {
-      const result = ApolloPersonDataSchema.safeParse({ ...validPerson, lastName: null });
-      expect(result.success).toBe(false);
-    });
-
-    it("rejects null organizationName", () => {
-      const result = ApolloPersonDataSchema.safeParse({ ...validPerson, organizationName: null });
-      expect(result.success).toBe(false);
-    });
-
-    it("accepts new Apollo fields (name, personalEmails, mobilePhone, phoneNumbers, organizationId, organizationRawAddress)", () => {
-      const result = ApolloPersonDataSchema.safeParse({
-        ...validPerson,
-        name: "Sara Freshley",
-        personalEmails: ["sara.personal@gmail.com", "sara@me.com"],
-        mobilePhone: "+1-555-555-5555",
-        phoneNumbers: [
-          {
-            rawNumber: "+1-555-555-5555",
-            sanitizedNumber: "+15555555555",
-            type: "mobile",
-            position: 1,
-            status: "verified",
-            dncStatus: "no_dnc",
-            dncOtherInfo: null,
-            dialerFlags: { do_not_call: false },
-          },
-        ],
-        organizationId: "org-apollo-123",
-        organizationRawAddress: "123 Main St, Portland, ME 04101",
-      });
-      expect(result.success).toBe(true);
-    });
-
-    it("accepts raw field as arbitrary record", () => {
-      const result = ApolloPersonDataSchema.safeParse({
-        ...validPerson,
-        raw: {
-          first_name: "Sara",
-          last_name: "Freshley",
-          some_new_apollo_field: { nested: true },
-          totally_unknown_array: [1, 2, 3],
+  it("accepts a lead with contact methods and employment history", () => {
+    const result = FullLeadSchema.safeParse({
+      ...minimalLead,
+      contacts: [
+        { channel: "email", value: "sara@cascobay.com", status: "verified", source: "apollo" },
+        { channel: "phone", value: "+15555555555", status: null, source: "apollo" },
+      ],
+      employmentHistory: [
+        {
+          organizationId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+          organizationName: "Casco Bay",
+          title: "Founder",
+          startDate: "2018-01-01",
+          endDate: null,
+          current: true,
+          description: null,
         },
-      });
-      expect(result.success).toBe(true);
+      ],
     });
+    expect(result.success).toBe(true);
+  });
 
-    it("accepts null/undefined raw field", () => {
-      expect(ApolloPersonDataSchema.safeParse({ ...validPerson, raw: null }).success).toBe(true);
-      expect(ApolloPersonDataSchema.safeParse({ ...validPerson }).success).toBe(true);
-    });
+  it("requires leadId", () => {
+    const without = { ...minimalLead };
+    delete (without as Record<string, unknown>).leadId;
+    expect(FullLeadSchema.safeParse(without).success).toBe(false);
+  });
 
-    it("accepts null/undefined personalEmails and phoneNumbers", () => {
-      expect(ApolloPersonDataSchema.safeParse({ ...validPerson, personalEmails: null, phoneNumbers: null }).success).toBe(true);
-      expect(ApolloPersonDataSchema.safeParse({ ...validPerson, personalEmails: [], phoneNumbers: [] }).success).toBe(true);
+  it("requires firstName", () => {
+    expect(
+      FullLeadSchema.safeParse({ ...minimalLead, firstName: undefined }).success,
+    ).toBe(false);
+  });
+
+  it("requires lastName", () => {
+    expect(
+      FullLeadSchema.safeParse({ ...minimalLead, lastName: undefined }).success,
+    ).toBe(false);
+  });
+
+  it("requires contacts array", () => {
+    const without = { ...minimalLead };
+    delete (without as Record<string, unknown>).contacts;
+    expect(FullLeadSchema.safeParse(without).success).toBe(false);
+  });
+
+  it("requires employmentHistory array", () => {
+    const without = { ...minimalLead };
+    delete (without as Record<string, unknown>).employmentHistory;
+    expect(FullLeadSchema.safeParse(without).success).toBe(false);
+  });
+
+  it("strips legacy raw/metadata fields if passed in (no longer part of contract)", () => {
+    const result = FullLeadSchema.safeParse({
+      ...minimalLead,
+      metadata: { foo: "bar" },
+      raw: { first_name: "Sara" },
     });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as Record<string, unknown>;
+      expect(data.metadata).toBeUndefined();
+      expect(data.raw).toBeUndefined();
+    }
+  });
+});
+
+describe("BufferNextResponseSchema", () => {
+  it("accepts found:true with FullLead", () => {
+    const result = BufferNextResponseSchema.safeParse({
+      found: true,
+      lead: {
+        leadId: LEAD_UUID,
+        email: "sara@cascobay.com",
+        data: minimalLead,
+        brandIds: ["brand-1"],
+        orgId: "org-1",
+        userId: "user-1",
+        apolloPersonId: null,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts found:false without lead", () => {
+    expect(BufferNextResponseSchema.safeParse({ found: false }).success).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- POST /orgs/buffer/next was returning the raw Apollo metadata JSONB spread into \`data\`. When the blob lacked the camelCase recipient keys, email-gateway rejected sends with 400 and workflow runs failed (campaign 683cd043... has been stuck for hours).
- Replace with a single canonical FullLead shape built from structured DB columns + joined organization / contacts / employment history.
- Every lead-bearing endpoint (POST /orgs/buffer/next, GET /orgs/leads) now returns the same shape. No raw metadata in the public API surface.
- OpenAPI: every primitive field documented with description + example; top-level schemas carry full JSON examples.

## Triage

**Hotfix.** Production currently broken — workflow \`sales-cold-email-outreach-helium\` failing with \`recipientFirstName/Last/Company is required\`, campaign re-claiming on every heartbeat. Branch from \`origin/main\`, target \`main\`.

## Breaking change for consumers

\`POST /orgs/buffer/next\` and \`GET /orgs/leads\` no longer expose arbitrary Apollo snake_case keys via \`data.metadata\` / \`data.raw\`. Consumers must read:
- \`data.firstName\`, \`data.lastName\` for recipient name
- \`data.organization.name\` for company name
- \`data.contacts[]\` for emails / phones (filter by \`channel\`)
- \`data.employmentHistory[]\` for career history

\`ApolloPersonData\` schema is no longer exported in OpenAPI; clients regenerating from the spec will get the new \`FullLead\` schema.

## Test plan

- [x] \`npm run test:unit\` — 123 passed
- [x] \`npm run build\` — typecheck + openapi regen clean
- [x] \`tests/unit/lead-shape.test.ts\` — buildFullLead joins + null-org case + missing-lead throws
- [x] \`tests/unit/schemas.test.ts\` — FullLead validation, BufferNextResponse round-trip
- [x] \`tests/unit/openapi-shape.test.ts\` — FullLead / OrganizationView / ContactMethodView / EmploymentEntryView registered, documented, exampled; ApolloPersonData no longer present; no raw/metadata leaked

## Downstream

After merge + deploy, notify:
- workflow-service (windmill scripts that consume pullNext)
- api-service (any \`GET /orgs/leads\` consumers)
- frontend (if reading lead detail panels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)