### PR TITLE
fix(leads): conform audience resolver to human-service deployed contract (#166)

### DIFF
--- a/src/lib/audience-client.ts
+++ b/src/lib/audience-client.ts
@@ -2,7 +2,7 @@ import { HUMAN_SERVICE_URL, HUMAN_SERVICE_API_KEY } from "../config.js";
 import { fetchWithRetry } from "./fetch-retry.js";
 
 /**
- * Client for human-service's server-to-server audience resolver.
+ * Client for human-service's internal bulk audience resolver (#166 / #346).
  *
  * The dashboard Leads page must show each lead's ACTIVE audience for a brand.
  * Resolving that in the browser meant POSTing every brand lead email in one
@@ -13,10 +13,9 @@ import { fetchWithRetry } from "./fetch-retry.js";
  * lead-service owns only ~5% of `leads_campaigns.audience_id` tags; historical
  * leads resolve by EMAIL → active-audience membership. Both keys are sent to
  * human-service, which owns the brand-correct pick (audience.brandId +
- * status='active' + membership) and the deterministic tie-break. This client is
- * purely a bulk transport: it batches the identity set, calls the resolver, and
- * returns a leadId → { id, name, avatarUrl } map. leadIds with no active
- * audience for the brand are simply absent from the map (⟹ null on the lead).
+ * status + membership) and the deprecated→canonical audience mapping. This
+ * client is a bulk transport: it sends the brand's distinct audienceIds + emails
+ * and returns the two lookup maps human-service produces.
  *
  * Fail-loud: a non-2xx resolver response or a network failure throws. The
  * `GET /orgs/leads` handler resolves the audience BEFORE writing each chunk, so
@@ -24,28 +23,24 @@ import { fetchWithRetry } from "./fetch-retry.js";
  * (mid-stream) — never a silently-blank "-" that masks the outage (AC4).
  */
 
-// Locked wire contract (lead-service ↔ human-service, server-to-server, direct
-// to HUMAN_SERVICE_URL — NOT via the api-service gateway, so no 100KB body cap):
+// Deployed wire contract (lead-service ↔ human-service, server-to-server, direct
+// to HUMAN_SERVICE_URL — NOT via the api-service gateway; the resolver mounts its
+// own 25MB parser BEFORE human-service's global 100KB json parser, so no body cap):
 //
-//   POST {HUMAN_SERVICE_URL}/orgs/audiences/resolve
-//   Headers: X-API-Key: <internal>, x-org-id: <orgId>
-//   Body:    { "brandId": "<uuid>",
-//              "leads": [ { "leadId": "<opaque string>",
-//                           "email": "<string|null>",
-//                           "audienceId": "<uuid|null>" } ] }   // lead-service batches ≤ RESOLVE_BATCH_SIZE
-//   200:     { "audiences": { "<leadId>": { "id","name","avatarUrl": string|null } } }
-//            (a leadId is present only when it maps to an ACTIVE audience for brandId;
-//             absent ⟹ the lead has no active audience for the brand ⟹ null.)
+//   POST {HUMAN_SERVICE_URL}/internal/audiences/resolve
+//   Headers: X-API-Key: <internal>   (requireApiKey; orgId travels in the body)
+//   Body:    { "orgId": "<uuid>", "brandId": "<uuid>",
+//              "audienceIds"?: string[],   // tagged audience_ids on the leads (~5%)
+//              "emails"?: string[] }        // lead emails — HISTORICAL key (raw; normalized server-side)
+//            (at least one of audienceIds / emails must be non-empty)
+//   200:     { "byAudienceId": { "<audienceId>": Card|null },
+//              "byEmail":       { "<rawEmail>":  Card|null } }
+//   Card = { id, name, avatarUrl: string|null }. Only this brand's active audiences
+//   are ever returned (brand-correct); a non-matching / retired key resolves to null.
 export interface AudienceCard {
   id: string;
   name: string;
   avatarUrl: string | null;
-}
-
-export interface AudienceResolveLead {
-  leadId: string;
-  email: string | null;
-  audienceId: string | null;
 }
 
 export interface AudienceResolveContext {
@@ -54,8 +49,9 @@ export interface AudienceResolveContext {
   runId?: string | null;
 }
 
-interface ResolveResponse {
-  audiences: Record<string, AudienceCard>;
+export interface AudienceResolveResult {
+  byAudienceId: Record<string, AudienceCard | null>;
+  byEmail: Record<string, AudienceCard | null>;
 }
 
 export class AudienceServiceError extends Error {
@@ -70,32 +66,41 @@ export class AudienceServiceError extends Error {
   }
 }
 
-// One brand's identity set per call. A single leads chunk (LEADS_STREAM_CHUNK_SIZE,
-// default 500) stays well under this, but keep the batch bounded so a large chunk
-// or a future bigger chunk size never sends an unbounded body / query to a
-// Neon-backed sibling.
-const RESOLVE_BATCH_SIZE = Math.max(1, Number(process.env.AUDIENCE_RESOLVE_BATCH_SIZE) || 1000);
-
 function buildHeaders(ctx: AudienceResolveContext): Record<string, string> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     "X-API-Key": HUMAN_SERVICE_API_KEY,
-    "x-org-id": ctx.orgId,
   };
   if (ctx.userId) headers["x-user-id"] = ctx.userId;
   if (ctx.runId) headers["x-run-id"] = ctx.runId;
   return headers;
 }
 
-async function resolveBatch(
+const EMPTY: AudienceResolveResult = { byAudienceId: {}, byEmail: {} };
+
+/**
+ * Resolve, for a single brand, the active-audience card behind each distinct
+ * tagged audienceId and/or lead email. Returns human-service's two lookup maps
+ * ({ byAudienceId, byEmail }); the caller correlates them back onto each lead.
+ * A call with no keys short-circuits (the resolver 400s on an empty request).
+ * Throws on any resolver / network failure (fail-loud).
+ */
+export async function resolveAudiencesForBrand(
   brandId: string,
-  leads: AudienceResolveLead[],
+  keys: { audienceIds: string[]; emails: string[] },
   ctx: AudienceResolveContext,
-): Promise<Record<string, AudienceCard>> {
-  const response = await fetchWithRetry(`${HUMAN_SERVICE_URL}/orgs/audiences/resolve`, {
+): Promise<AudienceResolveResult> {
+  if (keys.audienceIds.length === 0 && keys.emails.length === 0) return EMPTY;
+
+  const response = await fetchWithRetry(`${HUMAN_SERVICE_URL}/internal/audiences/resolve`, {
     method: "POST",
     headers: buildHeaders(ctx),
-    body: JSON.stringify({ brandId, leads }),
+    body: JSON.stringify({
+      orgId: ctx.orgId,
+      brandId,
+      audienceIds: keys.audienceIds,
+      emails: keys.emails,
+    }),
     signal: AbortSignal.timeout(120_000),
   });
 
@@ -103,30 +108,9 @@ async function resolveBatch(
     throw new AudienceServiceError(response.status, await response.text());
   }
 
-  const parsed = (await response.json()) as ResolveResponse;
-  return parsed.audiences ?? {};
-}
-
-/**
- * Resolve the active audience card for each lead of a single brand, batching
- * internally. Returns a leadId → AudienceCard map; leads without an active
- * audience are absent. Throws on any resolver / network failure (fail-loud).
- */
-export async function resolveAudiences(
-  brandId: string,
-  leads: AudienceResolveLead[],
-  ctx: AudienceResolveContext,
-): Promise<Map<string, AudienceCard>> {
-  const map = new Map<string, AudienceCard>();
-  if (leads.length === 0) return map;
-
-  for (let i = 0; i < leads.length; i += RESOLVE_BATCH_SIZE) {
-    const batch = leads.slice(i, i + RESOLVE_BATCH_SIZE);
-    const audiences = await resolveBatch(brandId, batch, ctx);
-    for (const [leadId, card] of Object.entries(audiences)) {
-      map.set(leadId, card);
-    }
-  }
-
-  return map;
+  const parsed = (await response.json()) as Partial<AudienceResolveResult>;
+  return {
+    byAudienceId: parsed.byAudienceId ?? {},
+    byEmail: parsed.byEmail ?? {},
+  };
 }

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -12,7 +12,7 @@ import { traceEvent } from "../lib/trace-event.js";
 import { buildFullLeadsBatch, type FullLead } from "../lib/lead-shape.js";
 import { streamBasicLeadChunks, toIsoTimestamp, type BasicLeadRow } from "../lib/basic-leads.js";
 import { leadCampaignBaseRelation, type LeadListScope } from "../lib/lead-list-query.js";
-import { resolveAudiences, type AudienceCard, type AudienceResolveContext } from "../lib/audience-client.js";
+import { resolveAudiencesForBrand, type AudienceCard, type AudienceResolveContext } from "../lib/audience-client.js";
 
 const router = Router();
 
@@ -243,24 +243,54 @@ async function fetchLeadCampaignChunk(
 // lead carries — its tagged audienceId (~5% of rows) AND its email (historical
 // coverage) — are forwarded; human-service owns the brand-correct pick. Fail-loud:
 // a resolver failure rejects and aborts the request (never a silently-blank field).
+interface AudienceRowDescriptor {
+  leadId: string;
+  email: string | null;
+  audienceId: string | null;
+  brandIds: string[];
+}
+
 async function buildAudienceMapForRows(
-  descriptors: Array<{ leadId: string; email: string | null; audienceId: string | null; brandIds: string[] }>,
+  descriptors: AudienceRowDescriptor[],
   scopeBrandId: string | undefined,
   ctx: AudienceResolveContext,
 ): Promise<Map<string, AudienceCard>> {
-  const groups = new Map<string, { leadId: string; email: string | null; audienceId: string | null }[]>();
+  // Group rows by the brand the audience must be correct for: the explicitly-
+  // scoped brandId when present, else the row's primary brand. human-service
+  // resolves by DISTINCT audienceId + email arrays, so per group we send the
+  // deduped key sets and correlate the two returned maps back onto each lead.
+  const groups = new Map<string, AudienceRowDescriptor[]>();
   for (const d of descriptors) {
     const brandId = scopeBrandId ?? d.brandIds[0];
     if (!brandId) continue;
     if (!groups.has(brandId)) groups.set(brandId, []);
-    groups.get(brandId)!.push({ leadId: d.leadId, email: d.email, audienceId: d.audienceId });
+    groups.get(brandId)!.push(d);
   }
 
   const merged = new Map<string, AudienceCard>();
   await Promise.all(
-    Array.from(groups.entries()).map(async ([brandId, leads]) => {
-      const map = await resolveAudiences(brandId, leads, ctx);
-      for (const [leadId, card] of map) merged.set(leadId, card);
+    Array.from(groups.entries()).map(async ([brandId, rows]) => {
+      const audienceIds = Array.from(
+        new Set(rows.map((r) => r.audienceId).filter((x): x is string => !!x)),
+      );
+      const emails = Array.from(
+        new Set(rows.map((r) => r.email).filter((x): x is string => !!x)),
+      );
+
+      const { byAudienceId, byEmail } = await resolveAudiencesForBrand(
+        brandId,
+        { audienceIds, emails },
+        ctx,
+      );
+
+      for (const r of rows) {
+        // Prefer the tagged audience's card; fall back to the email membership
+        // when the tag is absent / not this brand / retired (null).
+        const byTag = r.audienceId ? byAudienceId[r.audienceId] : null;
+        const byMail = r.email ? byEmail[r.email] : null;
+        const card = byTag ?? byMail ?? null;
+        if (card) merged.set(r.leadId, card);
+      }
     }),
   );
   return merged;

--- a/tests/unit/audience-client.test.ts
+++ b/tests/unit/audience-client.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Read at module load by the client — set BEFORE importing it.
-process.env.AUDIENCE_RESOLVE_BATCH_SIZE = "2";
-
 vi.mock("../../src/config.js", () => ({
   HUMAN_SERVICE_URL: "http://human.test",
   HUMAN_SERVICE_API_KEY: "human-key",
@@ -10,14 +7,11 @@ vi.mock("../../src/config.js", () => ({
 
 type CapturedRequest = { url: string; init: RequestInit };
 
-function mockFetch(responseBodies: unknown[]): { calls: CapturedRequest[] } {
+function mockFetch(responseBody: unknown): { calls: CapturedRequest[] } {
   const calls: CapturedRequest[] = [];
-  let i = 0;
   const fetchSpy = vi.fn(async (url: string, init: RequestInit) => {
     calls.push({ url, init });
-    const body = responseBodies[Math.min(i, responseBodies.length - 1)];
-    i += 1;
-    return new Response(JSON.stringify(body), {
+    return new Response(JSON.stringify(responseBody), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
@@ -28,16 +22,16 @@ function mockFetch(responseBodies: unknown[]): { calls: CapturedRequest[] } {
 
 const ctx = { orgId: "org-1", userId: "user-1", runId: "run-1" };
 
-let resolveAudiences: typeof import("../../src/lib/audience-client.js").resolveAudiences;
+let resolveAudiencesForBrand: typeof import("../../src/lib/audience-client.js").resolveAudiencesForBrand;
 let AudienceServiceError: typeof import("../../src/lib/audience-client.js").AudienceServiceError;
 
 beforeAll(async () => {
   const mod = await import("../../src/lib/audience-client.js");
-  resolveAudiences = mod.resolveAudiences;
+  resolveAudiencesForBrand = mod.resolveAudiencesForBrand;
   AudienceServiceError = mod.AudienceServiceError;
 });
 
-describe("audience-client resolveAudiences", () => {
+describe("audience-client resolveAudiencesForBrand", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
@@ -46,63 +40,47 @@ describe("audience-client resolveAudiences", () => {
     vi.unstubAllGlobals();
   });
 
-  it("returns an empty map and makes no call when there are no leads", async () => {
-    const { calls } = mockFetch([{ audiences: {} }]);
-    const map = await resolveAudiences("brand-1", [], ctx);
-    expect(map.size).toBe(0);
+  it("short-circuits (no call) when there are no keys", async () => {
+    const { calls } = mockFetch({ byAudienceId: {}, byEmail: {} });
+    const res = await resolveAudiencesForBrand("brand-1", { audienceIds: [], emails: [] }, ctx);
+    expect(res).toEqual({ byAudienceId: {}, byEmail: {} });
     expect(calls).toHaveLength(0);
   });
 
-  it("posts brandId + leads to the resolver with internal auth headers", async () => {
-    const { calls } = mockFetch([
-      { audiences: { "lead-1": { id: "aud-1", name: "A", avatarUrl: null } } },
-    ]);
+  it("posts orgId + brandId + key arrays to /internal/audiences/resolve with internal auth", async () => {
+    const { calls } = mockFetch({
+      byAudienceId: { "aud-t": { id: "aud-t", name: "Tagged", avatarUrl: null } },
+      byEmail: { "a@b.com": { id: "aud-e", name: "ByEmail", avatarUrl: "u" } },
+    });
 
-    const map = await resolveAudiences(
+    const res = await resolveAudiencesForBrand(
       "brand-1",
-      [{ leadId: "lead-1", email: "a@b.com", audienceId: null }],
+      { audienceIds: ["aud-t"], emails: ["a@b.com"] },
       ctx,
     );
 
     expect(calls).toHaveLength(1);
-    expect(calls[0].url).toBe("http://human.test/orgs/audiences/resolve");
+    expect(calls[0].url).toBe("http://human.test/internal/audiences/resolve");
     expect(calls[0].init.method).toBe("POST");
     const headers = calls[0].init.headers as Record<string, string>;
     expect(headers["X-API-Key"]).toBe("human-key");
-    expect(headers["x-org-id"]).toBe("org-1");
     expect(headers["x-user-id"]).toBe("user-1");
     expect(headers["x-run-id"]).toBe("run-1");
     expect(JSON.parse(calls[0].init.body as string)).toEqual({
+      orgId: "org-1",
       brandId: "brand-1",
-      leads: [{ leadId: "lead-1", email: "a@b.com", audienceId: null }],
+      audienceIds: ["aud-t"],
+      emails: ["a@b.com"],
     });
-    expect(map.get("lead-1")).toEqual({ id: "aud-1", name: "A", avatarUrl: null });
+    expect(res.byAudienceId["aud-t"]).toEqual({ id: "aud-t", name: "Tagged", avatarUrl: null });
+    expect(res.byEmail["a@b.com"]).toEqual({ id: "aud-e", name: "ByEmail", avatarUrl: "u" });
   });
 
-  it("batches leads at AUDIENCE_RESOLVE_BATCH_SIZE and merges the maps", async () => {
-    const { calls } = mockFetch([
-      { audiences: { "lead-1": { id: "aud-1", name: "A", avatarUrl: null } } },
-      { audiences: { "lead-3": { id: "aud-3", name: "C", avatarUrl: "u" } } },
-    ]);
-
-    const map = await resolveAudiences(
-      "brand-1",
-      [
-        { leadId: "lead-1", email: "a@b.com", audienceId: null },
-        { leadId: "lead-2", email: "b@b.com", audienceId: null },
-        { leadId: "lead-3", email: "c@b.com", audienceId: "aud-3" },
-      ],
-      ctx,
-    );
-
-    // batch size 2 => 2 calls (2 + 1)
-    expect(calls).toHaveLength(2);
-    expect(JSON.parse(calls[0].init.body as string).leads).toHaveLength(2);
-    expect(JSON.parse(calls[1].init.body as string).leads).toHaveLength(1);
-    expect(map.get("lead-1")).toEqual({ id: "aud-1", name: "A", avatarUrl: null });
-    expect(map.get("lead-3")).toEqual({ id: "aud-3", name: "C", avatarUrl: "u" });
-    // lead-2 mapped to no active audience => absent
-    expect(map.has("lead-2")).toBe(false);
+  it("defaults missing maps to empty objects", async () => {
+    mockFetch({ byEmail: { "a@b.com": null } });
+    const res = await resolveAudiencesForBrand("brand-1", { audienceIds: [], emails: ["a@b.com"] }, ctx);
+    expect(res.byAudienceId).toEqual({});
+    expect(res.byEmail["a@b.com"]).toBeNull();
   });
 
   it("throws AudienceServiceError on a non-2xx response (fail loud)", async () => {
@@ -110,7 +88,7 @@ describe("audience-client resolveAudiences", () => {
     vi.stubGlobal("fetch", fetchSpy);
 
     await expect(
-      resolveAudiences("brand-1", [{ leadId: "lead-1", email: "a@b.com", audienceId: null }], ctx),
+      resolveAudiencesForBrand("brand-1", { audienceIds: [], emails: ["a@b.com"] }, ctx),
     ).rejects.toBeInstanceOf(AudienceServiceError);
   });
 });

--- a/tests/unit/leads-stream.test.ts
+++ b/tests/unit/leads-stream.test.ts
@@ -39,10 +39,10 @@ vi.mock("../../src/lib/email-gateway-client.js", () => ({
   checkDeliveryStatus: (...args: unknown[]) => checkDeliveryStatusMock(...args),
 }));
 
-const resolveAudiencesMock = vi.fn();
+const resolveAudiencesForBrandMock = vi.fn();
 vi.mock("../../src/lib/audience-client.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../src/lib/audience-client.js")>()),
-  resolveAudiences: (...args: unknown[]) => resolveAudiencesMock(...args),
+  resolveAudiencesForBrand: (...args: unknown[]) => resolveAudiencesForBrandMock(...args),
 }));
 
 vi.mock("../../src/lib/trace-event.js", () => ({
@@ -197,8 +197,8 @@ describe("GET /orgs/leads chunked streaming", () => {
     buildFullLeadsBatchMock.mockImplementation((ids: string[]) => Promise.resolve(fullLeadMapFor(ids)));
     checkDeliveryStatusMock.mockReset();
     checkDeliveryStatusMock.mockResolvedValue({ results: [] });
-    resolveAudiencesMock.mockReset();
-    resolveAudiencesMock.mockResolvedValue(new Map());
+    resolveAudiencesForBrandMock.mockReset();
+    resolveAudiencesForBrandMock.mockResolvedValue({ byAudienceId: {}, byEmail: {} });
   });
 
   it("returns { leads: [] } for an empty result set", async () => {
@@ -234,11 +234,13 @@ describe("GET /orgs/leads chunked streaming", () => {
     expect(res.body.leads[0].audience).toBeNull();
   });
 
-  it("attaches the resolved audience card per lead (full view)", async () => {
+  it("attaches the resolved audience card per lead, correlating byEmail (full view)", async () => {
     mockRows = [rawRow(1), rawRow(2)];
-    resolveAudiencesMock.mockResolvedValue(
-      new Map([["lead-1", { id: "aud-1", name: "US SaaS founders", avatarUrl: "https://cdn/x.png" }]]),
-    );
+    // Full path email = `${leadId}@example.com` (from the primary email contact).
+    resolveAudiencesForBrandMock.mockResolvedValue({
+      byAudienceId: {},
+      byEmail: { "lead-1@example.com": { id: "aud-1", name: "US SaaS founders", avatarUrl: "https://cdn/x.png" } },
+    });
 
     const res = await request(app)
       .get(`/orgs/leads?brandId=${BRAND}`)
@@ -246,23 +248,41 @@ describe("GET /orgs/leads chunked streaming", () => {
       .set("x-org-id", ORG);
 
     expect(res.status).toBe(200);
-    // human-service is asked with the scoped brandId + each lead's identity keys.
-    expect(resolveAudiencesMock).toHaveBeenCalled();
-    expect(resolveAudiencesMock.mock.calls[0][0]).toBe(BRAND);
+    // human-service is asked with the scoped brandId + deduped key arrays.
+    expect(resolveAudiencesForBrandMock).toHaveBeenCalled();
+    expect(resolveAudiencesForBrandMock.mock.calls[0][0]).toBe(BRAND);
+    expect(resolveAudiencesForBrandMock.mock.calls[0][1].emails).toContain("lead-1@example.com");
     expect(res.body.leads[0].audience).toEqual({
       id: "aud-1",
       name: "US SaaS founders",
       avatarUrl: "https://cdn/x.png",
     });
-    // lead-2 has no active audience => null (absent from the map).
+    // lead-2 has no active audience => null.
     expect(res.body.leads[1].audience).toBeNull();
+  });
+
+  it("prefers the tagged audienceId card over the email membership", async () => {
+    mockRows = [{ ...rawRow(1), audience_id: "tag-1" }];
+    resolveAudiencesForBrandMock.mockResolvedValue({
+      byAudienceId: { "tag-1": { id: "tag-1", name: "Tagged", avatarUrl: null } },
+      byEmail: { "lead-1@example.com": { id: "mail-1", name: "ByEmail", avatarUrl: null } },
+    });
+
+    const res = await request(app)
+      .get(`/orgs/leads?brandId=${BRAND}`)
+      .set("x-api-key", "test-api-key")
+      .set("x-org-id", ORG);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leads[0].audience).toEqual({ id: "tag-1", name: "Tagged", avatarUrl: null });
   });
 
   it("attaches the resolved audience card per lead (view=basic)", async () => {
     streamBasicLeadChunksMock.mockImplementationOnce(() => basicChunks([[basicRow(1)]]));
-    resolveAudiencesMock.mockResolvedValue(
-      new Map([["lead-1", { id: "aud-9", name: "EU ecommerce", avatarUrl: null }]]),
-    );
+    resolveAudiencesForBrandMock.mockResolvedValue({
+      byAudienceId: {},
+      byEmail: { "lead-1@example.com": { id: "aud-9", name: "EU ecommerce", avatarUrl: null } },
+    });
 
     const res = await request(app)
       .get(`/orgs/leads?brandId=${BRAND}&view=basic`)
@@ -275,7 +295,7 @@ describe("GET /orgs/leads chunked streaming", () => {
 
   it("fails loud when audience resolution errors (does not blank to null)", async () => {
     mockRows = [rawRow(1)];
-    resolveAudiencesMock.mockRejectedValue(new Error("human-service 502"));
+    resolveAudiencesForBrandMock.mockRejectedValue(new Error("human-service 502"));
 
     // Resolution runs before the chunk is written; the stream is aborted, so the
     // client sees an error rather than a 200 with a silently-blank audience.


### PR DESCRIPTION
## Why
#347 merged the `audience` feature to staging against the **pre-lock** contract (`POST /orgs/audiences/resolve`, leadId-correlated). human-service #167 actually shipped the resolver as:

```
POST /internal/audiences/resolve        (requireApiKey; orgId in body)
body:  { orgId, brandId, audienceIds?: string[], emails?: string[] }   (≥1 key)
200:   { byAudienceId: { <id>: Card|null }, byEmail: { <rawEmail>: Card|null } }
```
(mounts its own 25MB parser before human-service's global 100KB json parser → no body cap.)

So `GET /orgs/leads` on staging currently calls a **404** path → fail-loud 500 (blank Audience column's replacement is now a hard error, as designed). Registry/producer is ground truth and is **live on human staging + main**, so this conforms the consumer.

## Change
- `audience-client.ts` → `resolveAudiencesForBrand` posts `/internal/audiences/resolve` with `{ orgId, brandId, audienceIds, emails }`, parses `{ byAudienceId, byEmail }`; short-circuits when no keys (resolver 400s on empty); fail-loud unchanged.
- `leads.ts` → `buildAudienceMapForRows` sends **deduped** audienceId + email arrays per brand group and correlates the two maps back onto each lead (**tagged** audience card preferred over email membership).
- Tests updated to the deployed contract + a tag-preference case.

196 unit tests pass, build green. Wire field `audience: { id, name, avatarUrl } | null` on both views is unchanged.

Follow-up to #347. Ref #346, human-service#166/#167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)