### PR TITLE
feat(leads): widen GET /orgs/leads?view=basic with firmographic fields (#327)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2178,7 +2178,7 @@
             "in": "query",
             "name": "view",
             "required": false,
-            "description": "Per-lead payload size. `basic` returns a slim `lead` object (firstName, lastName, name, headline, linkedinUrl, photoUrl, apolloPersonId + organization {id, name, logoUrl, primaryDomain, websiteUrl}); drops employmentHistory, funding events, and the extra organization columns. Absent or any other value => the full FullLead payload (default, backward-compatible). Use `basic` for list views to cut the response ~10x.",
+            "description": "Per-lead payload size. `basic` returns a slim `lead` object: firstName, lastName, name, headline, linkedinUrl, photoUrl, apolloPersonId, seniority, departments, functions, city, state, country + organization {id, name, logoUrl, primaryDomain, websiteUrl, industry, industries, estimatedNumEmployees, annualRevenue, foundedYear, shortDescription, city, state, country}. Field names/types are identical to the full FullLead/OrganizationView. Still drops the heavy stuff (employmentHistory, subdepartments, technologyNames, secondaryIndustries, funding events) so basic stays ~10x smaller than full. Absent or any other value => the full FullLead payload (default, backward-compatible). Use `basic` for list views.",
             "schema": {
               "type": "string",
               "enum": [

--- a/src/lib/basic-leads.ts
+++ b/src/lib/basic-leads.ts
@@ -14,12 +14,33 @@ export interface BasicSlimLead {
   headline: string | null;
   linkedinUrl: string | null;
   photoUrl: string | null;
+  // Additive firmographic fields (#327) — same names/types as FullLead.
+  // Still excludes the heavy stuff (subdepartments, twitter/github/etc, full
+  // employmentHistory) to keep basic ~10x smaller than full.
+  seniority: string | null;
+  departments: string[] | null;
+  functions: string[] | null;
+  city: string | null;
+  state: string | null;
+  country: string | null;
   organization: {
     id: string;
     name: string | null;
     logoUrl: string | null;
     primaryDomain: string | null;
     websiteUrl: string | null;
+    // Additive firmographic fields (#327) — same names/types as OrganizationView.
+    // Excludes the heavy arrays (technologyNames, secondaryIndustries) and
+    // funding events to keep basic lean.
+    industry: string | null;
+    industries: string[] | null;
+    estimatedNumEmployees: number | null;
+    annualRevenue: string | null;
+    foundedYear: number | null;
+    shortDescription: string | null;
+    city: string | null;
+    state: string | null;
+    country: string | null;
   } | null;
 }
 
@@ -88,11 +109,26 @@ interface RawBasicRow {
   headline: string | null;
   linkedin_url: string | null;
   photo_url: string | null;
+  seniority: string | null;
+  departments: string[] | null;
+  functions: string[] | null;
+  l_city: string | null;
+  l_state: string | null;
+  l_country: string | null;
   org_id_inner: string | null;
   org_name: string | null;
   logo_url: string | null;
   primary_domain: string | null;
   website_url: string | null;
+  industry: string | null;
+  industries: string[] | null;
+  estimated_num_employees: number | null;
+  annual_revenue: string | null;
+  founded_year: number | null;
+  short_description: string | null;
+  org_city: string | null;
+  org_state: string | null;
+  org_country: string | null;
   email_value: string | null;
   email_status: string | null;
 }
@@ -134,6 +170,12 @@ function mapRow(r: RawBasicRow): BasicLeadRow {
         headline: r.headline,
         linkedinUrl: r.linkedin_url,
         photoUrl: r.photo_url,
+        seniority: r.seniority,
+        departments: r.departments,
+        functions: r.functions,
+        city: r.l_city,
+        state: r.l_state,
+        country: r.l_country,
         organization: r.org_id_inner
           ? {
               id: r.org_id_inner,
@@ -141,6 +183,15 @@ function mapRow(r: RawBasicRow): BasicLeadRow {
               logoUrl: r.logo_url,
               primaryDomain: r.primary_domain,
               websiteUrl: r.website_url,
+              industry: r.industry,
+              industries: r.industries,
+              estimatedNumEmployees: r.estimated_num_employees,
+              annualRevenue: r.annual_revenue,
+              foundedYear: r.founded_year,
+              shortDescription: r.short_description,
+              city: r.org_city,
+              state: r.org_state,
+              country: r.org_country,
             }
           : null,
       }
@@ -186,12 +237,20 @@ function basicLeadQuery(
       lc.created_at,
       l.id AS l_id, l.apollo_person_id, l.first_name, l.last_name, l.name,
       l.headline, l.linkedin_url, l.photo_url,
+      l.seniority, l.departments, l.functions,
+      l.city AS l_city, l.state AS l_state, l.country AS l_country,
       org.org_id AS org_id_inner, org.org_name, org.logo_url, org.primary_domain, org.website_url,
+      org.industry, org.industries, org.estimated_num_employees, org.annual_revenue,
+      org.founded_year, org.short_description,
+      org.org_city, org.org_state, org.org_country,
       em.value AS email_value, em.status AS email_status
     FROM ${leadCampaignBaseRelation(f)}
     LEFT JOIN leads l ON l.id = lc.lead_id
     LEFT JOIN LATERAL (
-      SELECT o.id AS org_id, o.name AS org_name, o.logo_url, o.primary_domain, o.website_url
+      SELECT o.id AS org_id, o.name AS org_name, o.logo_url, o.primary_domain, o.website_url,
+             o.industry, o.industries, o.estimated_num_employees, o.annual_revenue,
+             o.founded_year, o.short_description,
+             o.city AS org_city, o.state AS org_state, o.country AS org_country
       FROM leads_organizations lo
       LEFT JOIN organizations o ON o.id = lo.organization_id
       WHERE lo.lead_id = lc.lead_id AND lo.current = true

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1542,11 +1542,16 @@ registry.registerPath({
       name: "view",
       required: false,
       description:
-        "Per-lead payload size. `basic` returns a slim `lead` object (firstName, lastName, name, " +
-        "headline, linkedinUrl, photoUrl, apolloPersonId + organization {id, name, logoUrl, " +
-        "primaryDomain, websiteUrl}); drops employmentHistory, funding events, and the extra " +
-        "organization columns. Absent or any other value => the full FullLead payload (default, " +
-        "backward-compatible). Use `basic` for list views to cut the response ~10x.",
+        "Per-lead payload size. `basic` returns a slim `lead` object: " +
+        "firstName, lastName, name, headline, linkedinUrl, photoUrl, apolloPersonId, " +
+        "seniority, departments, functions, city, state, country " +
+        "+ organization {id, name, logoUrl, primaryDomain, websiteUrl, industry, industries, " +
+        "estimatedNumEmployees, annualRevenue, foundedYear, shortDescription, city, state, country}. " +
+        "Field names/types are identical to the full FullLead/OrganizationView. " +
+        "Still drops the heavy stuff (employmentHistory, subdepartments, technologyNames, " +
+        "secondaryIndustries, funding events) so basic stays ~10x smaller than full. " +
+        "Absent or any other value => the full FullLead payload (default, " +
+        "backward-compatible). Use `basic` for list views.",
       schema: { type: "string" as const, enum: ["basic", "full"] },
     },
   ],

--- a/tests/unit/basic-leads.test.ts
+++ b/tests/unit/basic-leads.test.ts
@@ -42,11 +42,26 @@ function rawRow(servedAt: unknown) {
     headline: "CEO",
     linkedin_url: null,
     photo_url: null,
+    seniority: "founder",
+    departments: ["c_suite"],
+    functions: ["entrepreneurship"],
+    l_city: "Portland",
+    l_state: "ME",
+    l_country: "USA",
     org_id_inner: "org-inner-1",
     org_name: "Acme",
     logo_url: null,
     primary_domain: "acme.com",
     website_url: "https://acme.com",
+    industry: "marketing",
+    industries: ["marketing", "advertising"],
+    estimated_num_employees: 12,
+    annual_revenue: "1000000",
+    founded_year: 2018,
+    short_description: "Boutique agency.",
+    org_city: "Portland",
+    org_state: "ME",
+    org_country: "USA",
     email_value: "jane@example.com",
     email_status: "valid",
   };
@@ -75,5 +90,40 @@ describe("fetchBasicLeadRows", () => {
     const rows = await fetchBasicLeadChunk({ orgId: "org-1" }, null, 500);
 
     expect(rows[0].servedAt).toBe("2026-06-17T01:44:59.000Z");
+  });
+
+  it("projects the additive firmographic fields (#327) on the slim lead + org", async () => {
+    rawRows = [rawRow(new Date("2026-06-17T01:44:59.000Z"))];
+    const { fetchBasicLeadChunk } = await import("../../src/lib/basic-leads.js");
+
+    const rows = await fetchBasicLeadChunk({ orgId: "org-1", brandId: "brand-1" }, null, 500);
+    const lead = rows[0].lead!;
+
+    // Person-level firmographics, same names/types as FullLead.
+    expect(lead.seniority).toBe("founder");
+    expect(lead.departments).toEqual(["c_suite"]);
+    expect(lead.functions).toEqual(["entrepreneurship"]);
+    expect(lead.city).toBe("Portland");
+    expect(lead.state).toBe("ME");
+    expect(lead.country).toBe("USA");
+
+    // Org-level firmographics, same names/types as OrganizationView.
+    const org = lead.organization!;
+    expect(org.industry).toBe("marketing");
+    expect(org.industries).toEqual(["marketing", "advertising"]);
+    expect(org.estimatedNumEmployees).toBe(12);
+    expect(org.annualRevenue).toBe("1000000");
+    expect(org.foundedYear).toBe(2018);
+    expect(org.shortDescription).toBe("Boutique agency.");
+    expect(org.city).toBe("Portland");
+    expect(org.state).toBe("ME");
+    expect(org.country).toBe("USA");
+
+    // Basic stays lean — the heavy fields are NOT projected into basic.
+    expect(lead).not.toHaveProperty("subdepartments");
+    expect(lead).not.toHaveProperty("employmentHistory");
+    expect(org).not.toHaveProperty("technologyNames");
+    expect(org).not.toHaveProperty("secondaryIndustries");
+    expect(org).not.toHaveProperty("fundingEvents");
   });
 });


### PR DESCRIPTION
## What

Additively widen the slim `GET /orgs/leads?view=basic` per-lead projection so the distribute.you Leads page can show firmographics (industry, revenue, company size, seniority, etc.) in table columns + the detail panel. Those fields already exist in the FULL payload but were excluded from `basic`, arriving `undefined` on this page.

## Fields added to `basic` (same names/types as FullLead / OrganizationView — purely additive)

- **person** (lead top-level): `seniority`, `departments`, `functions`, `city`, `state`, `country`
- **organization**: `industry`, `industries`, `estimatedNumEmployees`, `annualRevenue`, `foundedYear`, `shortDescription`, `city`, `state`, `country`

## Kept lean (still excluded from basic)

`employmentHistory`, `subdepartments`, `technologyNames`, `secondaryIndustries`, funding events — basic stays ~10x smaller than full.

## Contract

- Field names/types byte-identical to existing full-payload names.
- Org fields nested under `lead.organization`; person fields at `lead` top level.
- **Full payload (`view=full` / default) unchanged.**
- All fields sourced in the existing single flat SQL pass (leads + current-employer org via LATERAL) — no new round-trips.
- OpenAPI `view` param description regenerated.

## Tests

- `tests/unit/basic-leads.test.ts`: new test asserts the firmographic fields are populated AND the heavy fields (`subdepartments`, `employmentHistory`, `technologyNames`, `secondaryIndustries`, `fundingEvents`) are absent.
- `npm run build` green, 185/185 unit tests pass.

Triage: staging (additive), promotable to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)