### PR TITLE
feat(leads): a lead row names the offer it belongs to

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1267,6 +1267,28 @@
             "description": "Explicit brand profile ID stored on the leads_campaigns row. null means unattributed.",
             "example": "brand_profile_123"
           },
+          "offer": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Offer UUID (brand-service offer.offerId).",
+                "example": "0ffe0000-0000-4000-8000-000000000001"
+              },
+              "name": {
+                "type": "string",
+                "nullable": true,
+                "description": "Offer display name, from brand-service. null when the campaign names an offer brand-service does not list back (a deleted offer, or a brand that could not be reached) — the id is still true, so it is stated rather than dropping the offer.",
+                "example": "Fractional CFO retainer"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ],
+            "description": "The OFFER this lead belongs to — brand-service's proposition level, between the brand and the campaign. Resolved server-side as the offer named by the campaign the lead was served under (`campaignId` above, the attribution frozen on the leads_campaigns row), with its name read from brand-service. null when that campaign names no offer, and also when the resolution was unavailable (logged loudly server-side) — never inferred from the lead's brand, its funnel or a sibling campaign. Present on every lead in both views."
+          },
           "audienceId": {
             "type": "string",
             "nullable": true,
@@ -1477,6 +1499,7 @@
           "userId",
           "workflowSlug",
           "featureSlug",
+          "offer",
           "audience",
           "servedAt",
           "apolloPersonId",

--- a/src/lib/offer-card-client.ts
+++ b/src/lib/offer-card-client.ts
@@ -1,0 +1,244 @@
+/**
+ * Name, for a set of lead rows, the OFFER each one belongs to — brand-service's proposition level,
+ * which sits between the brand and the campaign (Org > Brand > Offer > Campaign).
+ *
+ * lead-service defines NONE of an offer's semantics and holds no offer column. The resolution is
+ * the one offer scope already established next door (offer-campaigns-client.ts), read in the other
+ * direction:
+ *
+ *     a lead's offer = the offer named by the campaign the lead was served under.
+ *
+ * `leads_campaigns.campaign_id` is that attribution, frozen at serve time, and campaign-service
+ * records each campaign's offer (`campaigns.offer_id`). So a row's offer follows from a column the
+ * row already carries — never re-derived from its brand, its funnel, or a sibling campaign, and
+ * unaffected by the campaign being reconfigured afterwards, which is why the attribution was frozen
+ * in the first place. The offer's NAME is brand-service's (`/internal/brands/{brandId}/offers`);
+ * nothing is invented or cached here.
+ *
+ * PER REQUEST, NEVER PER ROW. A brand's leads list reaches tens of thousands of rows and is polled
+ * every 30 seconds, so a lookup per row (or even per chunk) would be the whole cost of the feature.
+ * Both reads are therefore memoized on this resolver, which the route builds once per request:
+ *
+ *   - ONE campaign-service `/campaigns` read for the org, whatever the row count. It answers
+ *     campaign -> offer for every campaign in the org at once, exactly as the offer FILTER's read
+ *     does, so a hundred chunks share one call.
+ *   - ONE brand-service offers read per BRAND actually seen, and only for brands whose campaigns
+ *     name an offer. A brand-scoped list — what the dashboard reads — is one call; an org-wide
+ *     staff read is one per brand it actually returned rows for, not one per row.
+ *
+ * FAIL-SOFT, with a loud log, like the campaign IDENTITY resolver and unlike the offer FILTER.
+ * The distinction is what the failure DOES. The filter decides which rows come back, so failing it
+ * open would serve the whole brand's people under one offer's name — wrong data, so it 502s. This
+ * decides what one DISPLAY field on a row says; unresolved, the field is absent and the row still
+ * carries the `campaignId` the offer is derived from. Degraded, never wrong — and a read that works
+ * today must not start failing because a field was added to it.
+ *
+ * So `offer` is null when the campaign names no offer AND when we could not ask, the second always
+ * accompanied by a `console.error`. It is NEVER a guess: no brand, no funnel and no sibling
+ * campaign is ever substituted for an offer the campaign did not itself name.
+ */
+import {
+  BRAND_SERVICE_URL,
+  BRAND_SERVICE_API_KEY,
+  CAMPAIGN_SERVICE_URL,
+  CAMPAIGN_SERVICE_API_KEY,
+} from "../config.js";
+import { fetchWithRetry } from "./fetch-retry.js";
+
+/**
+ * The offer a lead belongs to, as a row states it.
+ *
+ * `name` is null when campaign-service names an offer that brand-service does not list back — a
+ * deleted offer, or a brand we could not reach. The id is still true, so it is stated rather than
+ * collapsing the whole card to null, which would say "this lead belongs to no offer".
+ */
+export interface OfferCard {
+  id: string;
+  name: string | null;
+}
+
+export interface OfferResolveContext {
+  orgId: string;
+  userId?: string | null;
+  runId?: string | null;
+  brandId?: string | null;
+}
+
+/** What campaign-service says about one campaign, trimmed to what naming an offer needs. */
+interface CampaignOffer {
+  offerId: string;
+  /** The brand whose offer catalogue names it. null when the campaign states no brand. */
+  brandId: string | null;
+}
+
+function serviceHeaders(apiKey: string, ctx: OfferResolveContext): Record<string, string> {
+  const headers: Record<string, string> = {
+    "X-API-Key": apiKey,
+    "x-org-id": ctx.orgId,
+  };
+  if (ctx.userId) headers["x-user-id"] = ctx.userId;
+  if (ctx.runId) headers["x-run-id"] = ctx.runId;
+  if (ctx.brandId) headers["x-brand-id"] = ctx.brandId;
+  return headers;
+}
+
+interface RawCampaign {
+  id?: string;
+  offerId?: string | null;
+  brandIds?: string[] | null;
+}
+
+/**
+ * campaign -> offer for the whole org, in ONE read.
+ *
+ * No `limit`: campaign-service returns every match when none is named, and a bounded read would
+ * silently leave the org's older campaigns — the stopped rows that hold most of a brand's serve
+ * history — unable to name their offer.
+ */
+async function fetchOrgCampaignOffers(
+  ctx: OfferResolveContext,
+): Promise<Map<string, CampaignOffer>> {
+  const response = await fetchWithRetry(`${CAMPAIGN_SERVICE_URL}/campaigns`, {
+    method: "GET",
+    headers: serviceHeaders(CAMPAIGN_SERVICE_API_KEY, ctx),
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `campaign-service /campaigns failed (${response.status}): ${await response.text().catch(() => "")}`,
+    );
+  }
+
+  const data = (await response.json()) as { campaigns?: RawCampaign[] };
+  if (!Array.isArray(data?.campaigns)) {
+    throw new Error("campaign-service /campaigns returned no campaigns array");
+  }
+
+  const byCampaignId = new Map<string, CampaignOffer>();
+  for (const row of data.campaigns) {
+    // A campaign that states no offer belongs to no offer. Strict — never inferred from a sibling.
+    if (!row?.id || !row.offerId) continue;
+    byCampaignId.set(row.id, { offerId: row.offerId, brandId: row.brandIds?.[0] ?? null });
+  }
+  return byCampaignId;
+}
+
+/** offer -> name for one brand's catalogue. */
+async function fetchBrandOfferNames(
+  brandId: string,
+  ctx: OfferResolveContext,
+): Promise<Map<string, string>> {
+  const response = await fetchWithRetry(
+    `${BRAND_SERVICE_URL}/internal/brands/${brandId}/offers`,
+    {
+      method: "GET",
+      headers: serviceHeaders(BRAND_SERVICE_API_KEY, ctx),
+      signal: AbortSignal.timeout(30_000),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `brand-service /internal/brands/${brandId}/offers failed (${response.status}): ${
+        await response.text().catch(() => "")
+      }`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    offers?: Array<{ offerId?: string; name?: string }>;
+  };
+  if (!Array.isArray(data?.offers)) {
+    throw new Error(`brand-service offers read for brand ${brandId} returned no offers array`);
+  }
+
+  const names = new Map<string, string>();
+  for (const offer of data.offers) {
+    if (offer?.offerId && typeof offer.name === "string") names.set(offer.offerId, offer.name);
+  }
+  return names;
+}
+
+export interface OfferCardResolver {
+  /**
+   * The offer card for each of `campaignIds` that names one. A campaign absent from the result
+   * names no offer we can state; the caller renders that as `offer: null`.
+   *
+   * Safe to call once per chunk: the org's campaign -> offer read and each brand's offer catalogue
+   * are fetched at most once for the lifetime of this resolver, so a second call over a second
+   * chunk costs no network at all.
+   */
+  resolve(campaignIds: string[]): Promise<Map<string, OfferCard>>;
+}
+
+export function createOfferCardResolver(ctx: OfferResolveContext): OfferCardResolver {
+  // Memoized PROMISES, not values: two chunks resolving concurrently share the one in-flight read
+  // rather than racing into a second. Each failure is absorbed here, so it is logged once per
+  // request and every later chunk gets the same (empty) answer instead of retrying the outage.
+  let campaignOffers: Promise<Map<string, CampaignOffer>> | null = null;
+  const offerNamesByBrand = new Map<string, Promise<Map<string, string>>>();
+
+  function campaignOffersOnce(): Promise<Map<string, CampaignOffer>> {
+    if (!campaignOffers) {
+      campaignOffers = fetchOrgCampaignOffers(ctx).catch((error: Error) => {
+        console.error(
+          `[lead-service] offer unresolved for orgId=${ctx.orgId} — campaign-service could not say ` +
+            `which offer each campaign sells, so leads carry no offer on this read (their campaignId ` +
+            `is unchanged): ${error.message}`,
+        );
+        return new Map<string, CampaignOffer>();
+      });
+    }
+    return campaignOffers;
+  }
+
+  function offerNamesOnce(brandId: string): Promise<Map<string, string>> {
+    let names = offerNamesByBrand.get(brandId);
+    if (!names) {
+      names = fetchBrandOfferNames(brandId, ctx).catch((error: Error) => {
+        console.error(
+          `[lead-service] offer names unresolved for brandId=${brandId} orgId=${ctx.orgId} — ` +
+            `leads carry their offer id with no name on this read: ${error.message}`,
+        );
+        return new Map<string, string>();
+      });
+      offerNamesByBrand.set(brandId, names);
+    }
+    return names;
+  }
+
+  return {
+    async resolve(campaignIds: string[]): Promise<Map<string, OfferCard>> {
+      const cards = new Map<string, OfferCard>();
+      if (campaignIds.length === 0) return cards;
+
+      const byCampaignId = await campaignOffersOnce();
+
+      // Only the brands this chunk's campaigns actually name — an org-wide read never asks for a
+      // brand it returned no rows for.
+      const wanted = new Map<string, CampaignOffer>();
+      const brandIds = new Set<string>();
+      for (const campaignId of new Set(campaignIds)) {
+        const offer = byCampaignId.get(campaignId);
+        if (!offer) continue;
+        wanted.set(campaignId, offer);
+        if (offer.brandId) brandIds.add(offer.brandId);
+      }
+      if (wanted.size === 0) return cards;
+
+      const namesByBrand = new Map<string, Map<string, string>>();
+      await Promise.all(
+        Array.from(brandIds).map(async (brandId) => {
+          namesByBrand.set(brandId, await offerNamesOnce(brandId));
+        }),
+      );
+
+      for (const [campaignId, offer] of wanted) {
+        const name = offer.brandId ? namesByBrand.get(offer.brandId)?.get(offer.offerId) : undefined;
+        cards.set(campaignId, { id: offer.offerId, name: name ?? null });
+      }
+      return cards;
+    },
+  };
+}

--- a/src/routes/leads.ts
+++ b/src/routes/leads.ts
@@ -27,6 +27,7 @@ import {
   type LeadListScope,
 } from "../lib/lead-list-query.js";
 import { resolveAudiencesForBrand, type AudienceCard, type AudienceResolveContext } from "../lib/audience-client.js";
+import { createOfferCardResolver, type OfferCard } from "../lib/offer-card-client.js";
 
 const router = Router();
 
@@ -497,6 +498,7 @@ function serializeLeadItem(
   fullLead: FullLead | null,
   email: { value: string; status: string | null } | null,
   audience: AudienceCard | null,
+  offer: OfferCard | null,
   deliveryStatus: FlattenedStatus,
 ) {
   return {
@@ -516,6 +518,10 @@ function serializeLeadItem(
     goal: row.goal ?? null,
     activeGoalId: row.activeGoalId ?? null,
     brandProfileId: row.brandProfileId ?? null,
+    // The offer this lead belongs to: the offer named by the campaign it was served under, i.e. by
+    // the `campaignId` above. null when that campaign names none — or when it could not be asked,
+    // which is loud in the logs (see offer-card-client.ts). Never inferred from the brand.
+    offer: offer ?? null,
     audienceId: row.audienceId ?? null,
     audience: audience ?? null,
     servedAt: row.servedAt,
@@ -672,6 +678,15 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
       userId: req.userId ?? null,
       runId: req.runId ?? null,
     };
+    // ONE resolver for the whole response, built before the walk: the campaign -> offer read is
+    // org-wide and each brand's offer catalogue is read once, so naming the offer on fifty thousand
+    // rows costs the same two calls as naming it on one. Never constructed inside the chunk loop.
+    const offerResolver = createOfferCardResolver({
+      orgId: req.orgId!,
+      userId: req.userId ?? null,
+      runId: req.runId ?? null,
+      brandId: brandIdStr ?? null,
+    });
     // `?view=basic` => slim per-lead payload. Anything else (incl. absent) => full
     // FullLead, the existing default. No Zod default: a missing param is full.
     const slim = req.query.view === "basic";
@@ -707,6 +722,8 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
           audienceCtx,
         );
 
+        const offerMap = await offerResolver.resolve(basicRows.map((r) => r.campaignId));
+
         for (const r of basicRows) {
           const emailValue = r.email?.value ?? "";
           const emailStatus = r.email?.status ?? null;
@@ -735,6 +752,9 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
             goal: r.goal ?? null,
             activeGoalId: r.activeGoalId ?? null,
             brandProfileId: r.brandProfileId ?? null,
+            // Same field, same meaning, same resolver as the full path — a panel rendered from a
+            // slim row must not be missing the offer the full row names.
+            offer: offerMap.get(r.campaignId) ?? null,
             audienceId: r.audienceId ?? null,
             audience: audienceMap.get(r.leadId) ?? null,
             servedAt: r.servedAt,
@@ -799,6 +819,8 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
         audienceCtx,
       );
 
+      const offerMap = await offerResolver.resolve(chunkRows.map((row) => row.campaignId));
+
       // Delivery-status overlay, scoped to this chunk's served rows only.
       const statusMap = new Map<string, StatusResult>();
       if (hasScopeForStatus) {
@@ -835,6 +857,7 @@ router.get("/orgs/leads", apiKeyAuth, requireOrgId, async (req: AuthenticatedReq
           fullLead,
           email,
           audienceMap.get(row.leadId) ?? null,
+          offerMap.get(row.campaignId) ?? null,
           deliveryStatus,
         );
 
@@ -940,6 +963,15 @@ router.get("/orgs/leads/:id", apiKeyAuth, requireOrgId, async (req: Authenticate
       { orgId: req.orgId!, userId: req.userId ?? null, runId: req.runId ?? null },
     );
 
+    // One row, so the resolver's memoization buys nothing here — it exists so this route emits the
+    // same offer, resolved the same way, as the list element for the same row.
+    const offerMap = await createOfferCardResolver({
+      orgId: req.orgId!,
+      userId: req.userId ?? null,
+      runId: req.runId ?? null,
+      brandId: brandIdStr ?? null,
+    }).resolve([row.campaignId]);
+
     // Same rule as the list: evidence is only fetched for a served row in a named scope, so an
     // unserved row (or an unscoped read) carries the same all-false overlay it does there.
     let deliveryStatus: FlattenedStatus = DEFAULT_STATUS;
@@ -955,7 +987,14 @@ router.get("/orgs/leads/:id", apiKeyAuth, requireOrgId, async (req: Authenticate
     }
 
     return res.json({
-      leadDetail: serializeLeadItem(row, fullLead, email, audienceMap.get(row.leadId) ?? null, deliveryStatus),
+      leadDetail: serializeLeadItem(
+        row,
+        fullLead,
+        email,
+        audienceMap.get(row.leadId) ?? null,
+        offerMap.get(row.campaignId) ?? null,
+        deliveryStatus,
+      ),
     });
   } catch (error) {
     console.error("[lead-service] Lead detail error:", error);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1274,6 +1274,35 @@ const LeadDetailSchema = z
         description: "Explicit brand profile ID stored on the leads_campaigns row. null means unattributed.",
         example: "brand_profile_123",
       }),
+    offer: z
+      .object({
+        id: z
+          .string()
+          .openapi({
+            description: "Offer UUID (brand-service offer.offerId).",
+            example: "0ffe0000-0000-4000-8000-000000000001",
+          }),
+        name: z
+          .string()
+          .nullable()
+          .openapi({
+            description:
+              "Offer display name, from brand-service. null when the campaign names an offer " +
+              "brand-service does not list back (a deleted offer, or a brand that could not be " +
+              "reached) — the id is still true, so it is stated rather than dropping the offer.",
+            example: "Fractional CFO retainer",
+          }),
+      })
+      .nullable()
+      .openapi({
+        description:
+          "The OFFER this lead belongs to — brand-service's proposition level, between the brand " +
+          "and the campaign. Resolved server-side as the offer named by the campaign the lead was " +
+          "served under (`campaignId` above, the attribution frozen on the leads_campaigns row), " +
+          "with its name read from brand-service. null when that campaign names no offer, and also " +
+          "when the resolution was unavailable (logged loudly server-side) — never inferred from " +
+          "the lead's brand, its funnel or a sibling campaign. Present on every lead in both views.",
+      }),
     audienceId: z
       .string()
       .nullable()

--- a/tests/unit/leads-detail-route.test.ts
+++ b/tests/unit/leads-detail-route.test.ts
@@ -222,7 +222,7 @@ describe("GET /orgs/leads/:id — one lead's full record", () => {
         "brandProfileId", "campaignId", "clicked", "contacted", "delivered", "email", "emailStatus",
         "featureSlug", "firstBouncedAt", "firstClickedAt", "firstContactedAt", "firstDeliveredAt",
         "firstOpenedAt", "firstRepliedAt", "firstSentAt", "firstUnsubscribedAt", "global", "goal",
-        "id", "lastDeliveredAt", "lead", "leadId", "namespace", "opened", "orgId", "parentRunId",
+        "id", "lastDeliveredAt", "lead", "leadId", "namespace", "offer", "opened", "orgId", "parentRunId",
         "replied", "replyClassification", "runId", "sent", "sentCount", "servedAt", "status",
         "statusDetails", "statusReason", "unsubscribed", "userId", "workflowSlug",
       ].sort(),

--- a/tests/unit/leads-offer-on-row.test.ts
+++ b/tests/unit/leads-offer-on-row.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// A lead ROW carries the offer it belongs to, with its name — the customer dashboard's detail panel
+// names it above the audience, and joining it in the browser (fetch the org's campaigns, map
+// campaign to offer, match on the lead's campaign) is the client-side join the audience column was
+// already fixed away from. The resolution is the one the offer FILTER established: a lead's offer is
+// the offer named by the campaign it was served under, i.e. the frozen `campaign_id` on its row.
+
+let mockRows: Array<Record<string, unknown>> = [];
+let mockSqlChunkIndex = 0;
+
+vi.mock("../../src/db/index.js", () => ({
+  sql: (_strings: readonly string[], ..._values: unknown[]) => ({
+    then: (resolve: (rows: unknown[]) => void) => {
+      const start = mockSqlChunkIndex * 500;
+      mockSqlChunkIndex += 1;
+      return Promise.resolve(mockRows.slice(start, start + 500)).then(resolve);
+    },
+    cursor: (size: number) => ({
+      async *[Symbol.asyncIterator]() {
+        for (let i = 0; i < mockRows.length; i += size) yield mockRows.slice(i, i + size);
+      },
+    }),
+  }),
+}));
+
+vi.mock("../../src/lib/lead-shape.js", () => ({
+  buildFullLeadsBatch: (ids: string[]) =>
+    Promise.resolve(
+      new Map(
+        ids.map((id) => [
+          id,
+          {
+            leadId: id,
+            contacts: [{ channel: "email", value: `${id}@example.com`, status: "valid", source: "apollo" }],
+          },
+        ]),
+      ),
+    ),
+}));
+
+vi.mock("../../src/lib/email-gateway-client.js", () => ({
+  checkDeliveryStatus: () => Promise.resolve({ results: [] }),
+}));
+
+vi.mock("../../src/lib/campaign-identity-client.js", () => ({
+  resolveCampaignFamily: (id: string) => Promise.resolve([id]),
+}));
+
+vi.mock("../../src/lib/offer-campaigns-client.js", () => ({
+  resolveOfferCampaignIds: () => Promise.resolve([]),
+  OfferCampaignsUnavailableError: class extends Error {},
+}));
+
+vi.mock("../../src/lib/audience-client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/lib/audience-client.js")>()),
+  resolveAudiencesForBrand: () => Promise.resolve({ byAudienceId: {}, byEmail: {} }),
+}));
+
+vi.mock("../../src/lib/trace-event.js", () => ({
+  traceEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Real offer-card-client, mocked transport: what is under test is the cost the ROUTE puts on it.
+vi.mock("../../src/config.js", () => ({
+  LEAD_SERVICE_API_KEY: "test-api-key",
+  CAMPAIGN_SERVICE_URL: "https://campaign.test",
+  CAMPAIGN_SERVICE_API_KEY: "test-campaign-key",
+  BRAND_SERVICE_URL: "https://brand.test",
+  BRAND_SERVICE_API_KEY: "test-brand-key",
+}));
+
+const ORG = "30000000-0000-0000-0000-000000000001";
+const BRAND = "75d7e3e8-6926-4f85-a557-976895400666";
+const OFFER = "0ffe0000-0000-4000-8000-000000000001";
+const SELLING_CAMPAIGN = "aaaaaaaa-1111-4111-8111-111111111111";
+const OFFERLESS_CAMPAIGN = "bbbbbbbb-2222-4222-8222-222222222222";
+const ROW_ID = "11111111-1111-4111-8111-111111111111";
+
+const CAMPAIGNS_URL = "https://campaign.test/campaigns";
+const OFFERS_URL = `https://brand.test/internal/brands/${BRAND}/offers`;
+
+const fetchSpy = vi.fn();
+
+function rawRow(i: number, campaignId: string, id = `lc-${i}`) {
+  return {
+    id,
+    lead_id: `lead-${i}`,
+    campaign_id: campaignId,
+    org_id: ORG,
+    user_id: null,
+    brand_ids: [BRAND],
+    status: "served",
+    status_reason: null,
+    status_details: null,
+    parent_run_id: null,
+    run_id: null,
+    served_at: "2026-01-01T00:00:00.000Z",
+    workflow_slug: null,
+    feature_slug: null,
+    goal: null,
+    active_goal_id: null,
+    brand_profile_id: null,
+    audience_id: null,
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    created_at_cursor: "2026-01-01 00:00:00.000000+00",
+    lead_apollo_person_id: null,
+    email_value: `lead-${i}@example.com`,
+    email_status: "valid",
+  };
+}
+
+/** campaign-service knows both campaigns; only one names an offer. brand-service names it. */
+function healthyTransport() {
+  fetchSpy.mockImplementation(async (url: string) => {
+    if (url === CAMPAIGNS_URL) {
+      return {
+        ok: true,
+        json: async () => ({
+          campaigns: [
+            { id: SELLING_CAMPAIGN, orgId: ORG, brandIds: [BRAND], offerId: OFFER },
+            { id: OFFERLESS_CAMPAIGN, orgId: ORG, brandIds: [BRAND], offerId: null },
+          ],
+        }),
+      };
+    }
+    if (url === OFFERS_URL) {
+      return {
+        ok: true,
+        json: async () => ({ offers: [{ offerId: OFFER, brandId: BRAND, name: "Fractional CFO retainer" }] }),
+      };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+}
+
+async function buildApp() {
+  const { default: route } = await import("../../src/routes/leads.js");
+  const app = express();
+  app.use(express.json());
+  app.use(route);
+  return app;
+}
+
+function get(app: express.Express, path: string) {
+  return request(app).get(path).set("x-api-key", "test-api-key").set("x-org-id", ORG);
+}
+
+describe("a lead row carries its offer", () => {
+  let app: express.Express;
+
+  beforeAll(async () => {
+    vi.stubGlobal("fetch", fetchSpy);
+    app = await buildApp();
+  }, 30_000);
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    mockRows = [];
+    mockSqlChunkIndex = 0;
+    fetchSpy.mockReset();
+    healthyTransport();
+  });
+
+  // AC1 — the offer, with its NAME. An id alone leaves the panel with nothing to render.
+  it("names the offer its campaign sells, in the full view", async () => {
+    mockRows = [rawRow(1, SELLING_CAMPAIGN)];
+
+    const res = await get(app, `/orgs/leads?brandId=${BRAND}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leads[0].offer).toEqual({ id: OFFER, name: "Fractional CFO retainer" });
+  });
+
+  it("names it identically in the slim projection", async () => {
+    mockRows = [rawRow(1, SELLING_CAMPAIGN)];
+
+    const res = await get(app, `/orgs/leads?brandId=${BRAND}&view=basic`);
+
+    // The slim row is what the dashboard's table reads; a panel rendered from it must not be
+    // missing the offer the full row names.
+    expect(res.body.leads[0].offer).toEqual({ id: OFFER, name: "Fractional CFO retainer" });
+  });
+
+  it("names it identically on the one-lead read", async () => {
+    mockRows = [rawRow(1, SELLING_CAMPAIGN, ROW_ID)];
+
+    const res = await get(app, `/orgs/leads/${ROW_ID}?brandId=${BRAND}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leadDetail.offer).toEqual({ id: OFFER, name: "Fractional CFO retainer" });
+  });
+
+  // AC2 — a campaign that names no offer gives its leads none, and changes nothing else.
+  it("carries no offer for a campaign that sells none, and leaves the row otherwise unchanged", async () => {
+    mockRows = [rawRow(1, OFFERLESS_CAMPAIGN)];
+
+    const res = await get(app, `/orgs/leads?brandId=${BRAND}`);
+
+    const lead = res.body.leads[0];
+    expect(lead.offer).toBeNull();
+    // Never the brand's, never a sibling campaign's — the offer OFFER is right there in the org.
+    expect(JSON.stringify(lead)).not.toContain(OFFER);
+    expect(lead.campaignId).toBe(OFFERLESS_CAMPAIGN);
+    expect(lead.brandIds).toEqual([BRAND]);
+  });
+
+  // AC5 — the resolution is per REQUEST. A per-row implementation fails this outright.
+  it("resolves the whole response with two calls, whatever the row count", async () => {
+    // 1,200 rows over three chunks, both campaigns represented.
+    mockRows = Array.from({ length: 1200 }, (_, i) =>
+      rawRow(i, i % 2 === 0 ? SELLING_CAMPAIGN : OFFERLESS_CAMPAIGN),
+    );
+
+    const res = await get(app, `/orgs/leads?brandId=${BRAND}&view=basic`);
+
+    expect(res.body.leads).toHaveLength(1200);
+    expect(res.body.leads[0].offer).toEqual({ id: OFFER, name: "Fractional CFO retainer" });
+    expect(res.body.leads[1].offer).toBeNull();
+
+    // One campaign-service read, one brand-service read — for 1,200 rows across several chunks.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls.filter(([url]) => url === CAMPAIGNS_URL)).toHaveLength(1);
+    expect(fetchSpy.mock.calls.filter(([url]) => url === OFFERS_URL)).toHaveLength(1);
+  });
+
+  it("holds the same two calls on the full view's chunked walk", async () => {
+    mockRows = Array.from({ length: 1200 }, (_, i) => rawRow(i, SELLING_CAMPAIGN));
+
+    const res = await get(app, `/orgs/leads?brandId=${BRAND}`);
+
+    expect(res.body.leads).toHaveLength(1200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  // Unresolvable is ABSENT, and the list a consumer reads today still answers.
+  it("still returns the list, with no offer, when the offer cannot be resolved", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchSpy.mockRejectedValue(new Error("ECONNREFUSED"));
+    mockRows = [rawRow(1, SELLING_CAMPAIGN)];
+
+    const res = await get(app, `/orgs/leads?brandId=${BRAND}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.leads).toHaveLength(1);
+    expect(res.body.leads[0].offer).toBeNull();
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining("offer unresolved"));
+    consoleError.mockRestore();
+  });
+});

--- a/tests/unit/offer-card-client.test.ts
+++ b/tests/unit/offer-card-client.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// A lead's OFFER is the offer named by the campaign it was served under — the same resolution the
+// offer FILTER established, read in the other direction. The name is brand-service's. Neither read
+// may cost anything per row: a brand's list reaches tens of thousands of rows and is polled every
+// 30 seconds.
+
+vi.mock("../../src/config.js", () => ({
+  CAMPAIGN_SERVICE_URL: "https://campaign.test",
+  CAMPAIGN_SERVICE_API_KEY: "test-campaign-key",
+  BRAND_SERVICE_URL: "https://brand.test",
+  BRAND_SERVICE_API_KEY: "test-brand-key",
+}));
+
+const ORG = "30000000-0000-0000-0000-000000000001";
+const BRAND = "75d7e3e8-6926-4f85-a557-976895400666";
+const OTHER_BRAND = "75d7e3e8-6926-4f85-a557-976895400999";
+const OFFER = "0ffe0000-0000-4000-8000-000000000001";
+const OTHER_OFFER = "0ffe0000-0000-4000-8000-000000000002";
+
+const CAMPAIGNS_URL = "https://campaign.test/campaigns";
+const offersUrl = (brandId: string) => `https://brand.test/internal/brands/${brandId}/offers`;
+
+function campaign(id: string, offerId: string | null, brandId: string = BRAND) {
+  return { id, orgId: ORG, brandIds: [brandId], offerId };
+}
+
+function jsonOnce(body: unknown) {
+  return { ok: true, json: async () => body };
+}
+
+/** Answer each URL from a table, so call ORDER never makes a test pass or fail by accident. */
+function routeFetch(fetchSpy: ReturnType<typeof vi.fn>, table: Record<string, unknown>) {
+  fetchSpy.mockImplementation(async (url: string) => {
+    const body = table[url];
+    if (body === undefined) throw new Error(`unexpected fetch: ${url}`);
+    return jsonOnce(body);
+  });
+}
+
+const load = () => import("../../src/lib/offer-card-client.js");
+
+describe("createOfferCardResolver", () => {
+  const fetchSpy = vi.fn();
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // AC1 — the offer, with its name, for the campaign the lead was served under.
+  it("names the offer the row's campaign sells", async () => {
+    routeFetch(fetchSpy, {
+      [CAMPAIGNS_URL]: { campaigns: [campaign("c-1", OFFER)] },
+      [offersUrl(BRAND)]: { offers: [{ offerId: OFFER, brandId: BRAND, name: "Fractional CFO retainer" }] },
+    });
+
+    const { createOfferCardResolver } = await load();
+    const cards = await createOfferCardResolver({ orgId: ORG, brandId: BRAND }).resolve(["c-1"]);
+
+    expect(cards.get("c-1")).toEqual({ id: OFFER, name: "Fractional CFO retainer" });
+  });
+
+  // AC2 — a campaign that names no offer gives its leads none. Never a sibling's, never the brand's.
+  it("gives no card to a campaign that states no offer", async () => {
+    routeFetch(fetchSpy, {
+      [CAMPAIGNS_URL]: { campaigns: [campaign("c-1", OFFER), campaign("c-2", null)] },
+      [offersUrl(BRAND)]: { offers: [{ offerId: OFFER, name: "Retainer" }] },
+    });
+
+    const { createOfferCardResolver } = await load();
+    const cards = await createOfferCardResolver({ orgId: ORG }).resolve(["c-1", "c-2"]);
+
+    expect(cards.has("c-2")).toBe(false);
+    expect(cards.get("c-1")).toEqual({ id: OFFER, name: "Retainer" });
+  });
+
+  it("never lets one brand's catalogue name another brand's offer", async () => {
+    routeFetch(fetchSpy, {
+      [CAMPAIGNS_URL]: { campaigns: [campaign("c-1", OFFER, BRAND), campaign("c-2", OTHER_OFFER, OTHER_BRAND)] },
+      [offersUrl(BRAND)]: { offers: [{ offerId: OFFER, name: "Ours" }] },
+      [offersUrl(OTHER_BRAND)]: { offers: [{ offerId: OTHER_OFFER, name: "Theirs" }] },
+    });
+
+    const { createOfferCardResolver } = await load();
+    const cards = await createOfferCardResolver({ orgId: ORG }).resolve(["c-1", "c-2"]);
+
+    expect(cards.get("c-1")).toEqual({ id: OFFER, name: "Ours" });
+    expect(cards.get("c-2")).toEqual({ id: OTHER_OFFER, name: "Theirs" });
+  });
+
+  it("states the id with no name when brand-service does not list the offer back", async () => {
+    routeFetch(fetchSpy, {
+      [CAMPAIGNS_URL]: { campaigns: [campaign("c-1", OFFER)] },
+      [offersUrl(BRAND)]: { offers: [{ offerId: OTHER_OFFER, name: "Something else" }] },
+    });
+
+    const { createOfferCardResolver } = await load();
+    const cards = await createOfferCardResolver({ orgId: ORG }).resolve(["c-1"]);
+
+    // The offer is real; only its name is unknown. Collapsing the card would say "no offer".
+    expect(cards.get("c-1")).toEqual({ id: OFFER, name: null });
+  });
+
+  // AC5 — the cost is per REQUEST, not per row and not per chunk.
+  it("reads campaign-service ONCE and each brand ONCE, whatever the row count", async () => {
+    const campaigns = Array.from({ length: 60 }, (_, i) => campaign(`c-${i}`, OFFER));
+    routeFetch(fetchSpy, {
+      [CAMPAIGNS_URL]: { campaigns },
+      [offersUrl(BRAND)]: { offers: [{ offerId: OFFER, name: "Retainer" }] },
+    });
+
+    const { createOfferCardResolver } = await load();
+    const resolver = createOfferCardResolver({ orgId: ORG, brandId: BRAND });
+
+    // Ten chunks of 500 rows spread over 60 campaigns — the shape of a real large-brand walk.
+    for (let chunk = 0; chunk < 10; chunk += 1) {
+      const rowCampaignIds = Array.from({ length: 500 }, (_, i) => `c-${i % 60}`);
+      const cards = await resolver.resolve(rowCampaignIds);
+      expect(cards.size).toBe(60);
+    }
+
+    // 5,000 rows, 2 calls. A per-row (or per-chunk) implementation fails here.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls.filter(([url]) => url === CAMPAIGNS_URL)).toHaveLength(1);
+    expect(fetchSpy.mock.calls.filter(([url]) => url === offersUrl(BRAND))).toHaveLength(1);
+  });
+
+  it("shares one in-flight read between chunks resolved concurrently", async () => {
+    routeFetch(fetchSpy, {
+      [CAMPAIGNS_URL]: { campaigns: [campaign("c-1", OFFER)] },
+      [offersUrl(BRAND)]: { offers: [{ offerId: OFFER, name: "Retainer" }] },
+    });
+
+    const { createOfferCardResolver } = await load();
+    const resolver = createOfferCardResolver({ orgId: ORG });
+    await Promise.all([resolver.resolve(["c-1"]), resolver.resolve(["c-1"]), resolver.resolve(["c-1"])]);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("asks for no brand it returned no rows for", async () => {
+    routeFetch(fetchSpy, {
+      [CAMPAIGNS_URL]: { campaigns: [campaign("c-1", OFFER, BRAND), campaign("c-2", OTHER_OFFER, OTHER_BRAND)] },
+      [offersUrl(BRAND)]: { offers: [{ offerId: OFFER, name: "Ours" }] },
+    });
+
+    const { createOfferCardResolver } = await load();
+    await createOfferCardResolver({ orgId: ORG }).resolve(["c-1"]);
+
+    expect(fetchSpy.mock.calls.map(([url]) => url)).toEqual([CAMPAIGNS_URL, offersUrl(BRAND)]);
+  });
+
+  it("costs nothing at all when the chunk carries no campaign ids", async () => {
+    const { createOfferCardResolver } = await load();
+    expect((await createOfferCardResolver({ orgId: ORG }).resolve([])).size).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("reads the whole org list — a bound would leave stopped campaigns unable to name their offer", async () => {
+    routeFetch(fetchSpy, { [CAMPAIGNS_URL]: { campaigns: [] } });
+
+    const { createOfferCardResolver } = await load();
+    await createOfferCardResolver({ orgId: ORG, userId: "u-1", runId: "r-1", brandId: BRAND }).resolve(["c-1"]);
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe(CAMPAIGNS_URL);
+    expect(url).not.toContain("limit");
+    expect(init.headers["x-org-id"]).toBe(ORG);
+    expect(init.headers["X-API-Key"]).toBe("test-campaign-key");
+    expect(init.headers["x-brand-id"]).toBe(BRAND);
+  });
+
+  it("sends brand-service its own key and the org that owns the configuration", async () => {
+    routeFetch(fetchSpy, {
+      [CAMPAIGNS_URL]: { campaigns: [campaign("c-1", OFFER)] },
+      [offersUrl(BRAND)]: { offers: [] },
+    });
+
+    const { createOfferCardResolver } = await load();
+    await createOfferCardResolver({ orgId: ORG }).resolve(["c-1"]);
+
+    const [, init] = fetchSpy.mock.calls.find(([url]) => url === offersUrl(BRAND))!;
+    expect(init.headers["X-API-Key"]).toBe("test-brand-key");
+    expect(init.headers["x-org-id"]).toBe(ORG);
+  });
+
+  // Unresolvable is ABSENT — never a guess, and never a failed list.
+  it("carries no offer, loudly, when campaign-service cannot answer", async () => {
+    fetchSpy.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const { createOfferCardResolver } = await load();
+    const cards = await createOfferCardResolver({ orgId: ORG }).resolve(["c-1"]);
+
+    expect(cards.size).toBe(0);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("offer unresolved"));
+  });
+
+  it("absorbs an outage once per request rather than retrying it on every chunk", async () => {
+    fetchSpy.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const { createOfferCardResolver } = await load();
+    const resolver = createOfferCardResolver({ orgId: ORG });
+    await resolver.resolve(["c-1"]);
+    await resolver.resolve(["c-2"]);
+    await resolver.resolve(["c-3"]);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the offer id, loudly, when brand-service cannot name it", async () => {
+    fetchSpy.mockImplementation(async (url: string) => {
+      if (url === CAMPAIGNS_URL) return jsonOnce({ campaigns: [campaign("c-1", OFFER)] });
+      return { ok: false, status: 503, text: async () => "down" };
+    });
+
+    const { createOfferCardResolver } = await load();
+    const cards = await createOfferCardResolver({ orgId: ORG }).resolve(["c-1"]);
+
+    expect(cards.get("c-1")).toEqual({ id: OFFER, name: null });
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("offer names unresolved"));
+  });
+
+  it("treats an unreadable campaign body as unknown, not as an org selling nothing", async () => {
+    routeFetch(fetchSpy, { [CAMPAIGNS_URL]: {} });
+
+    const { createOfferCardResolver } = await load();
+    expect((await createOfferCardResolver({ orgId: ORG }).resolve(["c-1"])).size).toBe(0);
+    expect(console.error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Every lead row names the **offer** it belongs to:

```jsonc
"offer": { "id": "0ffe0000-…", "name": "Fractional CFO retainer" } | null
```

## Why here and not in the browser

`offerId` existed on this service as a **filter only**, so a row carried no offer and the dashboard's lead panel had nothing to render.

The dashboard could have joined it: fetch the org's campaigns, map campaign to offer, match on the lead's campaign. That is the wrong layer, and this fleet already has the precedent — the dashboard's Audience column *was* a client-side join on email, and was fixed by reading the `audience` object this service already serves on the row. Reading the row is simpler **and more accurate**: the stored attribution rather than a match.

Same resolution as the filter (#435): **a lead's offer is the offer named by the campaign it was served under**, off the frozen `campaign_id`. Never inferred from the brand, the funnel or a sibling campaign.

## Nothing resolves per row

That value repeats across thousands of rows, so:

- **one** campaign-service read per request — campaign → offer for the whole org, memoized as a *promise* so concurrent chunks share the in-flight call
- **one** brand-service offers read per **brand actually seen** — a brand-scoped list is 1; an org-wide staff read is one per brand that returned rows, never one per row

Measured by test: **5,000 rows over 10 chunks / 60 campaigns → 2 fetches.** 1,200 rows through the real route on both views → 2 fetches. A failure is absorbed once per request, so an outage costs one attempt and one log line.

**AC5 is pinned by a test that fails if someone later makes it per-row.** This list has already caused a production outage on payload size; the cost model is the point, not an afterthought.

## The slim projection carries it

`serializeLeadItem`'s contract is that a list element and a detail record are indistinguishable. A full-only field would make the panel change shape depending on how the lead was loaded. The cost is two short strings on a row that already repeats `campaignId`, `workflowSlug` and `featureSlug`, and it adds **zero** network work.

## Fail-soft, deliberately unlike the filter

The filter in #435 decides **which rows come back** — failing it open serves a brand's people under another offer's name, which is wrong data, so it 502s.

This decides **one display field**. Unresolved, it is absent (with a loud log) and the row still carries the `campaignId` the offer derives from. Degraded, never wrong.

Failing loud here would make brand-service and campaign-service hard dependencies of a list polled every 30 seconds that works today without either — a new outage mode, not an additive change.

A **null name on a present id** is stated rather than collapsing the card: the id is still true, and dropping it would claim the lead belongs to no offer.

## Verified

`tsc --noEmit` clean (raw) · build + openapi regen · **444 tests across 53 files**.

One existing test changed by one word: the detail route's exhaustive key list, which exists to pin list/detail parity — adding a field to both necessarily updates it. No assertion weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
