### PR TITLE
feat(leads): a lead's offer is the offer its campaign sells

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2563,6 +2563,15 @@
           },
           {
             "in": "query",
+            "name": "offerId",
+            "required": false,
+            "description": "Restrict returned leads to ONE offer — brand-service's proposition level, between the brand and the campaign. A lead's offer is the offer named by the campaign it was served under: the membership row's `campaign_id` is a frozen attribution, and campaign-service records which offer each campaign sells, so this resolves to every campaign in the org naming that offer and filters on the same `campaign_id` a campaignId read filters on. Delivery status is offer-scoped (the union over those campaigns), the same way a campaign identity's is. MUTUALLY EXCLUSIVE with `campaignId` — a campaign already sells exactly one offer, so naming both is a 400 rather than one silently winning. An offer no campaign sells yet returns an empty list, never the brand's leads. If campaign-service cannot say which campaigns sell it, the read is refused with a 502 — never widened to the brand. When absent, behavior + response shape are unchanged.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "orgId",
             "required": false,
             "schema": {
@@ -2650,7 +2659,7 @@
             }
           },
           "400": {
-            "description": "Invalid `status`, `limit`, `cursor` or `offset` value",
+            "description": "Invalid `status`, `limit`, `cursor` or `offset` value, or `offerId` and `campaignId` both named",
             "content": {
               "application/json": {
                 "schema": {
@@ -2661,6 +2670,16 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "502": {
+            "description": "`offerId` was named and campaign-service could not say which campaigns sell it — the read is refused rather than widened to the brand",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }

--- a/src/lib/lead-list-query.ts
+++ b/src/lib/lead-list-query.ts
@@ -10,10 +10,27 @@ export interface LeadListScope {
   /** The campaign the caller asked for. Kept for logging/telemetry; the FILTER is campaignIds. */
   campaignId?: string;
   /**
+   * The OFFER the caller asked for. Kept for logging/telemetry; the FILTER is campaignIds.
+   *
+   * A lead's offer is the offer named by the campaign it was served under (see
+   * offer-campaigns-client.ts), and `leads_campaigns.campaign_id` is that frozen attribution — so
+   * offer scope resolves to a set of campaign ids and rides the campaign-id filter below rather
+   * than adding a parallel one. It is therefore mutually exclusive with `campaignId`: a campaign
+   * already sells exactly one offer, so naming both is contradictory and the route 400s it.
+   *
+   * Set only when `campaignIds` is NON-EMPTY. An offer that resolves to no campaigns matches
+   * nothing, and the route answers it with an empty list before a scope is ever built — never by
+   * dropping the filter, which would serve the whole brand under the offer's name.
+   */
+  offerId?: string;
+  /**
    * The campaign IDENTITY's members — every stored campaign row the customer reads as the ONE
    * campaign they asked for (see campaign-identity.ts). Resolved by the route from campaign-service;
    * `[campaignId]` when the identity has a single member or could not be resolved. Absent means the
    * read is not campaign-scoped at all.
+   *
+   * Under an OFFER scope this is instead every campaign in the org that names that offer (see
+   * `offerId`). Either way it is the one campaign-id filter both list queries apply.
    */
   campaignIds?: string[];
   queryOrgId?: string;

--- a/src/lib/offer-campaigns-client.ts
+++ b/src/lib/offer-campaigns-client.ts
@@ -1,0 +1,130 @@
+/**
+ * Resolve the campaigns that sell one OFFER — brand-service's proposition level, which sits
+ * between the brand and the campaign (Org > Brand > Offer > Campaign).
+ *
+ * lead-service defines NONE of an offer's semantics. It holds no offer column and never will:
+ * what a lead's offer IS follows from what this service already froze on its own rows. A lead is
+ * served under a CAMPAIGN, and `leads_campaigns.campaign_id` records which one, permanently. A
+ * campaign names its offer (campaign-service, `campaigns.offer_id`). So:
+ *
+ *     a lead's offer = the offer named by the campaign the lead was served under.
+ *
+ * That is the same shape the campaign narrowing already has — resolve a set of campaign ids from
+ * campaign-service, then filter the frozen `campaign_id` on it — so offer scope reuses the
+ * campaign-id filter rather than adding a second, parallel one. It also survives a campaign being
+ * reconfigured later: the membership row keeps pointing at the campaign it was actually served
+ * under, whatever that campaign is switched to afterwards, which is exactly why the attribution
+ * was frozen in the first place.
+ *
+ * FAIL LOUD, unlike the campaign IDENTITY read next door. That one is fail-soft because its
+ * failure mode is a NARROWER answer (the single stored campaign row) — degraded, never wrong.
+ * This one's failure mode is the opposite: with no campaign ids to filter on, the read would fall
+ * back to the whole BRAND, which is the precise bug offer scope exists to fix — one brand's two
+ * offers showing the same people. So an unreachable campaign-service is an error the caller is
+ * told about, never a silently widened list.
+ *
+ * An offer that resolves to ZERO campaigns is NOT a failure: it is a real, correct answer for an
+ * offer nothing has been run for yet, and it returns an empty list rather than the brand's.
+ *
+ * The read is ORG-scoped, and the offer id is NOT validated against brand-service. Nothing in this
+ * service validates a caller-supplied entity id against its owning service (`brandId` and
+ * `campaignId` are both taken as given and used as filters), and an offer no campaign names is
+ * indistinguishable from an offer with no campaigns yet — both are honestly empty.
+ */
+import { CAMPAIGN_SERVICE_URL, CAMPAIGN_SERVICE_API_KEY } from "../config.js";
+import { fetchWithRetry } from "./fetch-retry.js";
+
+export interface OfferCampaignContext {
+  orgId: string;
+  userId?: string | null;
+  runId?: string | null;
+  brandId?: string | null;
+}
+
+/** A campaign row as campaign-service serves it, trimmed to what an offer scope needs. */
+export interface OfferCampaignRow {
+  id: string;
+  /** The offer the campaign sells. NULL is a real state — a campaign that names none. */
+  offerId?: string | null;
+}
+
+/**
+ * campaign-service could not answer, so which campaigns sell this offer is UNKNOWN. The route
+ * turns this into a 502: the alternative is returning the brand's leads under an offer's name.
+ */
+export class OfferCampaignsUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OfferCampaignsUnavailableError";
+  }
+}
+
+/**
+ * Every campaign id in the org that names `offerId`, ascending.
+ *
+ * Membership is strict equality on the offer the campaign itself states — never inferred from a
+ * sibling campaign, a funnel, or a brand. A campaign that states no offer belongs to no offer.
+ * (Checked against production 2026-08-19: no campaign identity is split across offer-carrying and
+ * offer-less rows, so this does not under-count relative to a campaign-scoped read of the same
+ * population.)
+ */
+export async function resolveOfferCampaignIds(
+  offerId: string,
+  ctx: OfferCampaignContext,
+): Promise<string[]> {
+  const headers: Record<string, string> = {
+    "X-API-Key": CAMPAIGN_SERVICE_API_KEY,
+    "x-org-id": ctx.orgId,
+  };
+  if (ctx.userId) headers["x-user-id"] = ctx.userId;
+  if (ctx.runId) headers["x-run-id"] = ctx.runId;
+  if (ctx.brandId) headers["x-brand-id"] = ctx.brandId;
+
+  let response: Response;
+  try {
+    // No `limit`: campaign-service returns every match when none is named, and a bounded read
+    // would silently drop the offer's older campaigns — the stopped rows that hold most of a
+    // brand's serve history.
+    response = await fetchWithRetry(`${CAMPAIGN_SERVICE_URL}/campaigns`, {
+      method: "GET",
+      headers,
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (error) {
+    throw new OfferCampaignsUnavailableError(
+      `campaign-service is unreachable, so the campaigns selling offer ${offerId} are unknown: ${
+        (error as Error).message
+      }`,
+    );
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new OfferCampaignsUnavailableError(
+      `campaign-service /campaigns failed (${response.status}), so the campaigns selling offer ${offerId} are unknown: ${body}`,
+    );
+  }
+
+  let data: { campaigns?: OfferCampaignRow[] };
+  try {
+    data = (await response.json()) as { campaigns?: OfferCampaignRow[] };
+  } catch (error) {
+    throw new OfferCampaignsUnavailableError(
+      `campaign-service /campaigns returned an unreadable body, so the campaigns selling offer ${offerId} are unknown: ${
+        (error as Error).message
+      }`,
+    );
+  }
+
+  if (!Array.isArray(data?.campaigns)) {
+    throw new OfferCampaignsUnavailableError(
+      `campaign-service /campaigns returned no campaigns array, so the campaigns selling offer ${offerId} are unknown`,
+    );
+  }
+
+  const ids = new Set<string>();
+  for (const row of data.campaigns) {
+    if (row?.id && row.offerId === offerId) ids.add(row.id);
+  }
+  return Array.from(ids).sort();
+}

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -10,6 +10,7 @@ import {
   type GlobalStatus,
 } from "../lib/email-gateway-client.js";
 import { resolveCampaignFamily } from "../lib/campaign-identity-client.js";
+import { resolveOfferCampaignIds, OfferCampaignsUnavailableError } from "../lib/offer-campaigns-client.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { buildFullLeadsBatch, type FullLead } from "../lib/lead-shape.js";
 import { streamBasicLeadChunks, toIsoTimestamp, type BasicLeadRow } from "../lib/basic-leads.js";
@@ -553,8 +554,9 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
       traceEvent(req.runId, { service: "lead-service", event: "leads-query-start", detail: `orgId=${req.orgId}` }, req.headers).catch(() => {});
     }
 
-    const { brandId, campaignId, orgId: queryOrgId, userId, workflowSlug } = req.query;
+    const { brandId, campaignId, offerId, orgId: queryOrgId, userId, workflowSlug } = req.query;
     const campaignIdStr = typeof campaignId === "string" ? campaignId : undefined;
+    const offerIdStr = typeof offerId === "string" ? offerId : undefined;
     const brandIdStr = typeof brandId === "string" ? brandId : undefined;
     const queryOrgIdStr = typeof queryOrgId === "string" ? queryOrgId : undefined;
     const userIdStr = typeof userId === "string" ? userId : undefined;
@@ -574,6 +576,48 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
       page = parseLeadListPage(req.query);
     } catch (error) {
       return res.status(400).json({ error: error instanceof Error ? error.message : String(error) });
+    }
+
+    // A campaign sells exactly ONE offer, so naming both an offer and a campaign states two
+    // narrowings where one already implies the other — either the campaign is in the offer (the
+    // offer adds nothing) or it is not (the pair matches nothing, and whichever the caller meant
+    // is unknowable). Refused rather than silently resolved one way.
+    if (offerIdStr && campaignIdStr) {
+      return res.status(400).json({
+        error:
+          "offerId and campaignId both narrow the read and a campaign already sells exactly one offer — pass one, not both",
+      });
+    }
+
+    // A lead's offer is the offer named by the campaign it was served under, and `campaign_id` on
+    // the membership row is that frozen attribution — so an offer scope resolves to the campaign
+    // ids selling it and rides the SAME campaign-id filter a campaign scope uses. FAIL LOUD: with
+    // campaign-service unreachable those ids are unknown, and dropping the filter would serve the
+    // whole BRAND under one offer's name, which is exactly the bug offer scope fixes.
+    let offerCampaignIds: string[] | null = null;
+    if (offerIdStr) {
+      try {
+        offerCampaignIds = await resolveOfferCampaignIds(offerIdStr, {
+          orgId: req.orgId!,
+          userId: req.userId ?? null,
+          runId: req.runId ?? null,
+          brandId: brandIdStr ?? null,
+        });
+      } catch (error) {
+        console.error(
+          `[lead-service] offer scope unresolved for offerId=${offerIdStr} orgId=${req.orgId} — ` +
+            `refusing the read rather than widening it to the brand: ${(error as Error).message}`,
+        );
+        return res.status(502).json({
+          error: error instanceof OfferCampaignsUnavailableError ? error.message : "campaign-service unavailable",
+        });
+      }
+
+      // No campaign sells this offer yet, so no lead has been served under it. That is a real,
+      // correct answer — and the one place a missing filter would otherwise become the brand.
+      if (offerCampaignIds.length === 0) {
+        return res.json({ leads: [], nextCursor: null });
+      }
     }
 
     // A campaign as the customer knows it is an IDENTITY (org, brand, sales funnel, acquisition
@@ -598,7 +642,8 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
       orgId: req.orgId!,
       brandId: brandIdStr,
       campaignId: campaignIdStr,
-      campaignIds: campaignFamily ?? undefined,
+      offerId: offerIdStr,
+      campaignIds: offerCampaignIds ?? campaignFamily ?? undefined,
       queryOrgId: queryOrgIdStr,
       userId: userIdStr,
       workflowSlug: workflowSlugStr,
@@ -610,10 +655,15 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
     const familySet =
       scopeCampaignIds && scopeCampaignIds.length > 1 ? new Set(scopeCampaignIds) : null;
 
-    const hasScopeForStatus = !!(campaignIdStr || brandIdStr);
+    const hasScopeForStatus = !!(campaignIdStr || brandIdStr || offerIdStr);
+    // Keyed on the resolved campaign ids, not on which param named them: a scope carrying ONE
+    // campaign row asks email-gateway in campaign mode, several take brand mode and read the
+    // per-campaign breakdown back out (aggregateFamilyScope). Identical to the previous
+    // `campaignIdStr` test for every campaign-scoped read — that param sets these ids — and it is
+    // what gives an offer's several campaigns the same widened engagement a campaign identity gets.
     const flatten = familySet
       ? (result: StatusResult) => flattenFamilyStatus(result, familySet)
-      : campaignIdStr
+      : scopeCampaignIds
         ? flattenCampaignStatus
         : flattenBrandStatus;
     const context = getServiceContext(req);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1651,6 +1651,26 @@ registry.registerPath({
     },
     {
       in: "query" as const,
+      name: "offerId",
+      required: false,
+      description:
+        "Restrict returned leads to ONE offer — brand-service's proposition level, between the " +
+        "brand and the campaign. A lead's offer is the offer named by the campaign it was served " +
+        "under: the membership row's `campaign_id` is a frozen attribution, and campaign-service " +
+        "records which offer each campaign sells, so this resolves to every campaign in the org " +
+        "naming that offer and filters on the same `campaign_id` a campaignId read filters on. " +
+        "Delivery status is offer-scoped (the union over those campaigns), the same way a " +
+        "campaign identity's is. " +
+        "MUTUALLY EXCLUSIVE with `campaignId` — a campaign already sells exactly one offer, so " +
+        "naming both is a 400 rather than one silently winning. " +
+        "An offer no campaign sells yet returns an empty list, never the brand's leads. " +
+        "If campaign-service cannot say which campaigns sell it, the read is refused with a 502 — " +
+        "never widened to the brand. " +
+        "When absent, behavior + response shape are unchanged.",
+      schema: { type: "string" as const },
+    },
+    {
+      in: "query" as const,
       name: "orgId",
       required: false,
       schema: { type: "string" as const },
@@ -1742,10 +1762,16 @@ registry.registerPath({
       content: { "application/json": { schema: LeadsResponseSchema } },
     },
     400: {
-      description: "Invalid `status`, `limit`, `cursor` or `offset` value",
+      description:
+        "Invalid `status`, `limit`, `cursor` or `offset` value, or `offerId` and `campaignId` both named",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
     401: { description: "Unauthorized" },
+    502: {
+      description:
+        "`offerId` was named and campaign-service could not say which campaigns sell it — the read is refused rather than widened to the brand",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
   },
 });
 

--- a/tests/unit/leads-offer-scope.test.ts
+++ b/tests/unit/leads-offer-scope.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// An OFFER is brand-service's proposition level, between the brand and the campaign. A brand
+// selling two offers must not show the same people under both — which is what the leads list did
+// while it could only narrow to a brand. A lead's offer is the offer named by the campaign it was
+// served under: `leads_campaigns.campaign_id` is the frozen attribution, campaign-service records
+// each campaign's offer, so an offer scope resolves to campaign ids and rides the campaign-id
+// filter that already exists.
+
+let capturedSqlValues: unknown[] = [];
+let mockRows: Array<Record<string, unknown>> = [];
+let mockSqlChunkIndex = 0;
+
+vi.mock("../../src/db/index.js", () => ({
+  sql: (_strings: readonly string[], ...values: unknown[]) => {
+    capturedSqlValues.push(...values);
+    return {
+      then: (resolve: (rows: unknown[]) => void) => {
+        const start = mockSqlChunkIndex * 500;
+        mockSqlChunkIndex += 1;
+        return Promise.resolve(mockRows.slice(start, start + 500)).then(resolve);
+      },
+      // The slim (`?view=basic`) path streams through a server-side cursor.
+      cursor: (size: number) => ({
+        async *[Symbol.asyncIterator]() {
+          for (let i = 0; i < mockRows.length; i += size) yield mockRows.slice(i, i + size);
+        },
+      }),
+    };
+  },
+}));
+
+vi.mock("../../src/lib/lead-shape.js", () => ({
+  buildFullLeadsBatch: (ids: string[]) =>
+    Promise.resolve(
+      new Map(
+        ids.map((id) => [
+          id,
+          {
+            leadId: id,
+            contacts: [{ channel: "email", value: `${id}@example.com`, status: "valid", source: "apollo" }],
+          },
+        ]),
+      ),
+    ),
+}));
+
+const checkDeliveryStatusMock = vi.fn();
+vi.mock("../../src/lib/email-gateway-client.js", () => ({
+  checkDeliveryStatus: (...args: unknown[]) => checkDeliveryStatusMock(...args),
+}));
+
+const resolveCampaignFamilyMock = vi.fn();
+vi.mock("../../src/lib/campaign-identity-client.js", () => ({
+  resolveCampaignFamily: (...args: unknown[]) => resolveCampaignFamilyMock(...args),
+}));
+
+const resolveOfferCampaignIdsMock = vi.fn();
+class OfferCampaignsUnavailableError extends Error {}
+vi.mock("../../src/lib/offer-campaigns-client.js", () => ({
+  resolveOfferCampaignIds: (...args: unknown[]) => resolveOfferCampaignIdsMock(...args),
+  OfferCampaignsUnavailableError,
+}));
+
+vi.mock("../../src/lib/audience-client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/lib/audience-client.js")>()),
+  resolveAudiencesForBrand: () => Promise.resolve({ byAudienceId: {}, byEmail: {} }),
+}));
+
+vi.mock("../../src/lib/trace-event.js", () => ({
+  traceEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/config.js", () => ({
+  LEAD_SERVICE_API_KEY: "test-api-key",
+}));
+
+const ORG = "30000000-0000-0000-0000-000000000001";
+const BRAND = "75d7e3e8-6926-4f85-a557-976895400666";
+const OFFER = "0ffe0000-0000-4000-8000-000000000001";
+const OFFER_CAMPAIGN_A = "aaaaaaaa-1111-4111-8111-111111111111";
+const OFFER_CAMPAIGN_B = "bbbbbbbb-2222-4222-8222-222222222222";
+const SOME_CAMPAIGN = "cccccccc-3333-4333-8333-333333333333";
+
+function rawRow(i: number, campaignId: string) {
+  return {
+    id: `lc-${i}`,
+    lead_id: `lead-${i}`,
+    campaign_id: campaignId,
+    org_id: ORG,
+    user_id: null,
+    brand_ids: [BRAND],
+    status: "served",
+    status_reason: null,
+    status_details: null,
+    parent_run_id: null,
+    run_id: null,
+    served_at: "2026-01-01T00:00:00.000Z",
+    workflow_slug: null,
+    feature_slug: null,
+    goal: null,
+    active_goal_id: null,
+    brand_profile_id: null,
+    audience_id: null,
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    lead_apollo_person_id: null,
+  };
+}
+
+/** Brand-mode answer: evidence keyed on the campaign that actually sent the email. */
+function brandModeResult(email: string, campaignId: string) {
+  return {
+    email,
+    broadcast: {
+      byCampaign: {
+        [campaignId]: {
+          contacted: true, sent: true, delivered: true, opened: true, clicked: true,
+          replied: true, replyClassification: "positive", bounced: false, unsubscribed: false,
+          sentCount: 2, lastDeliveredAt: "2026-02-01T00:00:00.000Z",
+          firstContactedAt: "2026-01-02T00:00:00.000Z", firstSentAt: "2026-01-02T00:00:00.000Z",
+          firstDeliveredAt: "2026-01-02T00:00:00.000Z", firstOpenedAt: "2026-01-03T00:00:00.000Z",
+          firstClickedAt: "2026-01-04T00:00:00.000Z", firstRepliedAt: "2026-01-05T00:00:00.000Z",
+          firstBouncedAt: null, firstUnsubscribedAt: null,
+        },
+      },
+      campaign: null,
+      brand: null,
+      global: { email: { bounced: false, unsubscribed: false } },
+    },
+  };
+}
+
+async function buildApp() {
+  const { default: route } = await import("../../src/routes/leads.js");
+  const app = express();
+  app.use(express.json());
+  app.use(route);
+  return app;
+}
+
+function get(app: express.Express, query: string) {
+  return request(app).get(`/orgs/leads?${query}`).set("x-api-key", "test-api-key").set("x-org-id", ORG);
+}
+
+describe("GET /orgs/leads offer scope", () => {
+  let app: express.Express;
+
+  beforeAll(async () => {
+    app = await buildApp();
+  }, 30_000);
+
+  beforeEach(() => {
+    capturedSqlValues = [];
+    mockRows = [];
+    mockSqlChunkIndex = 0;
+    checkDeliveryStatusMock.mockReset();
+    checkDeliveryStatusMock.mockResolvedValue({ results: [] });
+    resolveCampaignFamilyMock.mockReset();
+    resolveOfferCampaignIdsMock.mockReset();
+  });
+
+  // AC1 — narrowed to an offer, the list returns that offer's leads.
+  it("filters on every campaign that sells the offer", async () => {
+    resolveOfferCampaignIdsMock.mockResolvedValue([OFFER_CAMPAIGN_A, OFFER_CAMPAIGN_B]);
+    mockRows = [rawRow(1, OFFER_CAMPAIGN_A)];
+
+    const res = await get(app, `brandId=${BRAND}&offerId=${OFFER}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leads).toHaveLength(1);
+    expect(res.body.leads[0].campaignId).toBe(OFFER_CAMPAIGN_A);
+    // The offer's campaign ids are what the query binds — the frozen `campaign_id` filter, not a
+    // second parallel one.
+    expect(capturedSqlValues).toContainEqual([OFFER_CAMPAIGN_A, OFFER_CAMPAIGN_B]);
+    expect(resolveOfferCampaignIdsMock).toHaveBeenCalledWith(
+      OFFER,
+      expect.objectContaining({ orgId: ORG, brandId: BRAND }),
+    );
+  });
+
+  it("works with no brand named — the offer is narrowing enough on its own", async () => {
+    resolveOfferCampaignIdsMock.mockResolvedValue([OFFER_CAMPAIGN_A]);
+    mockRows = [rawRow(1, OFFER_CAMPAIGN_A)];
+
+    const res = await get(app, `offerId=${OFFER}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leads).toHaveLength(1);
+    expect(capturedSqlValues).toContainEqual([OFFER_CAMPAIGN_A]);
+  });
+
+  it("carries the offer's engagement — a lead served under one of its campaigns reads as contacted", async () => {
+    resolveOfferCampaignIdsMock.mockResolvedValue([OFFER_CAMPAIGN_A, OFFER_CAMPAIGN_B]);
+    mockRows = [rawRow(1, OFFER_CAMPAIGN_A)];
+    checkDeliveryStatusMock.mockResolvedValue({
+      results: [brandModeResult("lead-1@example.com", OFFER_CAMPAIGN_A)],
+    });
+
+    const res = await get(app, `brandId=${BRAND}&offerId=${OFFER}`);
+
+    // Several campaigns => brand mode on the wire, read back per-campaign.
+    expect(checkDeliveryStatusMock.mock.calls[0][1]).toBeUndefined();
+    const lead = res.body.leads[0];
+    expect(lead.contacted).toBe(true);
+    expect(lead.replied).toBe(true);
+    expect(lead.sentCount).toBe(2);
+  });
+
+  it("counts NO evidence from a campaign outside the offer — never a brand-wide answer", async () => {
+    resolveOfferCampaignIdsMock.mockResolvedValue([OFFER_CAMPAIGN_A, OFFER_CAMPAIGN_B]);
+    mockRows = [rawRow(1, OFFER_CAMPAIGN_A)];
+    checkDeliveryStatusMock.mockResolvedValue({
+      results: [brandModeResult("lead-1@example.com", SOME_CAMPAIGN)],
+    });
+
+    const res = await get(app, `brandId=${BRAND}&offerId=${OFFER}`);
+
+    const lead = res.body.leads[0];
+    expect(lead.contacted).toBe(false);
+    expect(lead.sentCount).toBe(0);
+  });
+
+  it("composes with the status filter and the slim projection", async () => {
+    resolveOfferCampaignIdsMock.mockResolvedValue([OFFER_CAMPAIGN_A]);
+    mockRows = [
+      {
+        ...rawRow(1, OFFER_CAMPAIGN_A),
+        created_at_cursor: "2026-01-01 00:00:00.000000+00",
+        email_value: "lead-1@example.com",
+        email_status: "valid",
+      },
+    ];
+
+    const res = await get(app, `brandId=${BRAND}&offerId=${OFFER}&status=served&view=basic`);
+
+    expect(res.status).toBe(200);
+    expect(capturedSqlValues).toContainEqual([OFFER_CAMPAIGN_A]);
+    expect(capturedSqlValues).toContainEqual(["served"]);
+  });
+
+  // AC2 — absent, the read is exactly what it is today.
+  it("is inert when absent: no offer resolution, brand scope unchanged", async () => {
+    mockRows = [rawRow(1, SOME_CAMPAIGN)];
+
+    const res = await get(app, `brandId=${BRAND}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leads).toHaveLength(1);
+    expect(resolveOfferCampaignIdsMock).not.toHaveBeenCalled();
+    // No campaign-id array bound, and brand-mode delivery status as before.
+    expect(capturedSqlValues).toContainEqual(BRAND);
+    expect(checkDeliveryStatusMock.mock.calls[0]?.[1]).toBeUndefined();
+  });
+
+  it("leaves a campaign-scoped read untouched", async () => {
+    resolveCampaignFamilyMock.mockResolvedValue([SOME_CAMPAIGN]);
+    mockRows = [rawRow(1, SOME_CAMPAIGN)];
+
+    const res = await get(app, `brandId=${BRAND}&campaignId=${SOME_CAMPAIGN}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leads).toHaveLength(1);
+    expect(resolveOfferCampaignIdsMock).not.toHaveBeenCalled();
+    // A single stored campaign still asks email-gateway in campaign mode.
+    expect(checkDeliveryStatusMock.mock.calls[0][1]).toBe(SOME_CAMPAIGN);
+  });
+
+  // AC3 — a contradictory request is refused.
+  it("400s when an offer and a campaign are both named", async () => {
+    const res = await get(app, `brandId=${BRAND}&offerId=${OFFER}&campaignId=${SOME_CAMPAIGN}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/offerId and campaignId/);
+    expect(resolveOfferCampaignIdsMock).not.toHaveBeenCalled();
+    expect(resolveCampaignFamilyMock).not.toHaveBeenCalled();
+  });
+
+  // No silent fallback in either direction.
+  it("returns an empty list — never the brand's leads — for an offer no campaign sells", async () => {
+    resolveOfferCampaignIdsMock.mockResolvedValue([]);
+    mockRows = [rawRow(1, SOME_CAMPAIGN)];
+
+    const res = await get(app, `brandId=${BRAND}&offerId=${OFFER}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ leads: [], nextCursor: null });
+  });
+
+  it("502s rather than widening to the brand when the offer cannot be resolved", async () => {
+    resolveOfferCampaignIdsMock.mockRejectedValue(
+      new OfferCampaignsUnavailableError("campaign-service is unreachable"),
+    );
+    mockRows = [rawRow(1, SOME_CAMPAIGN)];
+
+    const res = await get(app, `brandId=${BRAND}&offerId=${OFFER}`);
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toMatch(/campaign-service/);
+    expect(res.body.leads).toBeUndefined();
+  });
+});

--- a/tests/unit/offer-campaigns-client.test.ts
+++ b/tests/unit/offer-campaigns-client.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../src/config.js", () => ({
+  CAMPAIGN_SERVICE_URL: "https://campaign.test",
+  CAMPAIGN_SERVICE_API_KEY: "test-campaign-key",
+}));
+
+const ORG = "30000000-0000-0000-0000-000000000001";
+const BRAND = "75d7e3e8-6926-4f85-a557-976895400666";
+const OFFER = "0ffe0000-0000-4000-8000-000000000001";
+const OTHER_OFFER = "0ffe0000-0000-4000-8000-000000000002";
+
+function campaign(id: string, offerId: string | null) {
+  return { id, orgId: ORG, brandId: BRAND, offerId };
+}
+
+describe("resolveOfferCampaignIds", () => {
+  const fetchSpy = vi.fn();
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns every campaign in the org that names the offer, ascending", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        campaigns: [
+          campaign("c-live", OFFER),
+          campaign("a-stopped", OFFER),
+          campaign("b-other-offer", OTHER_OFFER),
+        ],
+      }),
+    });
+
+    const { resolveOfferCampaignIds } = await import("../../src/lib/offer-campaigns-client.js");
+    const ids = await resolveOfferCampaignIds(OFFER, { orgId: ORG, brandId: BRAND });
+
+    expect(ids).toEqual(["a-stopped", "c-live"]);
+  });
+
+  it("never adopts a campaign that states no offer", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ campaigns: [campaign("c-1", OFFER), campaign("c-2", null)] }),
+    });
+
+    const { resolveOfferCampaignIds } = await import("../../src/lib/offer-campaigns-client.js");
+    expect(await resolveOfferCampaignIds(OFFER, { orgId: ORG })).toEqual(["c-1"]);
+  });
+
+  it("reads the whole org list — a bound would silently drop the offer's stopped campaigns", async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true, json: async () => ({ campaigns: [] }) });
+
+    const { resolveOfferCampaignIds } = await import("../../src/lib/offer-campaigns-client.js");
+    await resolveOfferCampaignIds(OFFER, { orgId: ORG, userId: "u-1", runId: "r-1", brandId: BRAND });
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://campaign.test/campaigns");
+    expect(url).not.toContain("limit");
+    expect(init.headers["x-org-id"]).toBe(ORG);
+    expect(init.headers["X-API-Key"]).toBe("test-campaign-key");
+    expect(init.headers["x-brand-id"]).toBe(BRAND);
+  });
+
+  it("an offer no campaign sells is an EMPTY answer, not a failure", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ campaigns: [campaign("c-1", OTHER_OFFER)] }),
+    });
+
+    const { resolveOfferCampaignIds } = await import("../../src/lib/offer-campaigns-client.js");
+    expect(await resolveOfferCampaignIds(OFFER, { orgId: ORG })).toEqual([]);
+  });
+
+  it("throws rather than falling back when campaign-service answers with an error", async () => {
+    fetchSpy.mockResolvedValue({ ok: false, status: 503, text: async () => "down" });
+
+    const { resolveOfferCampaignIds, OfferCampaignsUnavailableError } = await import(
+      "../../src/lib/offer-campaigns-client.js"
+    );
+    await expect(resolveOfferCampaignIds(OFFER, { orgId: ORG })).rejects.toBeInstanceOf(
+      OfferCampaignsUnavailableError,
+    );
+  });
+
+  it("throws when campaign-service is unreachable", async () => {
+    fetchSpy.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const { resolveOfferCampaignIds, OfferCampaignsUnavailableError } = await import(
+      "../../src/lib/offer-campaigns-client.js"
+    );
+    await expect(resolveOfferCampaignIds(OFFER, { orgId: ORG })).rejects.toBeInstanceOf(
+      OfferCampaignsUnavailableError,
+    );
+  });
+
+  it("throws on a body carrying no campaigns array — an unreadable answer is not an empty offer", async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+    const { resolveOfferCampaignIds, OfferCampaignsUnavailableError } = await import(
+      "../../src/lib/offer-campaigns-client.js"
+    );
+    await expect(resolveOfferCampaignIds(OFFER, { orgId: ORG })).rejects.toBeInstanceOf(
+      OfferCampaignsUnavailableError,
+    );
+  });
+});


### PR DESCRIPTION
## What

The leads list can be narrowed to one **offer**: `GET /orgs/leads?offerId=<uuid>`.

## Why

The dashboard now has an offer-level Leads page, and it listed the **brand's** leads. A brand with two offers showed the same people under both — and the money and audiences rendered beside those rows were already offer-scoped, so the page contradicted itself: offer-scoped figures above a brand-wide list.

## How a lead's offer is resolved

**A lead's offer is the offer named by the campaign it was served under.**

Nothing new is stored, and nothing needs to be. A lead is served under a campaign, this service already froze that attribution on its own membership rows, and a campaign now names the offer it sells. So an offer resolves to the campaigns selling it, and the read filters on the **same `campaign_id` a campaign-scoped read already filters on**.

That is what survives a campaign being reconfigured later — which is the whole reason the frozen attribution exists. **No migration, no second source of truth, no query-builder change.**

Strict equality on the campaign's own offer: never inferred from a sibling, a funnel or a brand.

## Verified against production before choosing it

145 stopped campaigns carry no offer, which raised a real risk: a campaign read widens to its whole identity, so if an offer-less campaign shared an identity with an offer-carrying one, the offer page would under-count against its own campaign pages.

Checked in `campaign_service`: **zero** such identities exist. Strict equality neither under-counts nor over-attributes. The assumption and the date of the check are in the client's docblock — if campaign-service ever leaves a member of an offer-carrying identity without an `offerId`, that is what breaks.

## The contradictory and the unresolvable both refuse

| Request | Answer |
|---|---|
| `offerId` + `campaignId` | **400** — a campaign already sells exactly one offer, so the pair is contradictory rather than one silently winning |
| an offer no campaign sells | **200 `{leads: [], nextCursor: null}`** — never the brand's leads, which is the bug this fixes |
| campaign-service unable to answer | **502** — the read is refused, never widened |

## Purely additive

Absent, everything is byte-identical to today: no campaign-service call, no extra bind, same payload, same brand-mode delivery overlay. Two tests pin that.

Delivery status under an offer is the union over its campaigns — the same mechanism a multi-row campaign identity already uses. Composes with `brandId`, `status`, `workflowSlug`, `view=basic`, `limit`/`cursor`/`offset`.

## Verified

`tsc --noEmit` clean (raw, not the wrapper's parse) · build succeeds, openapi regenerated · **423 tests across 51 files** — all 406 pre-existing untouched and passing, +17 new.

## Note

The offer read fetches the org's campaign list per request, which is what campaign-identity resolution already does on every campaign-scoped read — no new class of load. If campaign-service ever exposes an `offerId` filter, this becomes a one-line narrowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
