### PR TITLE
hotfix: Fix /orgs/leads full-path crash on string served_at (toISOString)

### DIFF
--- a/src/lib/basic-leads.ts
+++ b/src/lib/basic-leads.ts
@@ -97,7 +97,7 @@ interface RawBasicRow {
   email_status: string | null;
 }
 
-function toIsoTimestamp(value: RawTimestamp): string | null {
+export function toIsoTimestamp(value: RawTimestamp): string | null {
   if (value == null) return null;
   if (value instanceof Date) return value.toISOString();
 

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -10,7 +10,7 @@ import {
 } from "../lib/email-gateway-client.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { buildFullLeadsBatch, type FullLead } from "../lib/lead-shape.js";
-import { streamBasicLeadChunks, type BasicLeadRow } from "../lib/basic-leads.js";
+import { streamBasicLeadChunks, toIsoTimestamp, type BasicLeadRow } from "../lib/basic-leads.js";
 import { leadCampaignBaseRelation, type LeadListScope } from "../lib/lead-list-query.js";
 
 const router = Router();
@@ -125,7 +125,8 @@ interface RawLeadCampaignRow {
   status_details: string | null;
   parent_run_id: string | null;
   run_id: string | null;
-  served_at: Date | null;
+  // postgres.js returns timestamptz as Date OR string depending on the path; normalize via toIsoTimestamp.
+  served_at: Date | string | null;
   workflow_slug: string | null;
   feature_slug: string | null;
   goal: string | null;
@@ -148,7 +149,7 @@ interface LeadCampaignRow {
   statusDetails: string | null;
   parentRunId: string | null;
   runId: string | null;
-  servedAt: Date | null;
+  servedAt: string | null;
   workflowSlug: string | null;
   featureSlug: string | null;
   goal: string | null;
@@ -200,7 +201,7 @@ async function fetchLeadCampaignChunk(
     statusDetails: r.status_details,
     parentRunId: r.parent_run_id,
     runId: r.run_id,
-    servedAt: r.served_at,
+    servedAt: toIsoTimestamp(r.served_at),
     workflowSlug: r.workflow_slug,
     featureSlug: r.feature_slug,
     goal: r.goal,
@@ -411,7 +412,7 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
           activeGoalId: row.activeGoalId ?? null,
           brandProfileId: row.brandProfileId ?? null,
           audienceId: row.audienceId ?? null,
-          servedAt: row.servedAt ? row.servedAt.toISOString() : null,
+          servedAt: row.servedAt,
           status: row.status as "buffered" | "skipped" | "claimed" | "served",
           emailStatus,
           lead: fullLead,

--- a/tests/unit/leads-stream.test.ts
+++ b/tests/unit/leads-stream.test.ts
@@ -24,7 +24,8 @@ vi.mock("../../src/db/index.js", () => ({
 }));
 
 const streamBasicLeadChunksMock = vi.fn();
-vi.mock("../../src/lib/basic-leads.js", () => ({
+vi.mock("../../src/lib/basic-leads.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/lib/basic-leads.js")>()),
   streamBasicLeadChunks: (...args: unknown[]) => streamBasicLeadChunksMock(...args),
 }));
 
@@ -221,6 +222,20 @@ describe("GET /orgs/leads chunked streaming", () => {
     expect(res.body.leads[0].email).toBe("lead-1@example.com");
     expect(res.body.leads[0].apolloPersonId).toBe("apollo-1");
     expect(res.body.leads[0].audienceId).toBeNull();
+  });
+
+  it("normalizes a postgres string served_at on the full path (no toISOString crash)", async () => {
+    // postgres.js can return timestamptz as a raw string; the full path used to call
+    // .toISOString() on it and crash mid-stream (TypeError: ...toISOString is not a function).
+    mockRows = [{ ...rawRow(1, "served"), served_at: "2026-01-01 00:00:01.5+00" }];
+    const res = await request(app)
+      .get(`/orgs/leads?brandId=${BRAND}`)
+      .set("x-api-key", "test-api-key")
+      .set("x-org-id", ORG);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leads).toHaveLength(1);
+    expect(res.body.leads[0].servedAt).toBe("2026-01-01T00:00:01.500Z");
   });
 
   it("hydrates per chunk (ceil(N/chunk) batches, each <= chunk size)", async () => {


### PR DESCRIPTION
Automated by release.sh