### PR TITLE
hotfix: detect concurrent buffer/next via runs-service, 409 fail-loud

### DIFF
--- a/src/lib/inflight-guard.ts
+++ b/src/lib/inflight-guard.ts
@@ -1,0 +1,61 @@
+import { listRuns, type RunsListItem } from "./runs-client.js";
+
+/**
+ * Detects concurrent buffer/next calls for the same campaignId by querying
+ * runs-service for any other lead-service run currently in `running` state
+ * for that campaign.
+ *
+ * campaign-service is supposed to serialize workflow runs per campaign, so
+ * lead-service should never see two concurrent buffer/next requests for the
+ * same campaignId. When this returns blocked=true, treat it as evidence of
+ * an upstream serial-invariant violation — investigate campaign-service /
+ * workflow-service, not lead-service.
+ *
+ * Best-effort detection: there is a small TOCTOU window between this query
+ * and the caller's subsequent createRun. The race is acceptable because the
+ * actual upstream bug surfaces as runs minutes apart, not millisecond races.
+ */
+
+export interface CheckConcurrentParams {
+  orgId: string;
+  campaignId: string;
+  attemptedParentRunId: string;
+  attemptedBrandIds: string[];
+  attemptedWorkflowSlug?: string;
+  attemptedFeatureSlug?: string;
+}
+
+export type ConcurrentCheckResult =
+  | { blocked: false }
+  | { blocked: true; detail: string; existing: RunsListItem };
+
+export async function checkConcurrentBufferNext(
+  params: CheckConcurrentParams,
+): Promise<ConcurrentCheckResult> {
+  const runs = await listRuns({
+    orgId: params.orgId,
+    campaignId: params.campaignId,
+    serviceName: "lead-service",
+    status: "running",
+    limit: 2,
+  });
+
+  if (runs.length === 0) {
+    return { blocked: false };
+  }
+
+  const existing = runs[0];
+  const startedAtMs = Date.parse(existing.startedAt);
+  const elapsedMs = Number.isFinite(startedAtMs) ? Date.now() - startedAtMs : -1;
+  const detail = [
+    `Concurrent buffer/next call for orgId=${params.orgId} campaignId=${params.campaignId}.`,
+    `campaign-service is supposed to serialize workflow runs per campaign — this is an upstream serial-invariant violation.`,
+    `In-flight: id=${existing.id} parentRunId=${existing.parentRunId ?? "none"} startedAt=${existing.startedAt} elapsedMs=${elapsedMs} brandIds=${(existing.brandIds ?? []).join(",")} workflowSlug=${existing.workflowSlug ?? "none"} featureSlug=${existing.featureSlug ?? "none"}.`,
+    `Rejected: parentRunId=${params.attemptedParentRunId} brandIds=${params.attemptedBrandIds.join(",")} workflowSlug=${params.attemptedWorkflowSlug ?? "none"} featureSlug=${params.attemptedFeatureSlug ?? "none"}.`,
+    runs.length > 1 ? `(runs-service returned ${runs.length} in-flight runs — only the first is shown above.)` : "",
+  ]
+    .filter((s) => s.length > 0)
+    .join(" ");
+
+  return { blocked: true, detail, existing };
+}

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -81,6 +81,36 @@ export async function updateRun(
   });
 }
 
+export interface RunsListItem {
+  id: string;
+  parentRunId: string | null;
+  campaignId: string | null;
+  startedAt: string;
+  brandIds: string[] | null;
+  workflowSlug: string | null;
+  featureSlug: string | null;
+}
+
+export async function listRuns(params: {
+  orgId: string;
+  campaignId: string;
+  serviceName: string;
+  status: string;
+  limit: number;
+}): Promise<RunsListItem[]> {
+  const query = new URLSearchParams({
+    campaignId: params.campaignId,
+    serviceName: params.serviceName,
+    status: params.status,
+    limit: String(params.limit),
+  });
+  const result = (await callRunsService(`/runs?${query.toString()}`, {
+    method: "GET",
+    headers: { "x-org-id": params.orgId },
+  })) as { runs: RunsListItem[] };
+  return result.runs;
+}
+
 export async function addCosts(
   runId: string,
   items: Array<{ costName: string; quantity: number; costSource: "platform" | "org" }>,

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -8,6 +8,7 @@ import { BufferNextRequestSchema } from "../schemas.js";
 import { db } from "../db/index.js";
 import { idempotencyCache } from "../db/schema.js";
 import { PULL_NEXT_TIMEOUT_MS } from "../config.js";
+import { checkConcurrentBufferNext } from "../lib/inflight-guard.js";
 
 const router = Router();
 
@@ -60,6 +61,25 @@ router.post("/orgs/buffer/next", apiKeyAuth, requireOrgId, requireRunId, async (
     console.log(`[lead-service] Idempotency hit for runId=${runId}`);
     traceEvent(runId, { service: "lead-service", event: "idempotency-hit", detail: `Returning cached response for runId=${runId}` }, req.headers).catch(() => {});
     return res.json(cached.response);
+  }
+
+  // In-flight guard: campaign-service is supposed to serialize workflow runs per campaignId.
+  // If runs-service shows another lead-service run already in-flight for this campaignId,
+  // the upstream serial invariant is broken — fail loud with full debug context instead of
+  // racing the strategy persist path into a duplicate-key 500.
+  // Must run BEFORE createRun so we don't self-detect.
+  const concurrentCheck = await checkConcurrentBufferNext({
+    orgId: req.orgId!,
+    campaignId,
+    attemptedParentRunId: runId,
+    attemptedBrandIds: brandIds,
+    attemptedWorkflowSlug: workflowSlug,
+    attemptedFeatureSlug: req.featureSlug,
+  });
+  if (concurrentCheck.blocked) {
+    console.error(`[lead-service] ${concurrentCheck.detail}`);
+    traceEvent(runId, { service: "lead-service", event: "buffer-next-concurrent-rejected", level: "error", detail: concurrentCheck.detail }, req.headers).catch(() => {});
+    return res.status(409).json({ error: "Concurrent buffer/next call for same campaign", detail: concurrentCheck.detail });
   }
 
   // Create child run for traceability (x-run-id from caller becomes our parentRunId)

--- a/tests/unit/inflight-guard.test.ts
+++ b/tests/unit/inflight-guard.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/lib/runs-client.js", () => ({
+  listRuns: vi.fn(),
+}));
+
+import { listRuns } from "../../src/lib/runs-client.js";
+import { checkConcurrentBufferNext } from "../../src/lib/inflight-guard.js";
+
+const listRunsMock = listRuns as unknown as ReturnType<typeof vi.fn>;
+
+describe("inflight-guard.checkConcurrentBufferNext", () => {
+  beforeEach(() => {
+    listRunsMock.mockReset();
+  });
+
+  it("returns blocked=false when no in-flight runs found", async () => {
+    listRunsMock.mockResolvedValueOnce([]);
+
+    const result = await checkConcurrentBufferNext({
+      orgId: "org-1",
+      campaignId: "camp-1",
+      attemptedParentRunId: "run-new",
+      attemptedBrandIds: ["b1"],
+      attemptedWorkflowSlug: "wf",
+      attemptedFeatureSlug: "feat",
+    });
+
+    expect(result.blocked).toBe(false);
+    expect(listRunsMock).toHaveBeenCalledWith({
+      orgId: "org-1",
+      campaignId: "camp-1",
+      serviceName: "lead-service",
+      status: "running",
+      limit: 2,
+    });
+  });
+
+  it("returns blocked=true with detail when an in-flight run exists", async () => {
+    const startedAt = new Date(Date.now() - 5000).toISOString();
+    listRunsMock.mockResolvedValueOnce([
+      {
+        id: "run-existing",
+        parentRunId: "parent-existing",
+        campaignId: "camp-1",
+        startedAt,
+        brandIds: ["b1", "b2"],
+        workflowSlug: "wf-old",
+        featureSlug: "feat-old",
+      },
+    ]);
+
+    const result = await checkConcurrentBufferNext({
+      orgId: "org-1",
+      campaignId: "camp-1",
+      attemptedParentRunId: "run-new",
+      attemptedBrandIds: ["b3"],
+      attemptedWorkflowSlug: "wf-new",
+      attemptedFeatureSlug: "feat-new",
+    });
+
+    expect(result.blocked).toBe(true);
+    if (result.blocked) {
+      expect(result.detail).toContain("orgId=org-1");
+      expect(result.detail).toContain("campaignId=camp-1");
+      expect(result.detail).toContain("run-existing");
+      expect(result.detail).toContain("parent-existing");
+      expect(result.detail).toContain(startedAt);
+      expect(result.detail).toContain("elapsedMs=");
+      expect(result.detail).toContain("wf-old");
+      expect(result.detail).toContain("feat-old");
+      expect(result.detail).toContain("Rejected");
+      expect(result.detail).toContain("run-new");
+      expect(result.detail).toContain("b3");
+      expect(result.detail).toContain("wf-new");
+      expect(result.detail).toContain("feat-new");
+    }
+  });
+
+  it("propagates listRuns errors (no silent fallback)", async () => {
+    listRunsMock.mockRejectedValueOnce(new Error("runs-service down"));
+
+    await expect(
+      checkConcurrentBufferNext({
+        orgId: "org-1",
+        campaignId: "camp-1",
+        attemptedParentRunId: "run-new",
+        attemptedBrandIds: ["b1"],
+      }),
+    ).rejects.toThrow(/runs-service down/);
+  });
+
+  it("handles missing optional fields on existing run gracefully", async () => {
+    listRunsMock.mockResolvedValueOnce([
+      {
+        id: "run-existing",
+        parentRunId: null,
+        campaignId: "camp-1",
+        startedAt: new Date().toISOString(),
+        brandIds: null,
+        workflowSlug: null,
+        featureSlug: null,
+      },
+    ]);
+
+    const result = await checkConcurrentBufferNext({
+      orgId: "org-1",
+      campaignId: "camp-1",
+      attemptedParentRunId: "run-new",
+      attemptedBrandIds: ["b1"],
+    });
+
+    expect(result.blocked).toBe(true);
+    if (result.blocked) {
+      expect(result.detail).toContain("run-existing");
+      expect(result.detail).toContain("parentRunId=none");
+    }
+  });
+});

--- a/tests/unit/runs-client.test.ts
+++ b/tests/unit/runs-client.test.ts
@@ -38,4 +38,66 @@ describe("runs-client", () => {
     const [, opts] = fetchSpy.mock.calls[0];
     expect(opts.signal).toBeInstanceOf(AbortSignal);
   });
+
+  describe("listRuns", () => {
+    it("builds correct URL with query params and forwards required headers", async () => {
+      fetchSpy.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ runs: [] }) });
+      const { listRuns } = await import("../../src/lib/runs-client.js");
+
+      await listRuns({
+        orgId: "org-1",
+        campaignId: "camp-1",
+        serviceName: "lead-service",
+        status: "running",
+        limit: 2,
+      });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, opts] = fetchSpy.mock.calls[0];
+      expect(url).toBe(
+        "https://runs.test/v1/runs?campaignId=camp-1&serviceName=lead-service&status=running&limit=2",
+      );
+      expect(opts.method).toBe("GET");
+      expect(opts.headers["x-org-id"]).toBe("org-1");
+      expect(opts.headers["X-API-Key"]).toBe("test-runs-key");
+      expect(opts.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("returns parsed runs array on success", async () => {
+      const runs = [
+        { id: "r1", parentRunId: "p1", campaignId: "camp-1", startedAt: "2026-05-10T00:00:00Z" },
+      ];
+      fetchSpy.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ runs }) });
+      const { listRuns } = await import("../../src/lib/runs-client.js");
+
+      const result = await listRuns({
+        orgId: "org-1",
+        campaignId: "camp-1",
+        serviceName: "lead-service",
+        status: "running",
+        limit: 2,
+      });
+
+      expect(result).toEqual(runs);
+    });
+
+    it("throws on non-OK response (no silent fallback)", async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("boom"),
+      });
+      const { listRuns } = await import("../../src/lib/runs-client.js");
+
+      await expect(
+        listRuns({
+          orgId: "org-1",
+          campaignId: "camp-1",
+          serviceName: "lead-service",
+          status: "running",
+          limit: 2,
+        }),
+      ).rejects.toThrow(/500/);
+    });
+  });
 });


### PR DESCRIPTION
Automated by release.sh