### PR TITLE
feat(leads): feature-memberships endpoint + workflowSlug filter on /orgs/leads

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1727,6 +1727,48 @@
           "sourceOrgId",
           "targetOrgId"
         ]
+      },
+      "FeatureMembershipsResponse": {
+        "type": "object",
+        "properties": {
+          "memberships": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FeatureMembership"
+            },
+            "description": "Distinct (orgId, brandId, workflowSlug) tuples from leads_campaigns whose feature_slug matches the requested feature(s). Empty array when no matches."
+          }
+        },
+        "required": [
+          "memberships"
+        ],
+        "description": "Response shape for GET /internal/feature-memberships."
+      },
+      "FeatureMembership": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string",
+            "description": "Internal organization UUID owning the leads.",
+            "example": "30000000-0000-0000-0000-000000000001"
+          },
+          "brandId": {
+            "type": "string",
+            "description": "Brand UUID (unnested from leads_campaigns.brand_ids).",
+            "example": "20000000-0000-0000-0000-000000000001"
+          },
+          "workflowSlug": {
+            "type": "string",
+            "description": "Workflow slug that produced leads for this (org, brand) under the requested feature.",
+            "example": "sales-cold-email-outreach-lithium"
+          }
+        },
+        "required": [
+          "orgId",
+          "brandId",
+          "workflowSlug"
+        ],
+        "description": "One distinct (org, brand, workflow) combination that has leads for a requested feature."
       }
     },
     "parameters": {},
@@ -1976,6 +2018,15 @@
             "in": "query",
             "name": "userId",
             "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workflowSlug",
+            "required": false,
+            "description": "Restrict returned leads to those whose leads_campaigns row has workflow_slug = <value>. When absent, behavior + response shape are unchanged.",
             "schema": {
               "type": "string"
             }
@@ -2272,6 +2323,47 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/internal/feature-memberships": {
+      "get": {
+        "summary": "List distinct (org, brand, workflow) combinations that have leads for a feature",
+        "description": "Returns the DISTINCT (orgId, brandId, workflowSlug) tuples from leads_campaigns whose feature_slug matches the requested feature(s). featureSlugs is comma-separated and matched exactly (feature slugs are not versioned). brandId is unnested from brand_ids[]. Rows with a null workflow_slug are excluded. Empty array when no matches. Auth: x-api-key only.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "API key for authenticating requests"
+          },
+          {
+            "in": "query",
+            "name": "featureSlugs",
+            "required": true,
+            "description": "Comma-separated list of feature slugs to resolve memberships for.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Distinct (org, brand, workflow) memberships for the requested feature(s)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureMembershipsResponse"
                 }
               }
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import bufferRoutes from "./routes/buffer.js";
 import leadsRoutes from "./routes/leads.js";
 import statsRoutes from "./routes/stats.js";
 import transferBrandRoutes from "./routes/transfer-brand.js";
+import featureMembershipsRoutes from "./routes/feature-memberships.js";
 import { registerProviders } from "./lib/register-providers.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -36,6 +37,7 @@ app.use(bufferRoutes);
 app.use(leadsRoutes);
 app.use(statsRoutes);
 app.use(transferBrandRoutes);
+app.use(featureMembershipsRoutes);
 
 app.use((req, res) => {
   res.status(404).json({ error: "Not found" });

--- a/src/routes/feature-memberships.ts
+++ b/src/routes/feature-memberships.ts
@@ -1,0 +1,68 @@
+import { Router } from "express";
+import { sql } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { apiKeyAuth } from "../middleware/auth.js";
+
+const router = Router();
+
+/**
+ * Parse a comma-separated query value: split on ",", trim each part, drop empties.
+ * Mirrors runs-service GET /v1/stats/public/costs featureSlugs resolution byte-for-byte.
+ */
+function parseCsv(value: unknown): string[] {
+  if (typeof value !== "string") return [];
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+interface MembershipRow {
+  org_id: string;
+  brand_id: string;
+  workflow_slug: string;
+}
+
+/**
+ * GET /internal/feature-memberships?featureSlugs=<csv>
+ *
+ * Returns the DISTINCT (orgId, brandId, workflowSlug) tuples that have leads for the
+ * requested feature(s). brandId is unnested from brand_ids[]. featureSlugs are matched
+ * exactly (same as runs-service /v1/stats/public/costs — feature slugs are not versioned).
+ *
+ * Auth: x-api-key only (same tier as other /internal/* routes). No identity headers required.
+ */
+router.get("/internal/feature-memberships", apiKeyAuth, async (req, res) => {
+  try {
+    const featureSlugs = parseCsv(req.query.featureSlugs);
+
+    // No requested features -> nothing to resolve. Never run an unfiltered cross-org dump.
+    if (featureSlugs.length === 0) {
+      res.json({ memberships: [] });
+      return;
+    }
+
+    const rows = (await db.execute(sql`
+      SELECT DISTINCT org_id, unnest(brand_ids) AS brand_id, workflow_slug
+      FROM leads_campaigns
+      WHERE feature_slug IN (${sql.join(
+        featureSlugs.map((s) => sql`${s}`),
+        sql`, `,
+      )})
+        AND workflow_slug IS NOT NULL
+    `)) as unknown as MembershipRow[];
+
+    const memberships = rows.map((r) => ({
+      orgId: r.org_id,
+      brandId: r.brand_id,
+      workflowSlug: r.workflow_slug,
+    }));
+
+    res.json({ memberships });
+  } catch (error) {
+    console.error("[lead-service] feature-memberships error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -96,7 +96,7 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
       traceEvent(req.runId, { service: "lead-service", event: "leads-query-start", detail: `orgId=${req.orgId}` }, req.headers).catch(() => {});
     }
 
-    const { brandId, campaignId, orgId: queryOrgId, userId } = req.query;
+    const { brandId, campaignId, orgId: queryOrgId, userId, workflowSlug } = req.query;
     const conditions: SQL[] = [eq(leadsCampaigns.orgId, req.orgId!)];
     if (brandId && typeof brandId === "string") {
       conditions.push(sql`${brandId} = ANY(${leadsCampaigns.brandIds})`);
@@ -109,6 +109,9 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
     }
     if (userId && typeof userId === "string") {
       conditions.push(eq(leadsCampaigns.userId, userId));
+    }
+    if (workflowSlug && typeof workflowSlug === "string") {
+      conditions.push(eq(leadsCampaigns.workflowSlug, workflowSlug));
     }
 
     const rows = await db

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1408,6 +1408,15 @@ registry.registerPath({
       required: false,
       schema: { type: "string" as const },
     },
+    {
+      in: "query" as const,
+      name: "workflowSlug",
+      required: false,
+      description:
+        "Restrict returned leads to those whose leads_campaigns row has workflow_slug = <value>. " +
+        "When absent, behavior + response shape are unchanged.",
+      schema: { type: "string" as const },
+    },
   ],
   responses: {
     200: {
@@ -1601,6 +1610,82 @@ registry.registerPath({
     400: {
       description: "Invalid request body",
       content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    401: { description: "Unauthorized" },
+  },
+});
+
+// --- Feature memberships (internal) ---
+
+const FeatureMembershipApiKeyHeader = [
+  {
+    in: "header" as const,
+    name: "x-api-key",
+    required: true,
+    schema: { type: "string" as const },
+    description: "API key for authenticating requests",
+  },
+];
+
+const FeatureMembershipSchema = z
+  .object({
+    orgId: z
+      .string()
+      .openapi({
+        description: "Internal organization UUID owning the leads.",
+        example: "30000000-0000-0000-0000-000000000001",
+      }),
+    brandId: z
+      .string()
+      .openapi({
+        description: "Brand UUID (unnested from leads_campaigns.brand_ids).",
+        example: "20000000-0000-0000-0000-000000000001",
+      }),
+    workflowSlug: z
+      .string()
+      .openapi({
+        description: "Workflow slug that produced leads for this (org, brand) under the requested feature.",
+        example: "sales-cold-email-outreach-lithium",
+      }),
+  })
+  .openapi("FeatureMembership", {
+    description:
+      "One distinct (org, brand, workflow) combination that has leads for a requested feature.",
+  });
+
+const FeatureMembershipsResponseSchema = z
+  .object({
+    memberships: z.array(FeatureMembershipSchema).openapi({
+      description:
+        "Distinct (orgId, brandId, workflowSlug) tuples from leads_campaigns whose feature_slug matches the requested feature(s). Empty array when no matches.",
+    }),
+  })
+  .openapi("FeatureMembershipsResponse", {
+    description: "Response shape for GET /internal/feature-memberships.",
+  });
+
+registry.registerPath({
+  method: "get",
+  path: "/internal/feature-memberships",
+  summary: "List distinct (org, brand, workflow) combinations that have leads for a feature",
+  description:
+    "Returns the DISTINCT (orgId, brandId, workflowSlug) tuples from leads_campaigns whose feature_slug matches the requested feature(s). " +
+    "featureSlugs is comma-separated and matched exactly (feature slugs are not versioned). brandId is unnested from brand_ids[]. " +
+    "Rows with a null workflow_slug are excluded. Empty array when no matches. Auth: x-api-key only.",
+  parameters: [
+    ...FeatureMembershipApiKeyHeader,
+    {
+      in: "query" as const,
+      name: "featureSlugs",
+      required: true,
+      description: "Comma-separated list of feature slugs to resolve memberships for.",
+      schema: { type: "string" as const },
+    },
+  ],
+  responses: {
+    200: {
+      description: "Distinct (org, brand, workflow) memberships for the requested feature(s)",
+      content: { "application/json": { schema: FeatureMembershipsResponseSchema } },
     },
     401: { description: "Unauthorized" },
   },

--- a/tests/unit/feature-memberships.test.ts
+++ b/tests/unit/feature-memberships.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { SQL } from "drizzle-orm";
+
+const execute = vi.fn();
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    execute: (...args: unknown[]) => execute(...args),
+  },
+}));
+
+vi.mock("../../src/config.js", () => ({
+  LEAD_SERVICE_API_KEY: "test-api-key",
+}));
+
+const dialect = new PgDialect();
+/** Compile the captured drizzle SQL object into { sql, params } for assertions. */
+function compile(call: unknown): { sql: string; params: unknown[] } {
+  return dialect.sqlToQuery(call as SQL);
+}
+
+async function buildApp() {
+  vi.resetModules();
+  const { default: route } = await import("../../src/routes/feature-memberships.js");
+  const app = express();
+  app.use(express.json());
+  app.use(route);
+  return app;
+}
+
+describe("GET /internal/feature-memberships", () => {
+  beforeEach(() => {
+    execute.mockReset().mockResolvedValue([]);
+  });
+
+  it("rejects missing x-api-key with 401", async () => {
+    const app = await buildApp();
+    const res = await request(app).get("/internal/feature-memberships?featureSlugs=sales-cold-email-outreach");
+    expect(res.status).toBe(401);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("returns distinct memberships mapped to {orgId, brandId, workflowSlug}", async () => {
+    execute.mockResolvedValueOnce([
+      { org_id: "org-1", brand_id: "brand-1", workflow_slug: "sales-cold-email-outreach-lithium" },
+      { org_id: "org-1", brand_id: "brand-2", workflow_slug: "sales-cold-email-outreach-bronze-2" },
+    ]);
+
+    const app = await buildApp();
+    const res = await request(app)
+      .get("/internal/feature-memberships?featureSlugs=sales-cold-email-outreach")
+      .set("x-api-key", "test-api-key");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      memberships: [
+        { orgId: "org-1", brandId: "brand-1", workflowSlug: "sales-cold-email-outreach-lithium" },
+        { orgId: "org-1", brandId: "brand-2", workflowSlug: "sales-cold-email-outreach-bronze-2" },
+      ],
+    });
+
+    expect(execute).toHaveBeenCalledOnce();
+    const { sql, params } = compile(execute.mock.calls[0][0]);
+    const lower = sql.toLowerCase();
+    expect(lower).toContain("feature_slug in");
+    expect(lower).toContain("workflow_slug is not null");
+    expect(lower).toContain("unnest(brand_ids)");
+    expect(lower).toContain("distinct");
+    expect(params).toEqual(["sales-cold-email-outreach"]);
+  });
+
+  it("parses comma-separated featureSlugs (trim + drop empties)", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .get("/internal/feature-memberships?featureSlugs=a, b ,,c")
+      .set("x-api-key", "test-api-key");
+
+    expect(res.status).toBe(200);
+    expect(execute).toHaveBeenCalledOnce();
+    const { params } = compile(execute.mock.calls[0][0]);
+    expect(params).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns empty memberships and skips the query when featureSlugs is missing", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .get("/internal/feature-memberships")
+      .set("x-api-key", "test-api-key");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ memberships: [] });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("returns empty memberships and skips the query when featureSlugs has only empties", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .get("/internal/feature-memberships?featureSlugs=,, ,")
+      .set("x-api-key", "test-api-key");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ memberships: [] });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("returns empty memberships when the query matches no rows", async () => {
+    execute.mockResolvedValueOnce([]);
+    const app = await buildApp();
+    const res = await request(app)
+      .get("/internal/feature-memberships?featureSlugs=nonexistent-feature")
+      .set("x-api-key", "test-api-key");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ memberships: [] });
+    expect(execute).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/leads-workflow-filter.test.ts
+++ b/tests/unit/leads-workflow-filter.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { SQL } from "drizzle-orm";
+
+// Capture the argument passed to .where() so we can assert on the compiled SQL.
+let capturedWhere: unknown = null;
+
+vi.mock("../../src/db/index.js", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        leftJoin: () => ({
+          where: (arg: unknown) => {
+            capturedWhere = arg;
+            return Promise.resolve([]);
+          },
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("../../src/lib/lead-shape.js", () => ({
+  buildFullLeadsBatch: vi.fn().mockResolvedValue(new Map()),
+}));
+
+vi.mock("../../src/lib/email-gateway-client.js", () => ({
+  checkDeliveryStatus: vi.fn().mockResolvedValue({ results: [] }),
+}));
+
+vi.mock("../../src/lib/trace-event.js", () => ({
+  traceEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/config.js", () => ({
+  LEAD_SERVICE_API_KEY: "test-api-key",
+}));
+
+const dialect = new PgDialect();
+function compileWhere(): { sql: string; params: unknown[] } {
+  return dialect.sqlToQuery(capturedWhere as SQL);
+}
+
+const ORG = "30000000-0000-0000-0000-000000000001";
+const BRAND = "20000000-0000-0000-0000-000000000001";
+
+async function buildApp() {
+  vi.resetModules();
+  const { default: route } = await import("../../src/routes/leads.js");
+  const app = express();
+  app.use(express.json());
+  app.use(route);
+  return app;
+}
+
+describe("GET /orgs/leads workflowSlug filter", () => {
+  beforeEach(() => {
+    capturedWhere = null;
+  });
+
+  it("rejects missing x-api-key with 401", async () => {
+    const app = await buildApp();
+    const res = await request(app).get(`/orgs/leads?brandId=${BRAND}`).set("x-org-id", ORG);
+    expect(res.status).toBe(401);
+  });
+
+  it("adds a workflow_slug condition when workflowSlug is provided", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .get(`/orgs/leads?brandId=${BRAND}&workflowSlug=sales-cold-email-outreach-lithium`)
+      .set("x-api-key", "test-api-key")
+      .set("x-org-id", ORG);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ leads: [] });
+
+    const { sql, params } = compileWhere();
+    expect(sql.toLowerCase()).toContain("workflow_slug");
+    expect(params).toContain("sales-cold-email-outreach-lithium");
+  });
+
+  it("does NOT add a workflow_slug condition when workflowSlug is absent", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .get(`/orgs/leads?brandId=${BRAND}`)
+      .set("x-api-key", "test-api-key")
+      .set("x-org-id", ORG);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ leads: [] });
+
+    const { sql, params } = compileWhere();
+    expect(sql.toLowerCase()).not.toContain("workflow_slug");
+    expect(params).not.toContain("sales-cold-email-outreach-lithium");
+  });
+});


### PR DESCRIPTION
## What

Two additive capabilities features-service needs to drive its per-(org, brand, workflow) revenue/CAC/ROI loop for the benchmarks page.

### 1. NEW `GET /internal/feature-memberships?featureSlugs=<csv>`
- Returns `{ memberships: [{ orgId, brandId, workflowSlug }] }` — DISTINCT (org_id, brand_id, workflow_slug) from `leads_campaigns` where `feature_slug` matches the requested feature(s).
- `brandId` unnested from `brand_ids[]`.
- `featureSlugs` resolution mirrors runs-service `GET /v1/stats/public/costs` **byte-for-byte**: comma-separated (`split(",")` → trim → drop empties), **exact** `feature_slug IN (...)` match. Verified against prod data — feature slugs are not versioned (`sales-cold-email-outreach`, clean), so exact = prefix here; no prefix logic exists in runs-service (feature dynasty was eradicated).
- Rows with null `workflow_slug` excluded (contract type is non-nullable `string`; 0 such rows today).
- Empty array on no/empty `featureSlugs` — never an unfiltered cross-org dump.
- Auth: `x-api-key` only (same tier as other `/internal/*`; no identity headers added).

### 2. `GET /orgs/leads` — optional `workflowSlug` query param
- When present: restricts to rows with `workflow_slug = <value>`.
- When absent: behavior + response shape **byte-identical** to before.

## Verification
- `?featureSlugs=sales-cold-email-outreach` → distinct tuples (62 in prod today, one row per versioned workflow); 401 without valid `x-api-key`; empty array on no match.
- `/orgs/leads?brandId=&workflowSlug=` → only that workflow's leads; same call without `workflowSlug` unchanged.
- Unit tests assert the compiled WHERE (via `PgDialect`) includes the filter when present / absent when not, plus 401 + empty guards.
- `npm run build` (tsc + openapi regen) + full suite green: 26 files, 189 tests.

## No new env vars. Additive only — no existing endpoint modified except one optional param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)