### PR TITLE
fix(leads): enforce one current employer per lead at write time (DIS-279)

### DIFF
--- a/scripts/backfill-current-employment.ts
+++ b/scripts/backfill-current-employment.ts
@@ -1,0 +1,109 @@
+/**
+ * ONE-TIME current-employer reconciliation.
+ *
+ * Why: Apollo enrichment re-asserts "current" on every call without expiring the
+ * prior employment, so ~86% of leads accumulated MORE THAN ONE leads_organizations
+ * row flagged current=true. The read path (lead-shape.ts pickCurrentEmployment) now
+ * picks the right one at serve time, and the write path (leads-registry.ts
+ * recordEmploymentHistory) now keeps exactly one current going forward — but the
+ * rows that piled up before that fix still carry multiple current=true.
+ *
+ * What: for every lead, collapse to exactly ONE current=true employment using the
+ * SAME winner-selection as the read path — enriched org first (logo_url OR
+ * primary_domain non-null), then most-recently-created, then organization_id for a
+ * stable tiebreak. All other current=true rows for the lead are set current=false.
+ *
+ * Properties:
+ *   - History-preserving — only flips the `current` flag; never deletes a row.
+ *   - Idempotent        — re-running converges (a lead already at one current is
+ *                         untouched; the `current <> (rn = 1)` guard skips no-op writes).
+ *   - Read-path aligned — same ORDER BY as pickCurrentEmployment, so the backfilled
+ *                         state matches what the serve path would have selected.
+ *
+ * Usage:
+ *   LEAD_SERVICE_DATABASE_URL=... npx tsx scripts/backfill-current-employment.ts --dry-run
+ *   LEAD_SERVICE_DATABASE_URL=... npx tsx scripts/backfill-current-employment.ts
+ */
+
+import { sql as leadSql } from "../src/db/index.js";
+
+export function parseArgs(argv: string[]): { dryRun: boolean } {
+  return { dryRun: argv.includes("--dry-run") };
+}
+
+/** Count leads that currently carry more than one current=true employment. */
+async function countMultiCurrentLeads(): Promise<number> {
+  const rows = await leadSql<{ c: string }[]>`
+    SELECT count(*)::text AS c FROM (
+      SELECT lead_id
+      FROM leads_organizations
+      WHERE current = true
+      GROUP BY lead_id
+      HAVING count(*) > 1
+    ) t`;
+  return Number(rows[0]?.c ?? "0");
+}
+
+/**
+ * Collapse every lead to one current=true row using the read-path winner-selection.
+ * Returns the number of rows whose current flag changed.
+ */
+async function collapseToOneCurrent(): Promise<number> {
+  const changed = await leadSql<{ id: string }[]>`
+    WITH ranked AS (
+      SELECT lo.id,
+        row_number() OVER (
+          PARTITION BY lo.lead_id
+          ORDER BY
+            (CASE WHEN o.logo_url IS NOT NULL OR o.primary_domain IS NOT NULL THEN 0 ELSE 1 END),
+            lo.created_at DESC,
+            lo.organization_id
+        ) AS rn
+      FROM leads_organizations lo
+      LEFT JOIN organizations o ON o.id = lo.organization_id
+      WHERE lo.current = true
+    )
+    UPDATE leads_organizations lo
+    SET current = (ranked.rn = 1)
+    FROM ranked
+    WHERE lo.id = ranked.id
+      AND lo.current <> (ranked.rn = 1)
+    RETURNING lo.id`;
+  return changed.length;
+}
+
+async function main(): Promise<void> {
+  const { dryRun } = parseArgs(process.argv.slice(2));
+  console.log(`[lead-service] current-employment backfill start dryRun=${dryRun}`);
+
+  try {
+    const multi = await countMultiCurrentLeads();
+    console.log(`[lead-service] leads with >1 current=true: ${multi}`);
+
+    if (dryRun) {
+      console.log("[lead-service] DRY RUN — no writes performed");
+      return;
+    }
+
+    const changed = await collapseToOneCurrent();
+    console.log(`[lead-service] backfill done — flipped current on ${changed} rows`);
+
+    const remaining = await countMultiCurrentLeads();
+    if (remaining > 0) {
+      console.warn(`[lead-service] WARNING: ${remaining} leads still have >1 current after backfill`);
+    } else {
+      console.log("[lead-service] verified: every lead now has at most one current=true");
+    }
+  } finally {
+    await leadSql.end();
+  }
+}
+
+// Only auto-run when invoked directly (not when imported by tests).
+const invokedDirectly = process.argv[1]?.includes("backfill-current-employment");
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error("[lead-service] current-employment backfill failed:", err);
+    process.exit(1);
+  });
+}

--- a/src/lib/leads-registry.ts
+++ b/src/lib/leads-registry.ts
@@ -246,40 +246,109 @@ function isGlobalContactDupKey(err: unknown): boolean {
 }
 
 /**
- * Persist current + past employment from an Apollo person. Idempotent on (leadId, organizationId, startDate).
+ * Reuse an existing organization with the same name instead of minting a fresh
+ * placeholder row on every enrichment. Apollo employment-history entries that
+ * don't match the person's top-level (enriched) org have only a name — inserting
+ * a brand-new uuid'd org each time defeats the (leadId, orgId, startDate) dedup
+ * and accumulates duplicate bare orgs without bound. Reuse by name; insert only
+ * when none exists.
+ */
+async function resolveHistoryOrgId(name: string): Promise<string | null> {
+  const existing = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.name, name))
+    .limit(1);
+  if (existing[0]) return existing[0].id;
+  const inserted = await db
+    .insert(organizations)
+    .values({ name })
+    .returning({ id: organizations.id });
+  return inserted[0]?.id ?? null;
+}
+
+/**
+ * Mark the lead's link to `organizationId` as the current employer, idempotent on
+ * (leadId, organizationId). Updates the existing link in place when present (so
+ * re-enrichment never grows the row count); inserts otherwise.
+ */
+async function markCurrentEmployment(
+  leadId: string,
+  organizationId: string,
+  title: string | null,
+): Promise<void> {
+  const existing = await db
+    .select({ id: leadsOrganizations.id })
+    .from(leadsOrganizations)
+    .where(
+      and(
+        eq(leadsOrganizations.leadId, leadId),
+        eq(leadsOrganizations.organizationId, organizationId),
+      ),
+    )
+    .limit(1);
+  if (existing[0]) {
+    await db
+      .update(leadsOrganizations)
+      .set({ current: true, title })
+      .where(eq(leadsOrganizations.id, existing[0].id));
+    return;
+  }
+  await db.insert(leadsOrganizations).values({ leadId, organizationId, title, current: true });
+}
+
+/**
+ * Persist current + past employment from an Apollo person.
+ *
+ * Apollo re-asserts "current" on every enrichment WITHOUT expiring the prior
+ * employment, so a lead would otherwise accumulate multiple current=true rows
+ * (the read path then picks the wrong one — see lead-shape.ts pickCurrentEmployment).
+ * Here we enforce exactly ONE current employer per lead at write time, history-
+ * preserving (no rows deleted):
+ *   1. Expire the current flag on all existing rows for this lead.
+ *   2. Resolve the canonical current employer — the person's top-level (enriched)
+ *      org when present, else the history entry Apollo flags current.
+ *   3. Record past employment with current=false (orgs reused by name, not churned).
+ *   4. Mark exactly the canonical current employer current=true.
+ *
+ * Idempotent on re-enrichment: org ids are stable (top-level by apolloId, history
+ * by name), the current link is upserted, and history rows dedup on
+ * (leadId, organizationId, startDate) — so re-running does not grow row count.
  */
 export async function recordEmploymentHistory(params: {
   leadId: string;
   person: ApolloPersonResult;
 }): Promise<void> {
   const { leadId, person } = params;
+
+  await db
+    .update(leadsOrganizations)
+    .set({ current: false })
+    .where(and(eq(leadsOrganizations.leadId, leadId), eq(leadsOrganizations.current, true)));
+
   const orgId = await upsertOrganizationFromPerson(person);
-  if (orgId) {
-    await db
-      .insert(leadsOrganizations)
-      .values({
-        leadId,
-        organizationId: orgId,
-        title: person.title ?? null,
-        current: true,
-      })
-      .onConflictDoNothing();
-  }
+
+  // Canonical current employer: top-level org wins; otherwise fall back to the
+  // first history entry Apollo flags current (search-time leads with no top-level org).
+  let currentOrgId: string | null = orgId;
+  let currentTitle: string | null = orgId ? person.title ?? null : null;
 
   const history = person.employmentHistory ?? [];
   for (const job of history) {
     if (!job.organizationName) continue;
-    let jobOrgId: string | null = null;
-    if (job.organizationName === person.organizationName && orgId) {
-      jobOrgId = orgId;
-    } else {
-      const inserted = await db
-        .insert(organizations)
-        .values({ name: job.organizationName })
-        .returning({ id: organizations.id });
-      jobOrgId = inserted[0]?.id ?? null;
-    }
+    const jobOrgId =
+      job.organizationName === person.organizationName && orgId
+        ? orgId
+        : await resolveHistoryOrgId(job.organizationName);
     if (!jobOrgId) continue;
+
+    if (!currentOrgId && job.current === true) {
+      currentOrgId = jobOrgId;
+      currentTitle = job.title ?? null;
+    }
+
+    // The canonical current employer is marked separately below.
+    if (jobOrgId === currentOrgId) continue;
 
     await db
       .insert(leadsOrganizations)
@@ -289,10 +358,14 @@ export async function recordEmploymentHistory(params: {
         title: job.title ?? null,
         startDate: job.startDate ?? null,
         endDate: job.endDate ?? null,
-        current: !!job.current,
+        current: false,
         description: job.description ?? null,
       })
       .onConflictDoNothing();
+  }
+
+  if (currentOrgId) {
+    await markCurrentEmployment(leadId, currentOrgId, currentTitle);
   }
 }
 

--- a/tests/unit/leads-registry-current-employment.test.ts
+++ b/tests/unit/leads-registry-current-employment.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { organizations, leadsOrganizations } from "../../src/db/schema.js";
+
+// Call recorders
+const insertCalls: { table: unknown; values: unknown }[] = [];
+const updateCalls: { table: unknown; set: unknown }[] = [];
+// table -> rows returned by select(...).from(table).where(...).limit(n)
+const selectResults = new Map<unknown, unknown[]>();
+const findFirstOrg = vi.fn();
+
+function makeInsert(table: unknown) {
+  return {
+    values: (obj: unknown) => {
+      insertCalls.push({ table, values: obj });
+      // organizations inserts return a new id (resolveHistoryOrgId / upsert insert path)
+      const returningVal = table === organizations ? [{ id: "org-inserted" }] : [];
+      const p = Promise.resolve(returningVal) as Promise<unknown[]> & {
+        onConflictDoNothing: () => Promise<unknown[]>;
+        returning: () => Promise<unknown[]>;
+      };
+      p.onConflictDoNothing = () => Promise.resolve(returningVal);
+      p.returning = () => Promise.resolve(returningVal);
+      return p;
+    },
+  };
+}
+
+function makeUpdate(table: unknown) {
+  return {
+    set: (obj: unknown) => {
+      updateCalls.push({ table, set: obj });
+      return { where: () => Promise.resolve(undefined) };
+    },
+  };
+}
+
+function makeSelect() {
+  return {
+    from: (table: unknown) => ({
+      where: () => ({
+        limit: () => Promise.resolve(selectResults.get(table) ?? []),
+      }),
+    }),
+  };
+}
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    insert: (table: unknown) => makeInsert(table),
+    update: (table: unknown) => makeUpdate(table),
+    select: () => makeSelect(),
+    query: {
+      organizations: { findFirst: (...a: unknown[]) => findFirstOrg(...a) },
+    },
+  },
+}));
+
+function leadsOrgInserts() {
+  return insertCalls.filter((c) => c.table === leadsOrganizations).map((c) => c.values as Record<string, unknown>);
+}
+function orgInserts() {
+  return insertCalls.filter((c) => c.table === organizations);
+}
+function leadsOrgUpdates() {
+  return updateCalls.filter((c) => c.table === leadsOrganizations).map((c) => c.set as Record<string, unknown>);
+}
+
+describe("recordEmploymentHistory — one current employer per lead", () => {
+  beforeEach(() => {
+    insertCalls.length = 0;
+    updateCalls.length = 0;
+    selectResults.clear();
+    findFirstOrg.mockReset();
+    // Top-level org already exists → upsertOrganizationFromPerson takes the UPDATE
+    // branch and returns "org-top" (no organizations INSERT from the top-level path).
+    findFirstOrg.mockResolvedValue({ id: "org-top" });
+  });
+
+  const person = {
+    id: "person-1",
+    title: "Founder",
+    organizationId: "apollo-org-1",
+    organizationName: "Casco Bay",
+    employmentHistory: [
+      { title: "Founder", organizationName: "Casco Bay", startDate: "2018-01-01", current: true },
+      { title: "PM", organizationName: "Old Co", startDate: "2014-01-01", endDate: "2017-12-31", current: false },
+    ],
+  };
+
+  it("expires all current rows for the lead before writing", async () => {
+    selectResults.set(leadsOrganizations, []); // fresh lead, no existing current link
+    selectResults.set(organizations, [{ id: "org-old" }]); // Old Co reused by name
+    const { recordEmploymentHistory } = await import("../../src/lib/leads-registry.js");
+    await recordEmploymentHistory({ leadId: "lead-1", person: person as never });
+
+    expect(leadsOrgUpdates()).toContainEqual(expect.objectContaining({ current: false }));
+    // the expire UPDATE is the first leads_organizations update
+    expect(leadsOrgUpdates()[0]).toMatchObject({ current: false });
+  });
+
+  it("marks exactly the top-level org current=true; history rows are current=false", async () => {
+    selectResults.set(leadsOrganizations, []); // no existing current link → insert
+    selectResults.set(organizations, [{ id: "org-old" }]); // Old Co reused
+    const { recordEmploymentHistory } = await import("../../src/lib/leads-registry.js");
+    await recordEmploymentHistory({ leadId: "lead-1", person: person as never });
+
+    const inserts = leadsOrgInserts();
+    // canonical current employer inserted current=true for org-top
+    expect(inserts).toContainEqual(
+      expect.objectContaining({ organizationId: "org-top", current: true, title: "Founder" }),
+    );
+    // past employment (Old Co) inserted current=false
+    expect(inserts).toContainEqual(
+      expect.objectContaining({ organizationId: "org-old", current: false, title: "PM" }),
+    );
+    // exactly one current=true link written
+    expect(inserts.filter((v) => v.current === true)).toHaveLength(1);
+    // the Casco Bay history entry (matches top-level org) is NOT inserted twice
+    expect(inserts.filter((v) => v.organizationId === "org-top")).toHaveLength(1);
+  });
+
+  it("re-enrich is idempotent: existing current link is UPDATED, not inserted", async () => {
+    selectResults.set(leadsOrganizations, [{ id: "link-top" }]); // current link already exists
+    selectResults.set(organizations, [{ id: "org-old" }]);
+    const { recordEmploymentHistory } = await import("../../src/lib/leads-registry.js");
+    await recordEmploymentHistory({ leadId: "lead-1", person: person as never });
+
+    // current employer set via UPDATE
+    expect(leadsOrgUpdates()).toContainEqual(expect.objectContaining({ current: true, title: "Founder" }));
+    // no current=true link was inserted (would grow row count on every enrich)
+    expect(leadsOrgInserts().filter((v) => v.current === true)).toHaveLength(0);
+  });
+
+  it("reuses an existing org by name for history — no fresh placeholder org minted", async () => {
+    selectResults.set(leadsOrganizations, []);
+    selectResults.set(organizations, [{ id: "org-old" }]); // Old Co already exists by name
+    const { recordEmploymentHistory } = await import("../../src/lib/leads-registry.js");
+    await recordEmploymentHistory({ leadId: "lead-1", person: person as never });
+
+    // top-level org existed (UPDATE branch) and history org reused → zero organizations INSERTs
+    expect(orgInserts()).toHaveLength(0);
+  });
+
+  it("mints a history org only when none exists by name", async () => {
+    selectResults.set(leadsOrganizations, []);
+    selectResults.set(organizations, []); // Old Co not found → insert it
+    const { recordEmploymentHistory } = await import("../../src/lib/leads-registry.js");
+    await recordEmploymentHistory({ leadId: "lead-1", person: person as never });
+
+    expect(orgInserts()).toHaveLength(1);
+    expect(orgInserts()[0].values).toMatchObject({ name: "Old Co" });
+  });
+});


### PR DESCRIPTION
## Problem

`recordEmploymentHistory` re-asserted Apollo's `current` flag on every enrichment **without expiring the prior employment**, so leads accumulated multiple `leads_organizations` rows flagged `current=true` (~86% of leads). It also minted a **fresh placeholder org per re-fetch** for history entries that didn't exact-name-match the top-level org → unbounded row + bare-org growth. The read path (DIS-278, v0.18.2) now picks the right one at serve time; this fixes the **write side** so the dup state stops being created.

## Fix (history-preserving — no rows deleted)

`recordEmploymentHistory`:
1. **Expire** the `current` flag on all existing rows for the lead before writing.
2. Resolve the **canonical current employer** — the person's top-level (enriched) org when present, else the history entry Apollo flags current — and mark only that row `current=true`, **idempotently** (update-in-place when the link exists, so re-enrichment doesn't grow the row count).
3. Record past employment `current=false`, **reusing orgs by name** instead of minting a fresh uuid each enrich (stops bare-org churn).

## Backfill

`scripts/backfill-current-employment.ts` — one-shot, history-preserving reconciliation that collapses existing leads to one `current=true` using the **same winner-selection as the read path** (enriched-first → most-recent → org-id). Idempotent, dry-run supported. Run manually post-deploy (NOT on boot). Reversible: only flips the `current` flag.

## Tests

5 new unit tests (`leads-registry-current-employment.test.ts`): expire-before-write, one current marked, history rows `current=false`, re-enrich idempotent (update not insert), org reused by name vs minted. **180 unit tests green**, build clean, `openapi.json` unchanged (no shape change).

## AC
1. After re-enrich, a lead has exactly one `current=true`. ✅
2. Re-enrich idempotent — no row growth for unchanged employment. ✅
3. No new bare org minted for a company already present. ✅
4. Backfill collapses existing leads; read-path guard (DIS-278) stays as safety belt. ✅ (validated on staging — real-PG winner-SQL)

Linear: DIS-279. Follows DIS-278 (v0.18.2, read-path fix, in prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)