### PR TITLE
chore(brand-client): remove dead fetchBrand + BrandDetails

### DIFF
--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -1,56 +1,5 @@
 import { BRAND_SERVICE_URL, BRAND_SERVICE_API_KEY } from "../config.js";
 
-export interface BrandDetails {
-  id: string;
-  name: string | null;
-  domain: string | null;
-  elevatorPitch: string | null;
-  bio: string | null;
-  mission: string | null;
-  location: string | null;
-  categories: string | null;
-}
-
-export async function fetchBrand(
-  brandId: string,
-  orgId?: string | null,
-  context?: { userId?: string; runId?: string; campaignId?: string; brandId?: string; workflowSlug?: string; featureSlug?: string }
-): Promise<BrandDetails | null> {
-  try {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      "X-API-Key": BRAND_SERVICE_API_KEY,
-    };
-    if (orgId) headers["x-org-id"] = orgId;
-    if (context?.userId) headers["x-user-id"] = context.userId;
-    if (context?.runId) headers["x-run-id"] = context.runId;
-    if (context?.campaignId) headers["x-campaign-id"] = context.campaignId;
-    if (context?.brandId) headers["x-brand-id"] = context.brandId;
-    if (context?.workflowSlug) headers["x-workflow-slug"] = context.workflowSlug;
-    if (context?.featureSlug) headers["x-feature-slug"] = context.featureSlug;
-
-    const url = new URL(`${BRAND_SERVICE_URL}/internal/brands/${brandId}`);
-    if (orgId) url.searchParams.set("orgId", orgId);
-
-    const response = await fetch(url.toString(), { headers, signal: AbortSignal.timeout(300_000) });
-
-    if (!response.ok) {
-      const msg = `[brand-client] Failed to fetch brand ${brandId}: ${response.status}`;
-      if (response.status >= 500) {
-        throw new Error(msg);
-      }
-      console.warn(msg);
-      return null;
-    }
-
-    const data = (await response.json()) as { brand: BrandDetails };
-    return data.brand;
-  } catch (error) {
-    console.error("[brand-client] Error fetching brand:", error);
-    throw error;
-  }
-}
-
 export interface ExtractedField {
   key: string;
   value: string | string[] | Record<string, unknown> | null;


### PR DESCRIPTION
## Summary
- brand-service contract change (PR shamanic-technologies/brand-service#190) removed `bio`, `mission`, `elevatorPitch`, `categories`, `location`, and similar fields from `GET /internal/brands/{id}`.
- `fetchBrand()` + `BrandDetails` in `src/lib/brand-client.ts` referenced those fields but had **zero callers** in this repo — dead code from a prior iteration.
- `extractBrandFields()` (the active brand consumer in `src/lib/buffer.ts:84`) is already on the new contract via `POST /orgs/brands/extract-fields`, with `orgId` guaranteed non-null by the `requireOrgId` middleware. No change needed there.

## Test plan
- [x] `npm run build` (tsc + OpenAPI generate) green
- [x] `npm test` — 156/156 tests pass
- [x] `grep "fetchBrand\|BrandDetails"` in `src/` returns zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)