### PR TITLE
feat(buffer): read goal from brand-service, drop x-goal header

### DIFF
--- a/src/lib/brand-client.ts
+++ b/src/lib/brand-client.ts
@@ -10,8 +10,8 @@ export interface ExtractedField {
 }
 
 type ServiceContext = {
-  userId?: string;
-  runId?: string;
+  userId?: string | null;
+  runId?: string | null;
   campaignId?: string;
   brandId?: string;
   workflowSlug?: string;
@@ -95,6 +95,34 @@ export async function extractBrandFields(
     console.error("[brand-client] Error extracting brand fields:", error);
     throw error;
   }
+}
+
+export type CurrentGoal = "signup" | "meetingBooked" | "purchase";
+
+/**
+ * Fetch the brand's canonical current goal from brand-service.
+ * The brand owns its goal (brands.currentGoal); lead-service reads it here
+ * instead of taking it as an x-goal header. Fails loud on any non-2xx — a
+ * brand with no goal set returns 404, and that is a config error (a brand in a
+ * lead-finding workflow must have a goal), not an empty/exhausted result.
+ */
+export async function getCurrentGoal(
+  brandId: string,
+  orgId?: string | null,
+  context?: ServiceContext,
+): Promise<CurrentGoal> {
+  const response = await fetch(`${BRAND_SERVICE_URL}/internal/brands/${brandId}/runtime-context`, {
+    headers: buildHeaders(orgId, context),
+    signal: AbortSignal.timeout(300_000),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `[brand-client] runtime-context failed for brand ${brandId}: ${response.status} ${text}`,
+    );
+  }
+  const data = (await response.json()) as { currentGoal: CurrentGoal };
+  return data.currentGoal;
 }
 
 export async function fetchExtractedFields(

--- a/src/lib/buffer.ts
+++ b/src/lib/buffer.ts
@@ -8,6 +8,7 @@ import {
   upsertContactMethod,
 } from "./leads-registry.js";
 import { buildFullLead } from "./lead-shape.js";
+import { getCurrentGoal } from "./brand-client.js";
 
 interface PullNextParams {
   orgId: string;
@@ -17,7 +18,6 @@ interface PullNextParams {
   /** Primary brand the audience is resolved for (per-brand audiences). */
   brandId: string;
   featureSlug: string;
-  goal: string;
   parentRunId?: string | null;
   runId?: string | null;
   userId?: string | null;
@@ -72,23 +72,29 @@ export async function pullNext(
     campaignId: params.campaignId,
     workflowSlug: params.workflowSlug,
     featureSlug: params.featureSlug,
-    goal: params.goal,
     activeGoalId: params.activeGoalId ?? undefined,
     brandProfileId: params.brandProfileId ?? undefined,
     customerPersonaId: params.customerPersonaId ?? undefined,
     customerProfileId: params.customerProfileId ?? undefined,
   };
 
+  // 0. The goal belongs to the brand (brands.currentGoal), not the caller — read
+  // it from brand-service. No goal set ⟹ brand-service 404 ⟹ this fails loud.
+  const goal = await getCurrentGoal(params.brandId, params.orgId, baseCtx);
+  const ctx: ServiceContext = { ...baseCtx, goal };
+
+  if (signal?.aborted) return { found: false };
+
   // 1. Most-relevant audience id for this brand + feature + goal.
   const audienceId = await getTopAudienceId({
     featureSlug: params.featureSlug,
     brandId: params.brandId,
-    goal: params.goal,
-    ctx: baseCtx,
+    goal,
+    ctx,
   });
   if (!audienceId) {
     console.log(
-      `[lead-service] pullNext found=false campaign=${params.campaignId} reason=no_audience brand=${params.brandId} feature=${params.featureSlug} goal=${params.goal}`,
+      `[lead-service] pullNext found=false campaign=${params.campaignId} reason=no_audience brand=${params.brandId} feature=${params.featureSlug} goal=${goal}`,
     );
     return { found: false };
   }
@@ -97,7 +103,7 @@ export async function pullNext(
 
   // 2. Next unserved person of that audience (human-service owns filters/provider/dedup).
   // Attribute the serve to the resolved audience id (= customer profile id).
-  const serveCtx: ServiceContext = { ...baseCtx, customerProfileId: audienceId };
+  const serveCtx: ServiceContext = { ...ctx, customerProfileId: audienceId };
   const served = await serveNext(audienceId, serveCtx);
 
   if (served.status === "exhausted" || !served.person) {
@@ -150,7 +156,7 @@ export async function pullNext(
       userId: params.userId ?? null,
       workflowSlug: params.workflowSlug ?? null,
       featureSlug: params.featureSlug ?? null,
-      goal: params.goal ?? null,
+      goal,
       activeGoalId: params.activeGoalId ?? null,
       brandProfileId: params.brandProfileId ?? null,
       customerPersonaId: params.customerPersonaId ?? null,
@@ -174,7 +180,7 @@ export async function pullNext(
       orgId: params.orgId,
       userId: params.userId ?? null,
       apolloPersonId: person.providerPersonId,
-      goal: params.goal ?? null,
+      goal,
       activeGoalId: params.activeGoalId ?? null,
       brandProfileId: params.brandProfileId ?? null,
       customerPersonaId: params.customerPersonaId ?? null,

--- a/src/routes/buffer.ts
+++ b/src/routes/buffer.ts
@@ -42,15 +42,12 @@ router.post("/orgs/buffer/next", apiKeyAuth, requireOrgId, requireRunId, async (
     return res.status(400).json({ error: "x-campaign-id and x-brand-id headers required" });
   }
 
-  // The audience is resolved per (brand, feature, goal) from features-service,
-  // so all three are required — a missing one is a 400, never a silent default.
+  // The audience is resolved per (brand, feature) from features-service; the goal
+  // is the brand's own (brands.currentGoal), fetched from brand-service inside
+  // pullNext — NOT a caller input. So x-feature-slug is required; x-goal is not.
   const featureSlug = req.featureSlug;
-  const goal = req.goal;
   if (!featureSlug) {
     return res.status(400).json({ error: "x-feature-slug header required" });
-  }
-  if (!goal) {
-    return res.status(400).json({ error: "x-goal header required" });
   }
   // Audiences are per-brand; resolve against the primary (first) brand id.
   const brandId = brandIds[0];
@@ -128,7 +125,6 @@ router.post("/orgs/buffer/next", apiKeyAuth, requireOrgId, requireRunId, async (
         brandIds,
         brandId,
         featureSlug,
-        goal,
         parentRunId: runId,
         runId: serveRunId,
         userId: req.userId ?? null,

--- a/tests/unit/brand-client.test.ts
+++ b/tests/unit/brand-client.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getCurrentGoal } from "../../src/lib/brand-client.js";
+
+type CapturedRequest = { url: string; init: RequestInit };
+
+function mockFetch(responseBody: unknown): { calls: CapturedRequest[] } {
+  const calls: CapturedRequest[] = [];
+  const fetchSpy = vi.fn(async (url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  vi.stubGlobal("fetch", fetchSpy);
+  return { calls };
+}
+
+describe("brand-client getCurrentGoal", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("GETs runtime-context and returns the brand's currentGoal", async () => {
+    const { calls } = mockFetch({
+      brand: { id: "brand-1" },
+      currentGoal: "meetingBooked",
+      brandProfile: null,
+    });
+
+    const goal = await getCurrentGoal("brand-1", "org-1", { runId: "run-1" });
+
+    expect(goal).toBe("meetingBooked");
+    expect(calls[0].url).toBe("http://brand:3005/internal/brands/brand-1/runtime-context");
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers["x-org-id"]).toBe("org-1");
+    expect(headers["x-run-id"]).toBe("run-1");
+    expect(headers["X-API-Key"]).toBeDefined();
+  });
+
+  it("throws on non-2xx (no goal set → 404 → fail loud)", async () => {
+    const fetchSpy = vi.fn(async () => new Response("Brand not found", { status: 404 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(getCurrentGoal("brand-1", "org-1")).rejects.toThrow(
+      /runtime-context failed for brand brand-1: 404/,
+    );
+  });
+});

--- a/tests/unit/buffer.test.ts
+++ b/tests/unit/buffer.test.ts
@@ -11,6 +11,11 @@ vi.mock("../../src/lib/people-client.js", () => ({
   serveNext: (...args: unknown[]) => serveNext(...args),
 }));
 
+const getCurrentGoal = vi.fn();
+vi.mock("../../src/lib/brand-client.js", () => ({
+  getCurrentGoal: (...args: unknown[]) => getCurrentGoal(...args),
+}));
+
 const upsertLeadFromPerson = vi.fn();
 const recordEmploymentHistory = vi.fn();
 const upsertContactMethod = vi.fn();
@@ -70,7 +75,6 @@ const baseParams = {
   brandIds: ["brand-1"],
   brandId: "brand-1",
   featureSlug: "lead-finder-v1",
-  goal: "signup",
   runId: "run-1",
   userId: "user-1",
 };
@@ -78,8 +82,37 @@ const baseParams = {
 describe("pullNext (audience serve-next flow)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // goal is brand-owned — default the brand-service lookup to "signup".
+    getCurrentGoal.mockResolvedValue("signup");
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("fetches the goal from brand-service and uses it for the audience + attribution", async () => {
+    getCurrentGoal.mockResolvedValueOnce("meetingBooked");
+    getTopAudienceId.mockResolvedValueOnce("aud-1");
+    serveNext.mockResolvedValueOnce({ status: "served", person });
+    upsertLeadFromPerson.mockResolvedValueOnce("lead-1");
+    recordEmploymentHistory.mockResolvedValueOnce(undefined);
+    upsertContactMethod.mockResolvedValueOnce({ inserted: true });
+    buildFullLead.mockResolvedValueOnce({ leadId: "lead-1" });
+
+    const result = await pullNext(baseParams);
+
+    // goal came from brand-service for THIS brand, not from a caller input
+    expect(getCurrentGoal).toHaveBeenCalledWith("brand-1", "org-1", expect.any(Object));
+    expect((getTopAudienceId.mock.calls[0][0] as Record<string, unknown>).goal).toBe("meetingBooked");
+    expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ goal: "meetingBooked" }));
+    expect(result.lead?.goal).toBe("meetingBooked");
+  });
+
+  it("fails loud when the brand has no goal set (brand-service throws)", async () => {
+    getCurrentGoal.mockRejectedValueOnce(
+      new Error("[brand-client] runtime-context failed for brand brand-1: 404 Brand not found"),
+    );
+
+    await expect(pullNext(baseParams)).rejects.toThrow(/runtime-context failed/);
+    expect(getTopAudienceId).not.toHaveBeenCalled();
   });
 
   it("resolves the audience, serves the next person, records it, and returns FullLead", async () => {


### PR DESCRIPTION
## What
The lead-finding goal (`signup|meetingBooked|purchase`) is a **brand attribute** (brand-service `brands.currentGoal`), not a caller input. lead-service now **fetches** it per `/orgs/buffer/next` iteration from brand-service instead of requiring the `x-goal` header.

## Changes
- `brand-client.getCurrentGoal(brandId)` → `GET /internal/brands/{brandId}/runtime-context` → `currentGoal`. Fail loud on non-2xx.
- `pullNext`: fetches `currentGoal`, uses it for features `persona-stats` **and** the served lead's attribution (`leads_campaigns.goal` + response `lead.goal`). One goal, brand-owned, consistent everywhere.
- `routes/buffer.ts`: drop the `x-goal` required 400 check (`x-feature-slug` still required).
- Tests: `brand-client.getCurrentGoal` (happy + 404 throws); `buffer` goal-from-brand-service + no-goal-fails-loud. 178 unit pass.

## Behavior
- Brand with **no goal set** → brand-service 404 → lead-service **fails loud** (500). A brand in a lead-finding workflow must have a goal; this is a config error, not "exhausted".
- `x-goal` header is now ignored for audience resolution (still passed through to run-tracking metadata, harmless).

## Deps / env
- brand-service `GET /internal/brands/:brandId/runtime-context` (PR #252) already on main/staging — no cross-repo work, no deploy gate.
- No new env vars (`BRAND_SERVICE_URL`/`KEY` already in use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)