### PR TITLE
fix(conversions): bind received_at as ISO string, not raw Date (fixes 500 on every conversion)

### DIFF
--- a/src/routes/conversions.ts
+++ b/src/routes/conversions.ts
@@ -160,6 +160,13 @@ router.post("/public/conversions", conversionTokenAuth, wrap(async (req: Convers
 
   // Race-safe insert: if a concurrent request already claimed this signature, the
   // partial unique index makes this a no-op and we still return 200.
+  //
+  // received_at is bound as `now.toISOString()`, NOT a raw `Date`: a raw `sql` template
+  // hands params straight to postgres.js `Bind`, which does not serialize a Date (only
+  // drizzle's typed insert builder / postgres.js's own tagged template do). Binding a
+  // `Date` throws `ERR_INVALID_ARG_TYPE ... Received an instance of Date` at Bind time —
+  // a client-side throw invisible to raw-SQL/EXECUTE tests — which 500'd every real
+  // conversion in prod (#357). The ISO string casts to timestamptz for the column.
   await db.execute(sql`
     INSERT INTO conversion_events (
       brand_id, org_id, event, email, phone, first_name, last_name, company_url,
@@ -170,7 +177,7 @@ router.post("/public/conversions", conversionTokenAuth, wrap(async (req: Convers
       ${body.firstName ?? null}, ${body.lastName ?? null}, ${body.companyUrl ?? null},
       ${body.dedupeKey ?? null}, ${dedupeSignature}, ${body.valueCents ?? null},
       ${match.matchedLeadId}, ${match.matchMethod}, ${match.matchConfidence},
-      ${match.attributionStatus}, ${match.candidateCount}, ${now}
+      ${match.attributionStatus}, ${match.candidateCount}, ${now.toISOString()}
     )
     ON CONFLICT (brand_id, dedupe_signature) WHERE dedupe_signature IS NOT NULL DO NOTHING
   `);

--- a/tests/unit/conversions-routes.test.ts
+++ b/tests/unit/conversions-routes.test.ts
@@ -34,6 +34,21 @@ function sqlAt(i: number): string {
   return compile(execute.mock.calls[i][0]).sql.toLowerCase();
 }
 
+// Faithfully reproduce postgres.js `Bind`: a raw `sql` template hands params straight to
+// the driver, which cannot serialize a JS `Date` (it does `Buffer.byteLength(value)` and
+// throws `ERR_INVALID_ARG_TYPE ... Received an instance of Date`). The plain vi.fn() mock
+// never serializes params, which is exactly why the 100%-broken handler shipped green
+// (#357). Assert-on-bind here so a raw-Date param 500s in tests just like it did in prod.
+function assertBindable(call: unknown): void {
+  for (const p of compile(call).params) {
+    if (p instanceof Date) {
+      throw new TypeError(
+        'The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Date',
+      );
+    }
+  }
+}
+
 async function buildApp() {
   const { default: route } = await import("../../src/routes/conversions.js");
   const app = express();
@@ -106,6 +121,79 @@ describe("POST /public/conversions", () => {
     expect(insertParams).toContain("attributed");
     expect(insertParams).toContain("deterministic");
     expect(insertParams).toContain("lead-1");
+  });
+
+  // Regression for #357: the INSERT bound `received_at` as a raw `Date`, which threw at
+  // postgres.js Bind time (a client-side throw invisible to raw-SQL/EXECUTE tests), so
+  // EVERY real conversion 500'd in prod while ping (SQL `now()`, no Date param) worked.
+  // These tests drive the real handler through a Bind-faithful mock: they FAIL (500) on
+  // the old `${now}` code and PASS on the `${now.toISOString()}` fix.
+  it("real signup conversion → 200 + persists conversion_events with a serializable received_at (AC1)", async () => {
+    const rowsByCall: unknown[][] = [
+      [{ brand_id: "brand-1", org_id: "org-1" }], // token lookup
+      [], // dedupe check → no dup
+      [], // insert
+    ];
+    let i = 0;
+    execute.mockImplementation((call: unknown) => {
+      assertBindable(call); // throws on a raw Date param, exactly like postgres.js in prod
+      return Promise.resolve(rowsByCall[i++] ?? []);
+    });
+    matchConversion.mockResolvedValueOnce({
+      matchedLeadId: "lead-1",
+      matchMethod: "email",
+      matchConfidence: "deterministic",
+      attributionStatus: "attributed",
+      candidateCount: 1,
+    });
+
+    const res = await request(app)
+      .post("/public/conversions")
+      .set("x-conversion-token", "pk_conv_ok")
+      .send({ event: "signup", email: "Jane@Acme.com", firstName: "Jane", lastName: "Doe" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+    // the insert actually ran (3rd execute call) …
+    const insert = compile(execute.mock.calls[2][0]);
+    expect(insert.sql.toLowerCase()).toContain("insert into conversion_events");
+    expect(insert.params).toContain("attributed");
+    expect(insert.params).toContain("lead-1");
+    // … with every bound param serializable — received_at is an ISO string, never a Date.
+    expect(insert.params.some((p) => p instanceof Date)).toBe(false);
+    expect(insert.params).toContainEqual(expect.stringMatching(/^\d{4}-\d{2}-\d{2}T.*Z$/));
+  });
+
+  it("bare signup (no identity) → 200 + persists unmatched row, null dedupe_signature, no Date param (AC2)", async () => {
+    const rowsByCall: unknown[][] = [
+      [{ brand_id: "brand-1", org_id: "org-1" }], // token lookup
+      [], // insert (no dedupe SELECT: no dedupeKey/email/phone → signature null)
+    ];
+    let i = 0;
+    execute.mockImplementation((call: unknown) => {
+      assertBindable(call);
+      return Promise.resolve(rowsByCall[i++] ?? []);
+    });
+    matchConversion.mockResolvedValueOnce({
+      matchedLeadId: null,
+      matchMethod: null,
+      matchConfidence: "unmatched",
+      attributionStatus: "unmatched",
+      candidateCount: 0,
+    });
+
+    const res = await request(app)
+      .post("/public/conversions")
+      .set("x-conversion-token", "pk_conv_ok")
+      .send({ event: "signup" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+    expect(execute).toHaveBeenCalledTimes(2); // token lookup + insert only (no dedupe SELECT)
+    const insert = compile(execute.mock.calls[1][0]);
+    expect(insert.sql.toLowerCase()).toContain("insert into conversion_events");
+    expect(insert.params).toContain("unmatched");
+    expect(insert.params.some((p) => p instanceof Date)).toBe(false);
   });
 
   it("accepts Authorization: Bearer token", async () => {


### PR DESCRIPTION
## What

`POST /public/conversions` has returned **500 on every real conversion event** (`signup` / `meeting_booked` / `form_submission` / `purchase`) in prod since the beta ingest (#357). `conversion_events` has **0 real rows ever** — distribute's own signups (fire-and-forget, client-side) were all silently dropped. Only `ping` (added in #364) worked.

## Root cause

The attribution INSERT bound `received_at` as a **raw JS `Date`** through a raw `db.execute(sql\`...\`)` template. A raw `sql` template passes params straight to postgres.js `Bind`, which cannot serialize a `Date` (only drizzle's typed insert builder and postgres.js's own tagged template do). It falls into `Buffer.byteLength(value)` and throws:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string
    or an instance of Buffer or ArrayBuffer. Received an instance of Date
    at Function.str (postgres/src/bytes.js:22)
    at Bind (postgres/src/connection.js:954)
```

(Pulled from lead-service prod Railway logs.)

This is a **client-side throw at Bind time**, invisible to raw-SQL / `EXECUTE ... USING` tests — which is exactly why the DB looked fully healthy when every query was run directly against the prod branch. `wrap()` → Express error middleware returned it as a generic 500.

Why ping worked: ping's UPDATE uses SQL `now()` (no Date param). GET conversion-token and the dedupe/match queries bind only strings. Only the conversion INSERT bound a `Date`.

## Fix

Bind `now.toISOString()` — the text value casts to the `timestamptz` column. One line + a why-comment so it's not reverted.

## Regression coverage

The existing route tests fully mocked `db.execute` (a `vi.fn()` returning `[]`), so params never reached postgres.js Bind and a handler-level throw shipped green. Added:
- a **Bind-faithful mock** that throws on a raw `Date` param, reproducing the prod behaviour;
- two **end-to-end handler tests** (AC1 email-match → 200 + persisted attributed row; AC2 bare/no-identity → 200 + unmatched row, null dedupe_signature).

Both **fail (500) on the old `${now}` code and pass on the fix** (verified by reverting locally). Ping behaviour still covered (200, no `conversion_events` row). Full suite: 243 passed, build clean.

## ⚠️ Promote to prod

**The bug is LIVE in PROD — conversion recording is currently dead.** After staging verification this MUST be promoted to prod (`release.sh promote`), or every conversion keeps 500'ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
