### PR TITLE
hotfix: Swallow global (channel, value) dup-key on lead_contact_methods as a collision skip; fall back to Apollo personalEmails alternates. Fixes 500 on POST /lead/orgs/buffer/next that left campaigns stuck.

### DIFF
--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -155,13 +155,27 @@ async function ingestPerson(person: ApolloPersonResult, params: IngestParams, si
   if (signal?.aborted) return false;
 
   if (person.email) {
-    await upsertContactMethod({
-      leadId,
-      channel: "email",
-      value: person.email,
-      status: person.emailStatus ?? null,
-      source: "apollo",
-    });
+    const candidates = [person.email, ...(person.personalEmails ?? [])];
+    let attached = false;
+    for (const candidate of candidates) {
+      const res = await upsertContactMethod({
+        leadId,
+        channel: "email",
+        value: candidate,
+        status: candidate === person.email ? (person.emailStatus ?? null) : null,
+        source: "apollo",
+      });
+      if (res.inserted) {
+        attached = true;
+        break;
+      }
+    }
+    if (!attached) {
+      console.warn(
+        `[lead-service] ingest skip — all Apollo emails already attached to other leads, personId=${person.id}, candidates=${candidates.join(",")}`,
+      );
+      return false;
+    }
   }
   if (signal?.aborted) return false;
 
@@ -435,15 +449,33 @@ export async function pullNext(
           await upsertLeadFromPerson(enrichResult.person, { enriched: true });
           await recordEmploymentHistory({ leadId: claimed.leadId, person: enrichResult.person });
           if (enrichResult.person.email) {
-            await upsertContactMethod({
-              leadId: claimed.leadId,
-              channel: "email",
-              value: enrichResult.person.email,
-              status: enrichResult.person.emailStatus ?? null,
-              source: "apollo",
-            });
-            email = enrichResult.person.email;
-            emailStatus = enrichResult.person.emailStatus ?? null;
+            const primary = enrichResult.person.email;
+            const primaryStatus = enrichResult.person.emailStatus ?? null;
+            const candidates = [primary, ...(enrichResult.person.personalEmails ?? [])];
+            let attached: { value: string; status: string | null } | null = null;
+            for (const candidate of candidates) {
+              const res = await upsertContactMethod({
+                leadId: claimed.leadId,
+                channel: "email",
+                value: candidate,
+                status: candidate === primary ? primaryStatus : null,
+                source: "apollo",
+              });
+              if (res.inserted) {
+                attached = { value: candidate, status: candidate === primary ? primaryStatus : null };
+                break;
+              }
+            }
+            if (attached) {
+              email = attached.value;
+              emailStatus = attached.status;
+            } else {
+              await settleSkip(
+                "email_collision_other_lead",
+                `All Apollo emails already attached to other leads, candidates=[${candidates.join(",")}], leadId=${claimed.leadId}, apolloPersonId=${claimed.apolloPersonId ?? "none"}, campaignId=${params.campaignId}`,
+              );
+              continue;
+            }
           }
         } else {
           await db

--- a/src/lib/leads-registry.ts
+++ b/src/lib/leads-registry.ts
@@ -189,10 +189,22 @@ export async function upsertOrganizationFromPerson(person: ApolloPersonResult): 
   return null;
 }
 
+export type UpsertContactResult =
+  | { inserted: true }
+  | { inserted: false; reason: "global_collision" };
+
 /**
- * Upsert a lead contact method (email/phone/twitter/etc.). Idempotent on (leadId, channel, value).
- * On conflict the latest status + source overwrite the existing row so re-enrichment
- * (e.g. Apollo upgrading "unverified" → "verified") is reflected instead of being silently dropped.
+ * Upsert a lead contact method (email/phone/twitter/etc.).
+ *
+ * Two unique indexes apply:
+ *   - idx_lcm_lead_channel_value (lead_id, channel, value) — same-lead re-enrichment, handled by ON CONFLICT DO UPDATE.
+ *   - idx_lcm_channel_value (channel, value)               — global "one email = one lead" invariant.
+ *
+ * When the second collides (Apollo returns an email already attached to a different lead — e.g. role
+ * inboxes, executive-assistant addresses, or Apollo person-id churn), Postgres raises 23505 because
+ * ON CONFLICT can target only one constraint. We catch that specific case and return
+ * { inserted: false, reason: "global_collision" } so the caller can fall back to alternate emails
+ * (Apollo's personalEmails[]) or mark the lead as skipped under a distinct status reason.
  */
 export async function upsertContactMethod(params: {
   leadId: string;
@@ -200,23 +212,37 @@ export async function upsertContactMethod(params: {
   value: string;
   status?: string | null;
   source: string;
-}): Promise<void> {
-  await db
-    .insert(leadContactMethods)
-    .values({
-      leadId: params.leadId,
-      channel: params.channel,
-      value: params.value,
-      status: params.status ?? null,
-      source: params.source,
-    })
-    .onConflictDoUpdate({
-      target: [leadContactMethods.leadId, leadContactMethods.channel, leadContactMethods.value],
-      set: {
+}): Promise<UpsertContactResult> {
+  try {
+    await db
+      .insert(leadContactMethods)
+      .values({
+        leadId: params.leadId,
+        channel: params.channel,
+        value: params.value,
         status: params.status ?? null,
         source: params.source,
-      },
-    });
+      })
+      .onConflictDoUpdate({
+        target: [leadContactMethods.leadId, leadContactMethods.channel, leadContactMethods.value],
+        set: {
+          status: params.status ?? null,
+          source: params.source,
+        },
+      });
+    return { inserted: true };
+  } catch (err) {
+    if (isGlobalContactDupKey(err)) {
+      return { inserted: false, reason: "global_collision" };
+    }
+    throw err;
+  }
+}
+
+function isGlobalContactDupKey(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { code?: string; constraint_name?: string };
+  return e.code === "23505" && e.constraint_name === "idx_lcm_channel_value";
 }
 
 /**

--- a/tests/unit/leads-registry-upsert.test.ts
+++ b/tests/unit/leads-registry-upsert.test.ts
@@ -13,12 +13,13 @@ describe("upsertContactMethod", () => {
   beforeEach(() => {
     insertValues.mockClear();
     onConflictDoUpdate.mockClear();
+    onConflictDoUpdate.mockResolvedValue(undefined);
   });
 
-  it("uses onConflictDoUpdate so re-enrichment overwrites stale status (e.g. unverified -> verified)", async () => {
+  it("returns { inserted: true } on happy path and targets (leadId, channel, value)", async () => {
     const { upsertContactMethod } = await import("../../src/lib/leads-registry.js");
 
-    await upsertContactMethod({
+    const result = await upsertContactMethod({
       leadId: "lead-1",
       channel: "email",
       value: "x@y.com",
@@ -26,6 +27,7 @@ describe("upsertContactMethod", () => {
       source: "apollo",
     });
 
+    expect(result).toEqual({ inserted: true });
     expect(insertValues).toHaveBeenCalledOnce();
     expect(insertValues.mock.calls[0][0]).toMatchObject({
       leadId: "lead-1",
@@ -38,5 +40,62 @@ describe("upsertContactMethod", () => {
     const setArg = onConflictDoUpdate.mock.calls[0][0] as { set: { status: string; source: string } };
     expect(setArg.set.status).toBe("verified");
     expect(setArg.set.source).toBe("apollo");
+  });
+
+  it("returns { inserted: false, reason: 'global_collision' } when (channel, value) already belongs to another lead", async () => {
+    const dupErr = Object.assign(
+      new Error('duplicate key value violates unique constraint "idx_lcm_channel_value"'),
+      { code: "23505", constraint_name: "idx_lcm_channel_value" },
+    );
+    onConflictDoUpdate.mockRejectedValueOnce(dupErr);
+
+    const { upsertContactMethod } = await import("../../src/lib/leads-registry.js");
+
+    const result = await upsertContactMethod({
+      leadId: "lead-2",
+      channel: "email",
+      value: "shared@x.com",
+      status: "verified",
+      source: "apollo",
+    });
+
+    expect(result).toEqual({ inserted: false, reason: "global_collision" });
+  });
+
+  it("rethrows non-dup Postgres errors (e.g. serialization failures)", async () => {
+    const serializationErr = Object.assign(new Error("could not serialize"), { code: "40001" });
+    onConflictDoUpdate.mockRejectedValueOnce(serializationErr);
+
+    const { upsertContactMethod } = await import("../../src/lib/leads-registry.js");
+
+    await expect(
+      upsertContactMethod({
+        leadId: "lead-3",
+        channel: "email",
+        value: "z@y.com",
+        status: null,
+        source: "apollo",
+      }),
+    ).rejects.toThrow("could not serialize");
+  });
+
+  it("rethrows 23505 on other constraints (only swallows the global (channel, value) collision)", async () => {
+    const wrongConstraintErr = Object.assign(
+      new Error('duplicate key value violates unique constraint "idx_lcm_lead_channel_value"'),
+      { code: "23505", constraint_name: "idx_lcm_lead_channel_value" },
+    );
+    onConflictDoUpdate.mockRejectedValueOnce(wrongConstraintErr);
+
+    const { upsertContactMethod } = await import("../../src/lib/leads-registry.js");
+
+    await expect(
+      upsertContactMethod({
+        leadId: "lead-4",
+        channel: "email",
+        value: "q@y.com",
+        status: "verified",
+        source: "apollo",
+      }),
+    ).rejects.toThrow("idx_lcm_lead_channel_value");
   });
 });


### PR DESCRIPTION
Automated by release.sh