### PR TITLE
release: persist organization annual revenue (#336)

### DIFF
--- a/src/lib/leads-registry.ts
+++ b/src/lib/leads-registry.ts
@@ -49,6 +49,7 @@ function pickOrgFields(org: NonNullable<Person["organization"]>): Partial<NewOrg
   if (org.state) out.state = org.state;
   if (org.country) out.country = org.country;
   if (org.estimatedNumEmployees != null) out.estimatedNumEmployees = org.estimatedNumEmployees;
+  if (org.annualRevenue != null) out.annualRevenue = String(org.annualRevenue);
   return out;
 }
 

--- a/src/lib/people-client.ts
+++ b/src/lib/people-client.ts
@@ -63,6 +63,7 @@ export interface PersonOrganization {
   websiteUrl: string | null;
   industry: string | null;
   estimatedNumEmployees: number | null;
+  annualRevenue: number | null;
   linkedinUrl: string | null;
   logoUrl: string | null;
   city: string | null;

--- a/tests/unit/leads-registry-org-fields.test.ts
+++ b/tests/unit/leads-registry-org-fields.test.ts
@@ -25,6 +25,7 @@ const PERSON_WITH_ORG = {
     websiteUrl: "https://cascobay.com",
     industry: "marketing",
     estimatedNumEmployees: 12,
+    annualRevenue: 1000000,
     linkedinUrl: "https://linkedin.com/company/cascobay",
     logoUrl: "https://logo.com/x.png",
     city: "Portland",
@@ -54,6 +55,8 @@ describe("pickOrgFields (via upsertOrganizationFromPerson) maps the neutral orga
     expect(payload.websiteUrl).toBe("https://cascobay.com");
     expect(payload.industry).toBe("marketing");
     expect(payload.estimatedNumEmployees).toBe(12);
+    // numeric column write-type is string; the basic-view projection passes it back verbatim.
+    expect(payload.annualRevenue).toBe("1000000");
     expect(payload.linkedinUrl).toBe("https://linkedin.com/company/cascobay");
     expect(payload.logoUrl).toBe("https://logo.com/x.png");
     expect(payload.city).toBe("Portland");
@@ -77,6 +80,7 @@ describe("pickOrgFields (via upsertOrganizationFromPerson) maps the neutral orga
     expect(payload.websiteUrl).toBeUndefined();
     expect(payload.industry).toBeUndefined();
     expect(payload.estimatedNumEmployees).toBeUndefined();
+    expect(payload.annualRevenue).toBeUndefined();
   });
 
   it("returns null when the person has no organization", async () => {


### PR DESCRIPTION
Promote staging → main (prod).

Single change: fix(leads): persist organization annual revenue on ingest (#336). Org Revenue showed '-' in dashboard; ingest now persists the value human-service sends into the existing `annual_revenue` column.

185/185 tests, build green on staging.