### PR TITLE
feat(leads): add ?view=basic slim projection to /orgs/leads

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2055,6 +2055,19 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "view",
+            "required": false,
+            "description": "Per-lead payload size. `basic` returns a slim `lead` object (firstName, lastName, name, headline, linkedinUrl, photoUrl, apolloPersonId + organization {id, name, logoUrl, primaryDomain, websiteUrl}); drops employmentHistory, funding events, and the extra organization columns. Absent or any other value => the full FullLead payload (default, backward-compatible). Use `basic` for list views to cut the response ~10x.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "basic",
+                "full"
+              ]
+            }
           }
         ],
         "responses": {

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -90,6 +90,54 @@ const DEFAULT_STATUS: FlattenedStatus = {
   global: { bounced: false, unsubscribed: false },
 };
 
+interface SlimLead {
+  leadId: string;
+  apolloPersonId: string | null;
+  firstName: string;
+  lastName: string;
+  name: string | null;
+  headline: string | null;
+  linkedinUrl: string | null;
+  photoUrl: string | null;
+  organization: {
+    id: string;
+    name: string | null;
+    logoUrl: string | null;
+    primaryDomain: string | null;
+    websiteUrl: string | null;
+  } | null;
+}
+
+// Slim projection of FullLead for `?view=basic`. Drops the fields no consumer reads —
+// employmentHistory, the ~34 extra organization columns, funding events — verified against
+// features-service (revenue engine) + dashboard (leads table + detail panel). Cuts the wire
+// payload ~10x (~150MB -> ~15MB for a 50k-lead brand), which is what callers actually choke
+// on: features-service parses the whole body, the dashboard transfers it on a poll timer.
+// `view` absent => full shape (unchanged, backward-compatible).
+function toSlimLead(full: FullLead | null): SlimLead | null {
+  if (!full) return null;
+  const org = full.organization;
+  return {
+    leadId: full.leadId,
+    apolloPersonId: full.apolloPersonId,
+    firstName: full.firstName,
+    lastName: full.lastName,
+    name: full.name,
+    headline: full.headline,
+    linkedinUrl: full.linkedinUrl,
+    photoUrl: full.photoUrl,
+    organization: org
+      ? {
+          id: org.id,
+          name: org.name,
+          logoUrl: org.logoUrl,
+          primaryDomain: org.primaryDomain,
+          websiteUrl: org.websiteUrl,
+        }
+      : null,
+  };
+}
+
 // A single brand can carry 50k+ leads_campaigns rows. Hydrating + serializing all of
 // them at once OOMs the heap (the full FullLead object graph + the ~150MB JSON string
 // both live in memory simultaneously → StreamBase::Writev allocation failure). We instead
@@ -156,6 +204,9 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
     const hasScopeForStatus = !!(campaignIdStr || brandIdStr);
     const flatten = campaignIdStr ? flattenCampaignStatus : flattenBrandStatus;
     const context = getServiceContext(req);
+    // `?view=basic` => slim per-lead payload (see toSlimLead). Anything else (incl. absent)
+    // => full FullLead, the existing default. No Zod default: a missing param is full.
+    const slim = req.query.view === "basic";
 
     // The DB query above is the last point a clean 500 can be sent. Everything below
     // writes to the socket; from here on, failures destroy the stream (headers are sent).
@@ -218,7 +269,7 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
           servedAt: row.servedAt ? row.servedAt.toISOString() : null,
           status: row.status as "buffered" | "skipped" | "claimed" | "served",
           emailStatus,
-          lead: fullLead,
+          lead: slim ? toSlimLead(fullLead) : fullLead,
           statusReason: row.statusReason ?? null,
           statusDetails: row.statusDetails ?? null,
           ...deliveryStatus,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1441,6 +1441,18 @@ registry.registerPath({
         "When absent, behavior + response shape are unchanged.",
       schema: { type: "string" as const },
     },
+    {
+      in: "query" as const,
+      name: "view",
+      required: false,
+      description:
+        "Per-lead payload size. `basic` returns a slim `lead` object (firstName, lastName, name, " +
+        "headline, linkedinUrl, photoUrl, apolloPersonId + organization {id, name, logoUrl, " +
+        "primaryDomain, websiteUrl}); drops employmentHistory, funding events, and the extra " +
+        "organization columns. Absent or any other value => the full FullLead payload (default, " +
+        "backward-compatible). Use `basic` for list views to cut the response ~10x.",
+      schema: { type: "string" as const, enum: ["basic", "full"] },
+    },
   ],
   responses: {
     200: {

--- a/tests/unit/leads-stream.test.ts
+++ b/tests/unit/leads-stream.test.ts
@@ -44,9 +44,28 @@ function fullLeadMapFor(ids: string[]) {
   for (const id of ids) {
     m.set(id, {
       leadId: id,
+      apolloPersonId: `apollo-${id}`,
+      firstName: "Jane",
+      lastName: "Doe",
+      name: "Jane Doe",
+      headline: "CEO",
+      linkedinUrl: "https://linkedin.com/in/jane",
+      photoUrl: "https://example.com/jane.jpg",
       contacts: [{ channel: "email", value: `${id}@example.com`, status: "valid", source: "apollo" }],
-      organization: null,
-      employmentHistory: [],
+      organization: {
+        id: `org-${id}`,
+        name: "Acme",
+        logoUrl: "https://example.com/acme.png",
+        primaryDomain: "acme.com",
+        websiteUrl: "https://acme.com",
+        // Heavy fields that view=basic must drop:
+        annualRevenue: "1000000",
+        keywords: ["a", "b", "c"],
+        seoDescription: "long".repeat(50),
+        industries: ["software"],
+      },
+      // Heavy field that view=basic must drop entirely:
+      employmentHistory: [{ organizationId: `org-${id}`, title: "CEO", current: true }],
     });
   }
   return m;
@@ -138,6 +157,49 @@ describe("GET /orgs/leads chunked streaming", () => {
     for (const call of buildFullLeadsBatchMock.mock.calls) {
       expect(call[0].length).toBeLessThanOrEqual(2);
     }
+  });
+
+  it("view=basic returns a slim lead (drops employmentHistory + heavy org fields)", async () => {
+    mockRows = [row(1)];
+    const app = await buildApp();
+    const res = await request(app)
+      .get(`/orgs/leads?brandId=${BRAND}&view=basic`)
+      .set("x-api-key", "test-api-key")
+      .set("x-org-id", ORG);
+
+    expect(res.status).toBe(200);
+    const lead = res.body.leads[0].lead;
+    // Kept fields
+    expect(lead.firstName).toBe("Jane");
+    expect(lead.headline).toBe("CEO");
+    expect(lead.organization).toEqual({
+      id: "org-lead-1",
+      name: "Acme",
+      logoUrl: "https://example.com/acme.png",
+      primaryDomain: "acme.com",
+      websiteUrl: "https://acme.com",
+    });
+    // Dropped fields
+    expect(lead.employmentHistory).toBeUndefined();
+    expect(lead.contacts).toBeUndefined();
+    expect(lead.organization.annualRevenue).toBeUndefined();
+    expect(lead.organization.keywords).toBeUndefined();
+    expect(lead.organization.seoDescription).toBeUndefined();
+  });
+
+  it("view absent returns the full lead shape (backward-compatible)", async () => {
+    mockRows = [row(1)];
+    const app = await buildApp();
+    const res = await request(app)
+      .get(`/orgs/leads?brandId=${BRAND}`)
+      .set("x-api-key", "test-api-key")
+      .set("x-org-id", ORG);
+
+    expect(res.status).toBe(200);
+    const lead = res.body.leads[0].lead;
+    expect(Array.isArray(lead.employmentHistory)).toBe(true);
+    expect(lead.organization.annualRevenue).toBe("1000000");
+    expect(lead.organization.keywords).toEqual(["a", "b", "c"]);
   });
 
   it("applies delivery overlay to served rows within a chunk", async () => {


### PR DESCRIPTION
## Why
`/orgs/leads` returns the full `FullLead` per row (40+ org columns, `employmentHistory`, funding events). The two real consumers read none of that:
- **features-service** revenue engine → ~8 thin fields
- **dashboard** table + detail panel → `firstName/lastName/headline/linkedinUrl/photoUrl` + org `{name, primaryDomain, logoUrl}` (verified: `employmentHistory` 0 uses, 3 of ~40 org fields used)

For a 50k-lead brand the full payload is ~150 MB → features-service OOMs parsing it, dashboard transfers it on a poll timer.

## What
`?view=basic` → slim per-lead `lead` object (verified-used fields only), drops `employmentHistory` + extra org columns + funding. ~10× smaller wire payload. **Absent or any other value → full `FullLead` (unchanged default, backward-compatible).** Still streamed in row chunks (v0.21.4).

No pagination: both consumers want the *whole* population (features for revenue, dashboard for client-side grouping/search).

## Tests
211 unit green (+2: slim drops heavy fields; absent = full shape). OpenAPI param documented.

## Rollout
Follow-up consumers switch to `?view=basic`: features-service#281, distribute.you#1620. This producer change is backward-compatible — merges independently.

Relates: lead-service#272 (OOM hotfix v0.21.4).