### PR TITLE
fix(retry-pool): mark a sent candidate through the query builder, not a hand-cast array

### DIFF
--- a/src/lib/retry-pool.ts
+++ b/src/lib/retry-pool.ts
@@ -1,5 +1,6 @@
-import { sql } from "drizzle-orm";
+import { and, inArray, isNull, sql } from "drizzle-orm";
 import { db } from "../db/index.js";
+import { leadsCampaigns } from "../db/schema.js";
 import { checkDeliveryStatus, type StatusResult } from "./email-gateway-client.js";
 
 /**
@@ -224,13 +225,16 @@ export async function loadRetryCandidates(params: {
  */
 export async function markSentCandidates(ids: string[], nowMs: number): Promise<void> {
   if (ids.length === 0) return;
-  const now = new Date(nowMs).toISOString();
-  await db.execute(sql`
-    UPDATE leads_campaigns
-       SET sent_at = ${now}, updated_at = ${now}
-     WHERE id::text = ANY(${ids}::text[])
-       AND sent_at IS NULL
-  `);
+  const now = new Date(nowMs);
+  // Built through the query builder rather than a raw `= ANY(${ids}::text[])`. The driver
+  // renders a bare JS array parameter as a ROW, so hand-casting it to an array type fails
+  // at runtime with `cannot cast type record to text[]` — which is what shipped, and what
+  // took a live campaign's serve down every minute until this was corrected. The builder
+  // owns the parameter's type, so there is nothing left to cast by hand.
+  await db
+    .update(leadsCampaigns)
+    .set({ sentAt: now, updatedAt: now })
+    .where(and(inArray(leadsCampaigns.id, ids), isNull(leadsCampaigns.sentAt)));
 }
 
 /**

--- a/tests/integration/retry-pool-sql.test.ts
+++ b/tests/integration/retry-pool-sql.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Executes the retry pool's own writes against a REAL database.
+ *
+ * The pool shipped with `WHERE id::text = ANY(${ids}::text[])` in `markSentCandidates`.
+ * Every unit test around it passed, because they all mock the database: nothing ever ran
+ * the statement before production did. The driver renders a bare JS array parameter as a
+ * ROW, so the hand-written cast failed at runtime with `cannot cast type record to
+ * text[]`, and a live campaign's serve failed on every pull that found an already-sent
+ * candidate.
+ *
+ * So this file runs the statements rather than asserting their shape. A mocked database
+ * cannot fail the way the real one did, which is exactly why the class survived review.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "../../src/db/index.js";
+import { leads, leadsCampaigns } from "../../src/db/schema.js";
+import { claimCandidate, markSentCandidates } from "../../src/lib/retry-pool.js";
+
+/**
+ * `tests/setup.ts` fills the DSN only when one is absent, so CI's throwaway Postgres wins
+ * there and this placeholder is what a laptop with no database sees. Skipping on it keeps
+ * the local suite runnable; CI always executes these.
+ */
+const PLACEHOLDER_DSN = "postgresql://test:test@localhost:5432/test";
+const hasRealDatabase = process.env.LEAD_SERVICE_DATABASE_URL !== PLACEHOLDER_DSN;
+
+describe.skipIf(!hasRealDatabase)("retry-pool statements against a real database", () => {
+  const campaignId = `itest-${randomUUID()}`;
+  const orgId = randomUUID();
+  const brandId = randomUUID();
+  const seeded: string[] = [];
+
+  async function seedServedRow(): Promise<string> {
+    const [lead] = await db
+      .insert(leads)
+      .values({ name: `itest ${randomUUID()}` })
+      .returning({ id: leads.id });
+    const [row] = await db
+      .insert(leadsCampaigns)
+      .values({
+        leadId: lead.id,
+        campaignId,
+        orgId,
+        brandIds: [brandId],
+        status: "served",
+        servedAt: new Date(),
+      })
+      .returning({ id: leadsCampaigns.id });
+    return row.id;
+  }
+
+  beforeAll(async () => {
+    for (let i = 0; i < 3; i++) seeded.push(await seedServedRow());
+  });
+
+  afterAll(async () => {
+    await db.delete(leadsCampaigns).where(eq(leadsCampaigns.campaignId, campaignId));
+  });
+
+  it("marks several candidates sent in one statement", async () => {
+    await markSentCandidates(seeded, Date.now());
+
+    const stillUnsent = await db
+      .select({ id: leadsCampaigns.id })
+      .from(leadsCampaigns)
+      .where(and(eq(leadsCampaigns.campaignId, campaignId), isNull(leadsCampaigns.sentAt)));
+
+    expect(stillUnsent).toHaveLength(0);
+  });
+
+  it("marks a single candidate sent — one element is the same statement", async () => {
+    const id = await seedServedRow();
+
+    await markSentCandidates([id], Date.now());
+
+    const [after] = await db
+      .select({ sentAt: leadsCampaigns.sentAt })
+      .from(leadsCampaigns)
+      .where(eq(leadsCampaigns.id, id));
+
+    expect(after.sentAt).not.toBeNull();
+  });
+
+  it("writes nothing when the list is empty", async () => {
+    await expect(markSentCandidates([], Date.now())).resolves.toBeUndefined();
+  });
+
+  it("claims a candidate once — a second claim of the same row is refused", async () => {
+    const id = await seedServedRow();
+    const now = Date.now();
+
+    const first = await claimCandidate({ id, nowMs: now, runId: randomUUID(), parentRunId: null });
+    const second = await claimCandidate({ id, nowMs: now, runId: randomUUID(), parentRunId: null });
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+});

--- a/tests/unit/retry-pool.test.ts
+++ b/tests/unit/retry-pool.test.ts
@@ -122,8 +122,23 @@ function execute(query: { queryChunks: unknown[] }): Promise<unknown[]> {
   return Promise.resolve(eligible);
 }
 
+const markSentUpdates: { ids: unknown; set: unknown }[] = [];
+
+// `update` is a builder chain, so the mock has to be one too. Note what that means: this
+// double cannot fail the way a real database does — the statement it stands in for shipped
+// broken past a green run of this very file. The statements themselves are exercised in
+// tests/integration/retry-pool-sql.test.ts, against a real database; keep them there.
 vi.mock("../../src/db/index.js", () => ({
-  db: { execute: (q: { queryChunks: unknown[] }) => execute(q) },
+  db: {
+    execute: (q: { queryChunks: unknown[] }) => execute(q),
+    update: () => ({
+      set: (values: unknown) => ({
+        where: async (predicate: unknown) => {
+          markSentUpdates.push({ ids: predicate, set: values });
+        },
+      }),
+    }),
+  },
 }));
 
 const checkDeliveryStatus = vi.fn();
@@ -337,6 +352,7 @@ describe("pickRetryCandidate", () => {
   });
 
   it("marks a sent person terminal, never returns them, and never re-queries them", async () => {
+    markSentUpdates.length = 0;
     rows = [row({ id: "aaaaaaaa-0000-4000-8000-000000000001" })];
     checkDeliveryStatus.mockResolvedValue({
       results: [
@@ -348,7 +364,13 @@ describe("pickRetryCandidate", () => {
     });
 
     expect(await pickRetryCandidate(base)).toBeNull();
-    expect(rows[0].sent_at).toBe(new Date(NOW).toISOString());
+    expect(markSentUpdates).toHaveLength(1);
+    expect(markSentUpdates[0].set).toMatchObject({ sentAt: new Date(NOW) });
+
+    // The fixture stands in for what the database persists from that write. Asserting the
+    // row here would only be asserting this file's own double — the statement itself is
+    // executed against a real database in tests/integration/retry-pool-sql.test.ts.
+    rows[0].sent_at = new Date(NOW).toISOString();
 
     // A later pull neither sees nor asks about them.
     checkDeliveryStatus.mockClear();


### PR DESCRIPTION
## What broke

`markSentCandidates` (shipped in #444) bound its id list as:

```sql
WHERE id::text = ANY(${ids}::text[])
```

The driver renders a bare JS array parameter as a ROW, so the hand-written cast fails at
runtime:

```
[lead-service] buffer/next error: PostgresError: cannot cast type record to text[]
```

`pullNext` therefore threw on every pull whose candidate pool contained at least one
already-sent person. Blast radius was narrow — a pool with no sent row never reaches the
statement, so the rest of the fleet kept serving (294 `completed` against 6 `failed` in
the hour) — but it landed squarely on the one campaign #444 was written to rescue: 133
uncontacted candidates beside 22 sent ones, so it hit the statement on every tick and its
serve failed every minute for roughly forty minutes.

## The fix

Build the statement through the query builder. It owns the parameter's type, so what goes
to the database is:

```
update "leads_campaigns" set "sent_at" = $1, "updated_at" = $2
 where ("leads_campaigns"."id" in ($3, $4, $5) and "leads_campaigns"."sent_at" is null)
```

One parameter per id, no array, nothing left to cast by hand.

## Why the tests were green while it was broken

`tests/unit/retry-pool.test.ts` is 411 lines and mocks the database, so **nothing executed
this SQL before production did**. Worse, the test asserted `rows[0].sent_at` — a mutation
its own double performed — which reads as proof that the write works and is proof of
nothing at all.

So this PR adds `tests/integration/retry-pool-sql.test.ts`, which runs the pool's writes
against a real database: several ids at once, a single id, an empty list, and the claim's
second-caller refusal. CI already stands up a Postgres service container and runs the whole
suite against it, so these execute on every run; they skip on a laptop with no database
(the setup file's placeholder DSN is the discriminator).

The unit double had to grow an `update` chain to keep working, and its comment now says
plainly that it cannot fail the way the real database did.

## Verification

- `npm test` — 480 passed, 4 skipped (the integration file skips with no local database)
- `npx tsc --noEmit` — clean
- Generated SQL printed and checked by hand (above)

## Triage

Hotfix, prod-direct. A customer's campaign is failing on every tick right now.

Refs #443
