### PR TITLE
feat(conversions): auto-attribute name-only matches (no review gate)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2789,7 +2789,7 @@
     "/public/conversions": {
       "post": {
         "summary": "Ingest a conversion event from a client's website (token-auth, public)",
-        "description": "Called directly by the CLIENT's website code (token-auth, NO Clerk). Authenticates the brand publishable token, records the conversion, and attributes it to a lead we emailed for that brand via a confidence-tiered match waterfall (email/phone → deterministic; domain+lastName → strong; name-only → probabilistic/needs_review). NEVER leaks the match result — always { received: true } on success. Dedupe: per (brand, dedupeKey) when supplied, else per (brand, event, email-or-phone, day).",
+        "description": "Called directly by the CLIENT's website code (token-auth, NO Clerk). Authenticates the brand publishable token, records the conversion, and attributes it to a lead we emailed for that brand via a confidence-tiered match waterfall (email/phone → deterministic; domain+lastName → strong; name-only → probabilistic, auto-attributed to the top candidate). Only strong-ambiguous (domain+lastName with >1 candidate) is held for review. NEVER leaks the match result — always { received: true } on success. Dedupe: per (brand, dedupeKey) when supplied, else per (brand, event, email-or-phone, day).",
         "parameters": [
           {
             "in": "header",

--- a/src/lib/conversions.ts
+++ b/src/lib/conversions.ts
@@ -80,8 +80,10 @@ export function computeDedupeSignature(params: {
 
 /**
  * Resolve the attribution status from the confidence tier and candidate count.
- * CRITICAL: weak tiers never auto-credit revenue. A false attribution poisons
- * downstream conversion/revenue stats, so probabilistic tiers are ALWAYS needs_review.
+ * Product decision: a name is enough — name-only (probabilistic) matches auto-attribute
+ * to the top candidate (the candidate set is already ordered most-engaged then recency).
+ * The only tier still held for review is the strong-ambiguous case (domain+lastName with
+ * >1 candidate), where two distinct people share a last name at the same company.
  */
 export function resolveAttributionStatus(
   confidence: MatchConfidence,
@@ -96,8 +98,8 @@ export function resolveAttributionStatus(
       // domain + lastname: single candidate → attribute; ambiguous → review.
       return candidateCount === 1 ? "attributed" : "needs_review";
     case "probabilistic":
-      // name-only: never auto-attribute, regardless of candidate count.
-      return "needs_review";
+      // name-only: attribute to the top (most-engaged) candidate, regardless of count.
+      return "attributed";
     case "unmatched":
       return "unmatched";
   }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2039,7 +2039,9 @@ registry.registerPath({
     "Called directly by the CLIENT's website code (token-auth, NO Clerk). Authenticates the brand " +
     "publishable token, records the conversion, and attributes it to a lead we emailed for that brand " +
     "via a confidence-tiered match waterfall (email/phone → deterministic; domain+lastName → strong; " +
-    "name-only → probabilistic/needs_review). NEVER leaks the match result — always { received: true } " +
+    "name-only → probabilistic, auto-attributed to the top candidate). Only strong-ambiguous " +
+    "(domain+lastName with >1 candidate) is held for review. NEVER leaks the match result — " +
+    "always { received: true } " +
     "on success. Dedupe: per (brand, dedupeKey) when supplied, else per (brand, event, email-or-phone, day).",
   request: {
     body: {

--- a/tests/unit/conversions-routes.test.ts
+++ b/tests/unit/conversions-routes.test.ts
@@ -125,14 +125,14 @@ describe("POST /public/conversions", () => {
     expect(res.body).toEqual({ received: true });
   });
 
-  it("lastName-only match stores needs_review, NOT attributed", async () => {
+  it("lastName-only match stores attributed (name is enough), NOT needs_review", async () => {
     execute.mockResolvedValueOnce([{ brand_id: "brand-1", org_id: "org-1" }]); // token
     execute.mockResolvedValueOnce([]); // dedupe (signature null → actually skipped; see below)
     matchConversion.mockResolvedValueOnce({
       matchedLeadId: "lead-7",
       matchMethod: "last_name",
       matchConfidence: "probabilistic",
-      attributionStatus: "needs_review",
+      attributionStatus: "attributed",
       candidateCount: 2,
     });
     const res = await request(app)
@@ -143,8 +143,9 @@ describe("POST /public/conversions", () => {
     // no email/phone/dedupeKey → dedupe signature is null → no dedupe SELECT, straight to insert.
     expect(lastSql()).toContain("insert into conversion_events");
     const insertParams = compile(execute.mock.calls[execute.mock.calls.length - 1][0]).params;
-    expect(insertParams).toContain("needs_review");
-    expect(insertParams).not.toContain("attributed");
+    expect(insertParams).toContain("attributed");
+    expect(insertParams).toContain("lead-7");
+    expect(insertParams).not.toContain("needs_review");
   });
 
   it("duplicate dedupeKey → 200, no second attribution insert", async () => {

--- a/tests/unit/conversions.test.ts
+++ b/tests/unit/conversions.test.ts
@@ -86,9 +86,9 @@ describe("resolveAttributionStatus", () => {
     expect(resolveAttributionStatus("strong", 1)).toBe("attributed");
     expect(resolveAttributionStatus("strong", 2)).toBe("needs_review");
   });
-  it("probabilistic NEVER auto-attributes", () => {
-    expect(resolveAttributionStatus("probabilistic", 1)).toBe("needs_review");
-    expect(resolveAttributionStatus("probabilistic", 9)).toBe("needs_review");
+  it("probabilistic auto-attributes to the top candidate (name is enough)", () => {
+    expect(resolveAttributionStatus("probabilistic", 1)).toBe("attributed");
+    expect(resolveAttributionStatus("probabilistic", 9)).toBe("attributed");
   });
   it("unmatched stays unmatched", () => {
     expect(resolveAttributionStatus("unmatched", 0)).toBe("unmatched");
@@ -137,14 +137,15 @@ describe("matchConversion waterfall", () => {
     expect(params).toContain("brand-1");
   });
 
-  it("last_name only → probabilistic/needs_review (never auto-attribute)", async () => {
+  it("last_name only → probabilistic/attributed to top candidate", async () => {
     // no email/phone/domain enabled → first enabled tier is full_name (needs first+last),
     // here only lastName given so full_name is disabled; last_name tier runs.
     execute.mockResolvedValueOnce([{ lead_id: "lead-2" }, { lead_id: "lead-3" }]);
     const result = await matchConversion({ brandId: "brand-1", lastName: "Doe" });
     expect(result.matchMethod).toBe("last_name");
     expect(result.matchConfidence).toBe("probabilistic");
-    expect(result.attributionStatus).toBe("needs_review");
+    expect(result.attributionStatus).toBe("attributed");
+    expect(result.matchedLeadId).toBe("lead-2"); // top = most-engaged candidate
     expect(result.candidateCount).toBe(2);
     expect(execute).toHaveBeenCalledOnce();
   });


### PR DESCRIPTION
## What

Name-only conversion matches now **auto-attribute and count**, instead of being held as `needs_review`.

When a conversion arrives at `POST /public/conversions` with only a name (no email/phone), the match waterfall's probabilistic tier (`full_name` / `last_name`) previously returned `needs_review` and never credited Signup/Meeting stats. Product decision: a name is enough — attribute it to the top candidate (already ordered most-engaged then recency) and count it, same as email/phone matches.

## Changes

- `src/lib/conversions.ts` — `resolveAttributionStatus()` probabilistic case → `"attributed"`. Updated function + file-header tier comments.
- `src/schemas.ts` — endpoint description: name-only is now attributed; only strong-ambiguous (domain+lastName, >1 candidate) is held for review.
- `openapi.json` — regenerated.
- `tests/unit/conversions.test.ts`, `tests/unit/conversions-routes.test.ts` — updated name-only → attributed assertions.

## Unchanged

- `domain+lastName` with >1 candidate STILL resolves `needs_review`.
- email/phone (deterministic) behavior unchanged.

## Verification

- `npm run test:unit` — 232 passed
- `npm run build` — clean (tsc + openapi)

Triage: staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
