### PR TITLE
feat(conversions): derive tracker liveness (ping heartbeat + status on conversion-token)

### DIFF
--- a/drizzle/0026_conversion_ping_liveness.sql
+++ b/drizzle/0026_conversion_ping_liveness.sql
@@ -1,0 +1,14 @@
+-- 0026: Conversion tracker liveness ping.
+--
+-- Net-new, additive: one new nullable column on brand_conversion_tokens, zero change
+-- to any existing column or table. Lets the client's on-page tag fire a { event: "ping" }
+-- heartbeat so the dashboard can DERIVE "the tracker is alive on my site" BEFORE any
+-- real conversion arrives (mirrors Meta Pixel "Last Received" / Google tag "Recording").
+--
+-- A ping is NOT a conversion: it updates last_ping_at only, never inserts a
+-- conversion_events row, never runs attribution, never counts toward eventTypesSeen.
+--
+-- Idempotent: guarded so a partially-applied state is a no-op.
+
+ALTER TABLE "brand_conversion_tokens"
+  ADD COLUMN IF NOT EXISTS "last_ping_at" timestamp with time zone;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1782000000000,
       "tag": "0025_conversion_tracking",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1782086400000,
+      "tag": "0026_conversion_ping_liveness",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -1949,9 +1949,10 @@
             "enum": [
               "signup",
               "meeting_booked",
-              "form_submission"
+              "form_submission",
+              "ping"
             ],
-            "description": "The conversion that happened on the client's website.",
+            "description": "The conversion that happened on the client's website. The special value \"ping\" is a liveness heartbeat the on-page tag fires on page-load — it is NOT a conversion (no attribution, not counted, excluded from eventTypesSeen), it only proves the tag is alive.",
             "example": "signup"
           },
           "email": {
@@ -2001,13 +2002,49 @@
             "type": "string",
             "description": "Full public URL a third party hits for POST /public/conversions.",
             "example": "https://api.distribute.you/public/conversions"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "not_set_up",
+              "live_waiting",
+              "live"
+            ],
+            "description": "Tracker liveness, DERIVED from received signals (never self-attested). not_set_up — nothing received yet; live_waiting — a ping proves the tag is alive but no real conversion yet; live — at least one real conversion received.",
+            "example": "live_waiting"
+          },
+          "lastEventAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO-8601 timestamp of the last REAL conversion event (signup/meeting_booked/form_submission), or null.",
+            "example": "2026-07-06T12:00:00.000Z"
+          },
+          "lastPingAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO-8601 timestamp of the last liveness ping, or null.",
+            "example": "2026-07-06T11:59:00.000Z"
+          },
+          "eventTypesSeen": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Distinct REAL conversion event types actually received. Always EXCLUDES \"ping\".",
+            "example": [
+              "signup"
+            ]
           }
         },
         "required": [
           "token",
-          "ingestUrl"
+          "ingestUrl",
+          "status",
+          "lastEventAt",
+          "lastPingAt",
+          "eventTypesSeen"
         ],
-        "description": "The brand's publishable conversion write-key plus the public ingest URL."
+        "description": "The brand's publishable conversion write-key, the public ingest URL, and a derived liveness overlay (status + last event/ping timestamps + event types seen)."
       }
     },
     "parameters": {},
@@ -2790,7 +2827,7 @@
     "/public/conversions": {
       "post": {
         "summary": "Ingest a conversion event from a client's website (token-auth, public)",
-        "description": "Called directly by the CLIENT's website code (token-auth, NO Clerk). Authenticates the brand publishable token, records the conversion, and attributes it to a lead we emailed for that brand via a confidence-tiered match waterfall (email/phone → deterministic; domain+lastName → strong; name-only → probabilistic, auto-attributed to the top candidate). Only strong-ambiguous (domain+lastName with >1 candidate) is held for review. NEVER leaks the match result — always { received: true } on success. Dedupe: per (brand, dedupeKey) when supplied, else per (brand, event, email-or-phone, day).",
+        "description": "Called directly by the CLIENT's website code (token-auth, NO Clerk). Authenticates the brand publishable token, records the conversion, and attributes it to a lead we emailed for that brand via a confidence-tiered match waterfall (email/phone → deterministic; domain+lastName → strong; name-only → probabilistic, auto-attributed to the top candidate). Only strong-ambiguous (domain+lastName with >1 candidate) is held for review. NEVER leaks the match result — always { received: true } on success. Dedupe: per (brand, dedupeKey) when supplied, else per (brand, event, email-or-phone, day). The special event \"ping\" is a liveness heartbeat: it stamps the brand's last-ping time and returns { received: true } WITHOUT running attribution, storing a conversion, or counting toward stats.",
         "parameters": [
           {
             "in": "header",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -242,6 +242,10 @@ export const brandConversionTokens = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
     rotatedAt: timestamp("rotated_at", { withTimezone: true }),
+    // Liveness heartbeat: last time the client's on-page tag fired a { event: "ping" }.
+    // Derives the "tracker is alive" signal BEFORE any real conversion arrives. A ping
+    // is NOT a conversion — it never lands in conversion_events, never runs attribution.
+    lastPingAt: timestamp("last_ping_at", { withTimezone: true }),
   },
   (table) => [
     uniqueIndex("idx_bct_brand_id").on(table.brandId),

--- a/src/lib/conversions.ts
+++ b/src/lib/conversions.ts
@@ -20,6 +20,31 @@ export function isConversionEvent(value: unknown): value is ConversionEventName 
   return typeof value === "string" && (CONVERSION_EVENTS as readonly string[]).includes(value);
 }
 
+// A liveness heartbeat the client's on-page tag fires on page-load. NOT a conversion:
+// it never runs attribution, never lands in conversion_events, never counts toward
+// eventTypesSeen or dedupe. It only stamps last_ping_at so the dashboard can derive
+// "the tracker is alive" before any real conversion arrives.
+export const PING_EVENT = "ping" as const;
+
+export function isPingEvent(value: unknown): value is typeof PING_EVENT {
+  return value === PING_EVENT;
+}
+
+// Consumer-observable liveness, derived (never self-attested):
+//   not_set_up   — nothing received yet (no ping, no real conversion)
+//   live_waiting — a ping proves the tag is alive, but no real conversion yet
+//   live         — at least one real conversion received
+export type ConversionTrackerStatus = "not_set_up" | "live_waiting" | "live";
+
+export function deriveConversionStatus(params: {
+  hasRealEvent: boolean;
+  hasPing: boolean;
+}): ConversionTrackerStatus {
+  if (params.hasRealEvent) return "live";
+  if (params.hasPing) return "live_waiting";
+  return "not_set_up";
+}
+
 /** Generate a publishable write-key. Not a secret (embedded in a client-side pixel). */
 export function generateConversionToken(): string {
   return `pk_conv_${randomBytes(24).toString("base64url")}`;

--- a/src/routes/conversions.ts
+++ b/src/routes/conversions.ts
@@ -6,11 +6,14 @@ import { apiKeyAuth, requireOrgId, AuthenticatedRequest } from "../middleware/au
 import { CONVERSION_INGEST_URL } from "../config.js";
 import {
   isConversionEvent,
+  isPingEvent,
+  deriveConversionStatus,
   generateConversionToken,
   computeDedupeSignature,
   matchConversion,
   type ConversionEventName,
 } from "../lib/conversions.js";
+import { toIsoTimestamp } from "../lib/basic-leads.js";
 
 const router = Router();
 
@@ -96,7 +99,26 @@ router.post("/public/conversions", conversionTokenAuth, wrap(async (req: Convers
   const orgId = req.conversionOrgId!;
 
   const parsed = ConversionIngestBodySchema.safeParse(req.body);
-  if (!parsed.success || !isConversionEvent(parsed.data.event)) {
+  if (!parsed.success) {
+    res.status(400).json({ error: "Invalid or missing event" });
+    return;
+  }
+
+  // Liveness heartbeat. The tag fires this on page-load: authenticate the token exactly
+  // like a real event (already done above), stamp last_ping_at, and STOP — no attribution,
+  // no conversion_events row, no dedupe, never counted as a conversion. Same opaque
+  // { received: true } so the public caller learns nothing.
+  if (isPingEvent(parsed.data.event)) {
+    await db.execute(sql`
+      UPDATE brand_conversion_tokens
+      SET last_ping_at = now()
+      WHERE brand_id = ${brandId}
+    `);
+    res.json({ received: true });
+    return;
+  }
+
+  if (!isConversionEvent(parsed.data.event)) {
     res.status(400).json({ error: "Invalid or missing event" });
     return;
   }
@@ -175,10 +197,38 @@ router.get(
       INSERT INTO brand_conversion_tokens (brand_id, org_id, token)
       VALUES (${brandId}, ${orgId}, ${token})
       ON CONFLICT (brand_id) DO UPDATE SET updated_at = now()
-      RETURNING token
-    `)) as unknown as Array<{ token: string }>;
+      RETURNING token, last_ping_at
+    `)) as unknown as Array<{ token: string; last_ping_at: Date | string | null }>;
 
-    res.json({ token: rows[0].token, ingestUrl: CONVERSION_INGEST_URL });
+    // Liveness overlay, DERIVED from received signals (never self-attested). Real events
+    // live in conversion_events; ping never lands there, so eventTypesSeen excludes it
+    // for free. array_agg over zero rows → null → [].
+    const agg = (await db.execute(sql`
+      SELECT max(received_at) AS last_event_at,
+             array_agg(DISTINCT event) AS event_types
+      FROM conversion_events
+      WHERE brand_id = ${brandId}
+    `)) as unknown as Array<{
+      last_event_at: Date | string | null;
+      event_types: string[] | null;
+    }>;
+
+    const lastEventAt = toIsoTimestamp(agg[0]?.last_event_at ?? null);
+    const lastPingAt = toIsoTimestamp(rows[0].last_ping_at ?? null);
+    const eventTypesSeen = agg[0]?.event_types ?? [];
+    const status = deriveConversionStatus({
+      hasRealEvent: lastEventAt !== null,
+      hasPing: lastPingAt !== null,
+    });
+
+    res.json({
+      token: rows[0].token,
+      ingestUrl: CONVERSION_INGEST_URL,
+      status,
+      lastEventAt,
+      lastPingAt,
+      eventTypesSeen,
+    });
   }),
 );
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1967,8 +1967,11 @@ registry.registerPath({
 
 const ConversionIngestRequestSchema = z
   .object({
-    event: z.enum(["signup", "meeting_booked", "form_submission"]).openapi({
-      description: "The conversion that happened on the client's website.",
+    event: z.enum(["signup", "meeting_booked", "form_submission", "ping"]).openapi({
+      description:
+        "The conversion that happened on the client's website. The special value \"ping\" is a " +
+        "liveness heartbeat the on-page tag fires on page-load — it is NOT a conversion (no " +
+        "attribution, not counted, excluded from eventTypesSeen), it only proves the tag is alive.",
       example: "signup",
     }),
     email: z.string().optional().openapi({ example: "jane@acme.com" }),
@@ -2008,9 +2011,32 @@ const ConversionTokenResponseSchema = z
       description: "Full public URL a third party hits for POST /public/conversions.",
       example: "https://api.distribute.you/public/conversions",
     }),
+    status: z.enum(["not_set_up", "live_waiting", "live"]).openapi({
+      description:
+        "Tracker liveness, DERIVED from received signals (never self-attested). " +
+        "not_set_up — nothing received yet; live_waiting — a ping proves the tag is alive but " +
+        "no real conversion yet; live — at least one real conversion received.",
+      example: "live_waiting",
+    }),
+    lastEventAt: z.string().nullable().openapi({
+      description:
+        "ISO-8601 timestamp of the last REAL conversion event (signup/meeting_booked/form_submission), or null.",
+      example: "2026-07-06T12:00:00.000Z",
+    }),
+    lastPingAt: z.string().nullable().openapi({
+      description: "ISO-8601 timestamp of the last liveness ping, or null.",
+      example: "2026-07-06T11:59:00.000Z",
+    }),
+    eventTypesSeen: z.array(z.string()).openapi({
+      description:
+        "Distinct REAL conversion event types actually received. Always EXCLUDES \"ping\".",
+      example: ["signup"],
+    }),
   })
   .openapi("ConversionTokenResponse", {
-    description: "The brand's publishable conversion write-key plus the public ingest URL.",
+    description:
+      "The brand's publishable conversion write-key, the public ingest URL, and a derived " +
+      "liveness overlay (status + last event/ping timestamps + event types seen).",
   });
 
 const ConversionTokenHeader = [
@@ -2042,7 +2068,9 @@ registry.registerPath({
     "name-only → probabilistic, auto-attributed to the top candidate). Only strong-ambiguous " +
     "(domain+lastName with >1 candidate) is held for review. NEVER leaks the match result — " +
     "always { received: true } " +
-    "on success. Dedupe: per (brand, dedupeKey) when supplied, else per (brand, event, email-or-phone, day).",
+    "on success. Dedupe: per (brand, dedupeKey) when supplied, else per (brand, event, email-or-phone, day). " +
+    "The special event \"ping\" is a liveness heartbeat: it stamps the brand's last-ping time and returns " +
+    "{ received: true } WITHOUT running attribution, storing a conversion, or counting toward stats.",
   request: {
     body: {
       content: { "application/json": { schema: ConversionIngestRequestSchema } },

--- a/tests/unit/conversions-routes.test.ts
+++ b/tests/unit/conversions-routes.test.ts
@@ -172,6 +172,34 @@ describe("POST /public/conversions", () => {
       .send({ event: "signup", email: "x@y.com" });
     expect(res.status).toBe(500);
   });
+
+  it("ping heartbeat → 200 {received:true}, stamps last_ping_at, NO attribution/insert", async () => {
+    execute.mockResolvedValueOnce([{ brand_id: "brand-1", org_id: "org-1" }]); // token
+    execute.mockResolvedValueOnce([]); // update last_ping_at
+    const res = await request(app)
+      .post("/public/conversions")
+      .set("x-conversion-token", "pk_conv_ok")
+      .send({ event: "ping" });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+    // ping never runs the match waterfall and never touches conversion_events.
+    expect(matchConversion).not.toHaveBeenCalled();
+    expect(execute).toHaveBeenCalledTimes(2); // token lookup + last_ping_at update only
+    const updateSql = lastSql();
+    expect(updateSql).toContain("update brand_conversion_tokens");
+    expect(updateSql).toContain("last_ping_at");
+    expect(updateSql).not.toContain("conversion_events");
+  });
+
+  it("ping still requires a valid token (401, no update)", async () => {
+    execute.mockResolvedValueOnce([]); // token lookup → no row
+    const res = await request(app)
+      .post("/public/conversions")
+      .set("x-conversion-token", "pk_conv_nope")
+      .send({ event: "ping" });
+    expect(res.status).toBe(401);
+    expect(execute).toHaveBeenCalledTimes(1); // only the token lookup
+  });
 });
 
 describe("GET /orgs/brands/:brandId/conversion-token", () => {
@@ -193,8 +221,9 @@ describe("GET /orgs/brands/:brandId/conversion-token", () => {
     expect(res.status).toBe(400);
   });
 
-  it("get-or-create returns {token, ingestUrl}", async () => {
-    execute.mockResolvedValueOnce([{ token: "pk_conv_existing" }]);
+  it("nothing received → not_set_up, both timestamps null, eventTypesSeen []", async () => {
+    execute.mockResolvedValueOnce([{ token: "pk_conv_existing", last_ping_at: null }]); // upsert
+    execute.mockResolvedValueOnce([{ last_event_at: null, event_types: null }]); // agg
     const res = await request(app)
       .get("/orgs/brands/brand-1/conversion-token")
       .set("x-api-key", "test-api-key")
@@ -203,10 +232,50 @@ describe("GET /orgs/brands/:brandId/conversion-token", () => {
     expect(res.body).toEqual({
       token: "pk_conv_existing",
       ingestUrl: "https://api.distribute.you/public/conversions",
+      status: "not_set_up",
+      lastEventAt: null,
+      lastPingAt: null,
+      eventTypesSeen: [],
     });
     expect(sqlAt(0)).toContain("insert into brand_conversion_tokens");
     expect(sqlAt(0)).toContain("on conflict");
     expect(sqlAt(0)).not.toContain("excluded.token"); // GET must NOT replace the token
+    expect(sqlAt(0)).toContain("last_ping_at"); // RETURNING now carries the ping time
+    expect(sqlAt(1)).toContain("from conversion_events"); // liveness overlay aggregate
+  });
+
+  it("ping received, no real conversion → live_waiting, lastPingAt set, eventTypesSeen still []", async () => {
+    execute.mockResolvedValueOnce([
+      { token: "pk_conv_existing", last_ping_at: new Date("2026-07-06T11:59:00.000Z") },
+    ]);
+    execute.mockResolvedValueOnce([{ last_event_at: null, event_types: null }]);
+    const res = await request(app)
+      .get("/orgs/brands/brand-1/conversion-token")
+      .set("x-api-key", "test-api-key")
+      .set("x-org-id", "org-1");
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("live_waiting");
+    expect(res.body.lastPingAt).toBe("2026-07-06T11:59:00.000Z");
+    expect(res.body.lastEventAt).toBeNull();
+    expect(res.body.eventTypesSeen).toEqual([]);
+  });
+
+  it("real conversion received → live, lastEventAt set, eventTypesSeen has signup (never ping)", async () => {
+    execute.mockResolvedValueOnce([
+      { token: "pk_conv_existing", last_ping_at: new Date("2026-07-06T11:59:00.000Z") },
+    ]);
+    execute.mockResolvedValueOnce([
+      { last_event_at: "2026-07-06T12:00:00.000Z", event_types: ["signup"] },
+    ]);
+    const res = await request(app)
+      .get("/orgs/brands/brand-1/conversion-token")
+      .set("x-api-key", "test-api-key")
+      .set("x-org-id", "org-1");
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("live");
+    expect(res.body.lastEventAt).toBe("2026-07-06T12:00:00.000Z");
+    expect(res.body.eventTypesSeen).toEqual(["signup"]);
+    expect(res.body.eventTypesSeen).not.toContain("ping");
   });
 });
 

--- a/tests/unit/conversions.test.ts
+++ b/tests/unit/conversions.test.ts
@@ -15,6 +15,8 @@ const {
   computeDedupeSignature,
   resolveAttributionStatus,
   isConversionEvent,
+  isPingEvent,
+  deriveConversionStatus,
   generateConversionToken,
   matchConversion,
 } = await import("../../src/lib/conversions.js");
@@ -104,6 +106,30 @@ describe("isConversionEvent", () => {
   it("rejects everything else", () => {
     expect(isConversionEvent("purchase")).toBe(false);
     expect(isConversionEvent(undefined)).toBe(false);
+  });
+  it("rejects ping (a heartbeat is NOT a conversion)", () => {
+    expect(isConversionEvent("ping")).toBe(false);
+  });
+});
+
+describe("isPingEvent", () => {
+  it("accepts only the ping value", () => {
+    expect(isPingEvent("ping")).toBe(true);
+    expect(isPingEvent("signup")).toBe(false);
+    expect(isPingEvent(undefined)).toBe(false);
+  });
+});
+
+describe("deriveConversionStatus", () => {
+  it("nothing received → not_set_up", () => {
+    expect(deriveConversionStatus({ hasRealEvent: false, hasPing: false })).toBe("not_set_up");
+  });
+  it("ping only → live_waiting", () => {
+    expect(deriveConversionStatus({ hasRealEvent: false, hasPing: true })).toBe("live_waiting");
+  });
+  it("real event → live (regardless of ping)", () => {
+    expect(deriveConversionStatus({ hasRealEvent: true, hasPing: false })).toBe("live");
+    expect(deriveConversionStatus({ hasRealEvent: true, hasPing: true })).toBe("live");
   });
 });
 


### PR DESCRIPTION
## What

Give the dashboard's Conversion Tracking settings a way to answer, **without the client self-attesting**:
1. Is the tracker alive on my site right now? (answerable *before* any real conversion)
2. Which conversion events has it actually sent?

Mirrors how Meta Pixel ("Last Received") and Google Ads tags ("Recording") derive liveness from received signals instead of asking the user to declare "it's installed".

## Changes (fully additive)

**① `GET /orgs/brands/{brandId}/conversion-token`** — keeps `{ token, ingestUrl }`, adds:
- `status`: `"not_set_up" | "live_waiting" | "live"`
- `lastEventAt`: ISO-8601 | null — last REAL conversion (signup/meeting_booked/form_submission)
- `lastPingAt`: ISO-8601 | null — last liveness ping
- `eventTypesSeen`: `string[]` — distinct REAL event types received, **always excludes `"ping"`**

Derived at read time from `conversion_events` (real events) + `brand_conversion_tokens.last_ping_at`. No materialized state.

**② `POST /public/conversions` accepts `{ "event": "ping" }`** — the on-page tag fires this on page-load. It authenticates the token exactly like a real event, stamps `last_ping_at`, returns the same opaque `{ received: true }`, and does **NOT**: run attribution, insert a `conversion_events` row, dedupe, or count toward `eventTypesSeen`.

**Migration `0026`** — adds nullable `brand_conversion_tokens.last_ping_at` (idempotent `ADD COLUMN IF NOT EXISTS`).

## Why additive / deploy-order-free
Existing `{ token, ingestUrl }` consumers and existing signup/meeting_booked/form_submission ingest are byte-unchanged. api-service's GET conversion-token + POST /public/conversions proxies are transparent passthrough — no api-service change needed.

## Tests
`npm run build` clean, 241 unit tests pass. New coverage: ping heartbeat (200, stamps `last_ping_at`, no attribution/insert, still 401 on bad token), status derivation (not_set_up / live_waiting / live), `eventTypesSeen` excludes ping, `isConversionEvent("ping") === false`.

## AC
1. ✅ GET returns 4 new fields; nothing received → `not_set_up`, both timestamps null, `eventTypesSeen: []`
2. ✅ after ping → `live_waiting`, `lastPingAt` set, `eventTypesSeen` still excludes ping
3. ✅ after real signup → `live`, `lastEventAt` set, `eventTypesSeen` has `"signup"`
4. ✅ existing consumers + existing events unchanged
5. ✅ no api-service change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
