### PR TITLE
feat(conversions): expose per-brand real conversion counts (internal)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2046,6 +2046,43 @@
           "eventTypesSeen"
         ],
         "description": "The brand's publishable conversion write-key, the public ingest URL, and a derived liveness overlay (status + last event/ping timestamps + event types seen)."
+      },
+      "ConversionCountsResponse": {
+        "type": "object",
+        "properties": {
+          "counts": {
+            "type": "object",
+            "properties": {
+              "signup": {
+                "type": "integer",
+                "example": 12
+              },
+              "meeting_booked": {
+                "type": "integer",
+                "example": 3
+              },
+              "form_submission": {
+                "type": "integer",
+                "example": 7
+              },
+              "purchase": {
+                "type": "integer",
+                "example": 2
+              }
+            },
+            "required": [
+              "signup",
+              "meeting_booked",
+              "form_submission",
+              "purchase"
+            ],
+            "description": "Count of REAL, deduped, attributed conversion events per event type. All four keys are ALWAYS present (0 when none received). Excludes the \"ping\" liveness heartbeat, needs_review, and unmatched events."
+          }
+        },
+        "required": [
+          "counts"
+        ],
+        "description": "Per-brand real conversion counts by event type, for features-service to compute real signups / cost-per-signup."
       }
     },
     "parameters": {},
@@ -3155,6 +3192,47 @@
           },
           "400": {
             "description": "Missing x-org-id"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/internal/brands/{brandId}/conversion-counts": {
+      "get": {
+        "summary": "Real conversion counts per event type for a brand (internal, service-auth)",
+        "description": "INTERNAL (service-auth: x-api-key — same tier as other /internal/* routes, NO Clerk). Returns the per-event-type COUNT of REAL, attributed conversions for the brand. Each count is deduped (rows are deduped at write via the (brand_id, dedupe_signature) partial unique index) and filtered to attribution_status = 'attributed' (credited to a lead we emailed for the brand; excludes needs_review and unmatched). The \"ping\" liveness heartbeat never lands in conversion_events, so it is excluded. All four keys are ALWAYS present (0 when none received); a brand with zero conversions returns all-zero counts (200, never 404).",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "API key for authenticating requests"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "20000000-0000-0000-0000-000000000001"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Per-event-type real conversion counts for the brand",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversionCountsResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized"

--- a/src/routes/conversions.ts
+++ b/src/routes/conversions.ts
@@ -11,6 +11,7 @@ import {
   generateConversionToken,
   computeDedupeSignature,
   matchConversion,
+  CONVERSION_EVENTS,
   type ConversionEventName,
 } from "../lib/conversions.js";
 import { toIsoTimestamp } from "../lib/basic-leads.js";
@@ -261,6 +262,51 @@ router.post(
     `)) as unknown as Array<{ token: string }>;
 
     res.json({ token: rows[0].token, ingestUrl: CONVERSION_INGEST_URL });
+  }),
+);
+
+/**
+ * GET /internal/brands/:brandId/conversion-counts
+ *
+ * INTERNAL (service-auth: x-api-key — same tier as other /internal/* routes, NO Clerk).
+ * Returns the per-event-type COUNT of REAL, attributed conversions for the brand, so
+ * features-service can compute real signups / cost-per-signup for the dashboard.
+ *
+ * Each count = deduped, attributed conversion events of that type:
+ *  - Rows in conversion_events are already deduped at WRITE (partial unique index on
+ *    (brand_id, dedupe_signature)), so counting stored rows is inherently deduped per the
+ *    same rules POST /public/conversions applies.
+ *  - `attribution_status = 'attributed'` keeps only conversions credited to a lead we
+ *    emailed for this brand (auto-accepted); excludes needs_review (held) + unmatched.
+ *    This is the "counts toward the brand's real outcomes" set.
+ *  - "ping" is a liveness heartbeat that never lands in conversion_events → excluded for free.
+ *
+ * All four event-type keys are ALWAYS present (0 when none received). Never 404 — a brand
+ * with zero conversions returns all-zero counts.
+ */
+router.get(
+  "/internal/brands/:brandId/conversion-counts",
+  apiKeyAuth,
+  wrap(async (req: Request, res: Response) => {
+    const brandId = req.params.brandId;
+
+    const rows = (await db.execute(sql`
+      SELECT event, count(*)::int AS n
+      FROM conversion_events
+      WHERE brand_id = ${brandId}
+        AND attribution_status = 'attributed'
+      GROUP BY event
+    `)) as unknown as Array<{ event: string; n: number }>;
+
+    const counts = Object.fromEntries(
+      CONVERSION_EVENTS.map((e) => [e, 0]),
+    ) as Record<ConversionEventName, number>;
+
+    for (const row of rows) {
+      if (isConversionEvent(row.event)) counts[row.event] = row.n;
+    }
+
+    res.json({ counts });
   }),
 );
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2127,3 +2127,48 @@ registry.registerPath({
     401: { description: "Unauthorized" },
   },
 });
+
+const ConversionCountsResponseSchema = z
+  .object({
+    counts: z
+      .object({
+        signup: z.number().int().openapi({ example: 12 }),
+        meeting_booked: z.number().int().openapi({ example: 3 }),
+        form_submission: z.number().int().openapi({ example: 7 }),
+        purchase: z.number().int().openapi({ example: 2 }),
+      })
+      .openapi({
+        description:
+          "Count of REAL, deduped, attributed conversion events per event type. All four keys " +
+          "are ALWAYS present (0 when none received). Excludes the \"ping\" liveness heartbeat, " +
+          "needs_review, and unmatched events.",
+      }),
+  })
+  .openapi("ConversionCountsResponse", {
+    description:
+      "Per-brand real conversion counts by event type, for features-service to compute real " +
+      "signups / cost-per-signup.",
+  });
+
+registry.registerPath({
+  method: "get",
+  path: "/internal/brands/{brandId}/conversion-counts",
+  summary: "Real conversion counts per event type for a brand (internal, service-auth)",
+  description:
+    "INTERNAL (service-auth: x-api-key — same tier as other /internal/* routes, NO Clerk). Returns the " +
+    "per-event-type COUNT of REAL, attributed conversions for the brand. Each count is deduped (rows are " +
+    "deduped at write via the (brand_id, dedupe_signature) partial unique index) and filtered to " +
+    "attribution_status = 'attributed' (credited to a lead we emailed for the brand; excludes needs_review " +
+    "and unmatched). The \"ping\" liveness heartbeat never lands in conversion_events, so it is excluded. " +
+    "All four keys are ALWAYS present (0 when none received); a brand with zero conversions returns all-zero " +
+    "counts (200, never 404).",
+  request: { params: BrandIdPathParam },
+  parameters: FeatureMembershipApiKeyHeader,
+  responses: {
+    200: {
+      description: "Per-event-type real conversion counts for the brand",
+      content: { "application/json": { schema: ConversionCountsResponseSchema } },
+    },
+    401: { description: "Unauthorized" },
+  },
+});

--- a/tests/unit/conversions-routes.test.ts
+++ b/tests/unit/conversions-routes.test.ts
@@ -367,6 +367,90 @@ describe("GET /orgs/brands/:brandId/conversion-token", () => {
   });
 });
 
+describe("GET /internal/brands/:brandId/conversion-counts", () => {
+  let app: express.Express;
+  beforeAll(async () => {
+    app = await buildApp();
+  }, 30_000);
+  beforeEach(() => execute.mockReset().mockResolvedValue([]));
+
+  it("401 without x-api-key", async () => {
+    const res = await request(app).get("/internal/brands/brand-1/conversion-counts");
+    expect(res.status).toBe(401);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("zero conversions → 200 with all four keys at 0 (never 404)", async () => {
+    execute.mockResolvedValueOnce([]); // count query → no rows
+    const res = await request(app)
+      .get("/internal/brands/brand-1/conversion-counts")
+      .set("x-api-key", "test-api-key");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      counts: { signup: 0, meeting_booked: 0, form_submission: 0, purchase: 0 },
+    });
+  });
+
+  it("counts real attributed events per type; missing types default to 0", async () => {
+    execute.mockResolvedValueOnce([
+      { event: "signup", n: 12 },
+      { event: "purchase", n: 2 },
+    ]);
+    const res = await request(app)
+      .get("/internal/brands/brand-1/conversion-counts")
+      .set("x-api-key", "test-api-key");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      counts: { signup: 12, meeting_booked: 0, form_submission: 0, purchase: 2 },
+    });
+  });
+
+  it("query is deduped-at-write, attributed-only, and ping-excluded", async () => {
+    execute.mockResolvedValueOnce([]);
+    await request(app)
+      .get("/internal/brands/brand-1/conversion-counts")
+      .set("x-api-key", "test-api-key");
+    const q = sqlAt(0);
+    // Counts stored conversion_events rows (already deduped at write via the partial
+    // unique index), grouped per event type.
+    expect(q).toContain("from conversion_events");
+    expect(q).toContain("group by event");
+    // Only conversions credited to a lead we emailed for the brand.
+    expect(q).toContain("attribution_status = 'attributed'");
+    // "ping" never lands in conversion_events, so it cannot leak into the counts —
+    // and the handler only ever emits the four real event-type keys.
+    expect(q).not.toContain("ping");
+    const params = compile(execute.mock.calls[0][0]).params;
+    expect(params).toContain("brand-1");
+  });
+
+  it("an unexpected event value in a row never leaks into the response", async () => {
+    execute.mockResolvedValueOnce([
+      { event: "signup", n: 3 },
+      { event: "ping", n: 99 }, // must be ignored (isConversionEvent guard)
+      { event: "garbage", n: 7 }, // must be ignored
+    ]);
+    const res = await request(app)
+      .get("/internal/brands/brand-1/conversion-counts")
+      .set("x-api-key", "test-api-key");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      counts: { signup: 3, meeting_booked: 0, form_submission: 0, purchase: 0 },
+    });
+    expect(Object.keys(res.body.counts).sort()).toEqual(
+      ["form_submission", "meeting_booked", "purchase", "signup"].sort(),
+    );
+  });
+
+  it("500 when the DB errors (fail loud)", async () => {
+    execute.mockRejectedValueOnce(new Error("db down"));
+    const res = await request(app)
+      .get("/internal/brands/brand-1/conversion-counts")
+      .set("x-api-key", "test-api-key");
+    expect(res.status).toBe(500);
+  });
+});
+
 describe("POST /orgs/brands/:brandId/conversion-token/rotate", () => {
   let app: express.Express;
   beforeAll(async () => {


### PR DESCRIPTION
## What

Adds `GET /internal/brands/{brandId}/conversion-counts` (service-auth: `x-api-key`, same tier as other `/internal/*` routes, no Clerk) returning:

```json
{ "counts": { "signup": 0, "meeting_booked": 0, "form_submission": 0, "purchase": 0 } }
```

All four keys ALWAYS present (0 when none received). A brand with zero conversions returns all-zero counts — **200, never 404**.

## Why

features-service will consume these real per-brand counts to compute real CPS and a real signups count for the dashboard's "Signups" / "CPS" tiles (today they render "—" because no tracked-conversion count is served anywhere).

## Counting rules (byte-equal to how conversions are recorded today)

- **Deduped** — `conversion_events` rows are deduped at WRITE via the `(brand_id, dedupe_signature)` partial unique index, so counting stored rows is inherently deduped per the same rules `POST /public/conversions` applies.
- **Attributed** — `attribution_status = 'attributed'` keeps only conversions credited to a lead we emailed for the brand (auto-accepted); excludes `needs_review` (held) and `unmatched`.
- **Ping-excluded** — `"ping"` (liveness heartbeat) never lands in `conversion_events`, so it's excluded for free; the handler only ever emits the four real event-type keys.

## No-gos respected

- No change to `POST /public/conversions` behavior or the conversion-token response shape.
- Internal service-auth only (no public/org route).

## AC

1. ✅ Returns the locked shape with all four event-type keys.
2. ✅ Counts deduped + attributed, exclude "ping", match today's recording.
3. ✅ Zero-conversion brand → all-zero counts (200, not 404).
4. ✅ `openapi.json` regenerated + committed; unit tests cover the counts query (dedup + attributed-only + ping-exclusion + zero-case + fail-loud 500).

Triage: staging (feature; additive internal endpoint, zero blast radius on existing routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)