### PR TITLE
fix(leads): tighten Apollo enrichment cache gating

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -29,16 +29,22 @@ import {
 import { fetchCampaign } from "./campaign-client.js";
 import { extractBrandFields } from "./brand-client.js";
 
-const VALID_EMAIL_STATUSES = new Set(["verified", "extrapolated"]);
+export const VALID_EMAIL_STATUSES = new Set(["verified", "extrapolated"]);
 
-/** TTL for re-enriching a lead. */
-const CACHE_TTL_EMAIL_FOUND_MS = 6 * 30 * 24 * 60 * 60 * 1000;
-const CACHE_TTL_NO_EMAIL_MS = 1 * 24 * 60 * 60 * 1000;
+/**
+ * TTL for re-enriching a lead. A lead with a valid email short-circuits
+ * before this check, so the TTL only governs how soon we retry leads whose
+ * latest enrichment did NOT yield a usable email (or had an invalid status).
+ */
+export const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
-function isCacheFresh(enrichedAt: Date | null, hasEmail: boolean): boolean {
+export function isCacheFresh(enrichedAt: Date | null): boolean {
   if (!enrichedAt) return false;
-  const ttl = hasEmail ? CACHE_TTL_EMAIL_FOUND_MS : CACHE_TTL_NO_EMAIL_MS;
-  return Date.now() - enrichedAt.getTime() < ttl;
+  return Date.now() - enrichedAt.getTime() < CACHE_TTL_MS;
+}
+
+export function hasValidEmail(email: string | null, status: string | null): boolean {
+  return !!email && !!status && VALID_EMAIL_STATUSES.has(status);
 }
 
 async function bufferedCount(orgId: string, campaignId: string): Promise<number> {
@@ -410,8 +416,9 @@ export async function pullNext(
       let email = claimed.primaryEmail;
       let emailStatus = claimed.primaryEmailStatus;
 
-      const cacheFresh = isCacheFresh(claimed.enrichedAt, claimed.hasEmail);
-      const needEnrich = !email && !cacheFresh;
+      const validEmail = hasValidEmail(email, emailStatus);
+      const cacheFresh = isCacheFresh(claimed.enrichedAt);
+      const needEnrich = !validEmail && !cacheFresh;
 
       if (needEnrich && claimed.apolloPersonId) {
         const enrichResult = await apolloEnrich(claimed.apolloPersonId, {

--- a/tests/unit/buffer-cache.test.ts
+++ b/tests/unit/buffer-cache.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+import {
+  hasValidEmail,
+  isCacheFresh,
+  CACHE_TTL_MS,
+  VALID_EMAIL_STATUSES,
+} from "../../src/lib/buffer.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const bufferSrc = readFileSync(
+  join(__dirname, "..", "..", "src", "lib", "buffer.ts"),
+  "utf-8",
+);
+
+describe("hasValidEmail", () => {
+  it("returns true for verified email", () => {
+    expect(hasValidEmail("a@b.com", "verified")).toBe(true);
+  });
+
+  it("returns true for extrapolated email", () => {
+    expect(hasValidEmail("a@b.com", "extrapolated")).toBe(true);
+  });
+
+  it("returns false for unverified status", () => {
+    expect(hasValidEmail("a@b.com", "unverified")).toBe(false);
+  });
+
+  it("returns false for guessed status", () => {
+    expect(hasValidEmail("a@b.com", "guessed")).toBe(false);
+  });
+
+  it("returns false when email is null", () => {
+    expect(hasValidEmail(null, "verified")).toBe(false);
+  });
+
+  it("returns false when status is null", () => {
+    expect(hasValidEmail("a@b.com", null)).toBe(false);
+  });
+
+  it("returns false when both null", () => {
+    expect(hasValidEmail(null, null)).toBe(false);
+  });
+
+  it("returns false for empty string email", () => {
+    expect(hasValidEmail("", "verified")).toBe(false);
+  });
+});
+
+describe("isCacheFresh", () => {
+  it("returns false when enrichedAt is null", () => {
+    expect(isCacheFresh(null)).toBe(false);
+  });
+
+  it("returns true for enrichedAt within TTL", () => {
+    const recent = new Date(Date.now() - 1_000);
+    expect(isCacheFresh(recent)).toBe(true);
+  });
+
+  it("returns true for enrichedAt 23h ago", () => {
+    const recent = new Date(Date.now() - 23 * 60 * 60 * 1000);
+    expect(isCacheFresh(recent)).toBe(true);
+  });
+
+  it("returns false for enrichedAt 25h ago", () => {
+    const stale = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    expect(isCacheFresh(stale)).toBe(false);
+  });
+
+  it("returns false for enrichedAt at exactly TTL boundary", () => {
+    const boundary = new Date(Date.now() - CACHE_TTL_MS);
+    expect(isCacheFresh(boundary)).toBe(false);
+  });
+});
+
+describe("CACHE_TTL_MS", () => {
+  it("is 24 hours", () => {
+    expect(CACHE_TTL_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});
+
+describe("VALID_EMAIL_STATUSES", () => {
+  it("contains exactly verified and extrapolated", () => {
+    expect(VALID_EMAIL_STATUSES).toEqual(new Set(["verified", "extrapolated"]));
+  });
+});
+
+describe("buffer.ts source invariants", () => {
+  it("does not reference dead constant CACHE_TTL_EMAIL_FOUND_MS", () => {
+    expect(bufferSrc).not.toMatch(/CACHE_TTL_EMAIL_FOUND_MS/);
+  });
+
+  it("does not reference dead constant CACHE_TTL_NO_EMAIL_MS", () => {
+    expect(bufferSrc).not.toMatch(/CACHE_TTL_NO_EMAIL_MS/);
+  });
+
+  it("uses single CACHE_TTL_MS constant", () => {
+    expect(bufferSrc).toMatch(/CACHE_TTL_MS/);
+  });
+
+  it("gates enrichment on hasValidEmail rather than raw email presence", () => {
+    expect(bufferSrc).toMatch(/hasValidEmail/);
+  });
+});


### PR DESCRIPTION
## Summary
- Re-enrich leads with invalid email status (`unverified`, `guessed`, etc.) when cache is stale, instead of skipping them permanently.
- Drop dead 6-month TTL branch (`CACHE_TTL_EMAIL_FOUND_MS`) — was never reachable.
- Single 24h TTL governs retry cadence for leads whose last enrichment did not yield a usable email.

## Why
Pre-fix gate: `needEnrich = !email && !cacheFresh`. Two issues:
1. A lead whose only contact_method email had a non-whitelisted status was burned with `invalid_email_status` at every pullNext, never giving Apollo a chance to upgrade the status.
2. `CACHE_TTL_EMAIL_FOUND_MS` was dead code: `isCacheFresh(enrichedAt, hasEmail)` was only consulted when `!email`, so `hasEmail` was always `false`.

Post-fix gate:
```ts
needEnrich = !hasValidEmail(email, status) && !isCacheFresh(enrichedAt)
```

Behavior matrix:

| Lead state | Cache | Action |
|---|---|---|
| email `verified`/`extrapolated` | any | serve, no enrich call |
| email invalid status | fresh (<24h) | skip `invalid_email_status` |
| email invalid status | stale (>24h) | re-enrich (Apollo may upgrade status) |
| no email | fresh (<24h) | skip `no_email` |
| no email | stale (>24h) or null | re-enrich |

## Edge case (intentionally not addressed)
If Apollo `/enrich` returns a person without email while the lead already has a contact_methods row, the row is not invalidated — current behavior preserved. To be revisited if it becomes a problem.

## Test plan
- [x] New unit tests `tests/unit/buffer-cache.test.ts` — 19 cases covering `hasValidEmail`, `isCacheFresh`, `CACHE_TTL_MS` constant, and source-text invariants
- [x] `npm run build` green
- [x] No regression in unrelated unit tests (transfer-brand timeout is a pre-existing flake, passes in isolation; full-suite flakiness exists on staging baseline too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)