### PR TITLE
feat(history): a generated email says why it has no words

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4498,7 +4498,7 @@
           "bodyText": {
             "type": "string",
             "nullable": true,
-            "description": "The words, as readable text. Null when the holder says it could not read them."
+            "description": "The words, as readable text. Null when no body was handed over — `bodyStatus` says whether that is an empty message or one we could not read."
           },
           "bodyStatus": {
             "type": "string",
@@ -4507,7 +4507,7 @@
               "empty",
               "unavailable"
             ],
-            "description": "ok: these are the words. empty: it genuinely says nothing. unavailable: we hold the message and could not read it — deliberately NOT the same answer as empty."
+            "description": "On a `message` and on a `generated_email`. ok: these are the words. empty: the holder handed over a body and it genuinely says nothing. unavailable: the thing exists and no body we could read came with it — deliberately NOT the same answer as empty, so a consumer can say out loud why an email it was told about has no words instead of rendering a date and nothing else."
           },
           "threadId": {
             "type": "string",

--- a/src/lib/lead-history.ts
+++ b/src/lib/lead-history.ts
@@ -127,7 +127,16 @@ export interface HistoryLifecycleEvent extends HistoryEventBase {
 export interface HistoryGeneratedEmailEvent extends HistoryEventBase {
   type: "generated_email";
   subject: string | null;
+  /** The words. Null whenever the producer handed none over — see `bodyStatus`, which says
+   * WHICH of the two absences this is. */
   bodyText: string | null;
+  /** Same three-way answer the `message` event carries, and for the same reason. ok: these are
+   * the words. empty: the producer handed over a body and it genuinely says nothing.
+   * unavailable: a generation exists — we wrote to this person — and its producer served no
+   * body we could read, so the words are missing rather than absent. Silence about that is what
+   * made a lead panel render a date and nothing else, with no sentence explaining why. The words
+   * are NEVER recovered from the planned sequence here: the producer owns what we wrote. */
+  bodyStatus: "ok" | "empty" | "unavailable";
   /** The cadence the sequence PLANNED, verbatim from its producer. It is a plan, not a promise —
    * what is still owed is the `followup` event, which reads this service's live state. */
   plannedSequence: unknown;
@@ -321,6 +330,18 @@ function pushDelivery(
   });
 }
 
+/**
+ * Why a generated email has no words, told apart the same way the `message` event tells them
+ * apart. A generation row EXISTS because we wrote to this person, so a body the producer never
+ * handed over is a body we could not read — `unavailable` — and not the email saying nothing.
+ * An empty string is the producer answering, and that answer is `empty`. Nothing here reads the
+ * planned sequence: recovering the copy is the producer's job, not this service's.
+ */
+function generatedBodyStatus(bodyText: string | null): "ok" | "empty" | "unavailable" {
+  if (bodyText === null || bodyText === undefined) return "unavailable";
+  return bodyText.trim().length > 0 ? "ok" : "empty";
+}
+
 export function assembleLeadHistory(input: AssembleHistoryInput): AssembledHistory {
   const events: HistoryEvent[] = [];
   const sources = new Map<HistorySource, HistorySourceState>();
@@ -460,6 +481,7 @@ export function assembleLeadHistory(input: AssembleHistoryInput): AssembledHisto
           direction: "outbound",
           subject: generation.subject,
           bodyText: generation.bodyText,
+          bodyStatus: generatedBodyStatus(generation.bodyText),
           plannedSequence: generation.sequence,
           model: generation.model,
         });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -4458,11 +4458,12 @@ const HistoryEventSchema = z
     to: z.array(z.string()).optional(),
     subject: z.string().nullable().optional(),
     bodyText: z.string().nullable().optional().openapi({
-      description: "The words, as readable text. Null when the holder says it could not read them.",
+      description:
+        "The words, as readable text. Null when no body was handed over — `bodyStatus` says whether that is an empty message or one we could not read.",
     }),
     bodyStatus: z.enum(["ok", "empty", "unavailable"]).optional().openapi({
       description:
-        "ok: these are the words. empty: it genuinely says nothing. unavailable: we hold the message and could not read it — deliberately NOT the same answer as empty.",
+        "On a `message` and on a `generated_email`. ok: these are the words. empty: the holder handed over a body and it genuinely says nothing. unavailable: the thing exists and no body we could read came with it — deliberately NOT the same answer as empty, so a consumer can say out loud why an email it was told about has no words instead of rendering a date and nothing else.",
     }),
     threadId: z.string().nullable().optional(),
     heldBy: z.array(z.string()).optional().openapi({

--- a/tests/unit/lead-history.test.ts
+++ b/tests/unit/lead-history.test.ts
@@ -557,4 +557,86 @@ describe("assembleLeadHistory — the copy we produced", () => {
     expect(generated.plannedSequence).toEqual([{ step: 2, waitDays: 3 }]);
     expect(events[0].evidence).toBe("observed");
   });
+
+  it("says the words could not be read rather than being silent about their absence", () => {
+    const { events } = assembleLeadHistory(
+      input({
+        campaigns: [
+          campaign({
+            servedAt: null,
+            generation: {
+              ok: true,
+              data: {
+                id: "gen-2",
+                campaignId: "camp-1",
+                subject: "quick question",
+                bodyText: null,
+                bodyHtml: null,
+                sequence: [{ step: 1 }],
+                model: "claude-sonnet-4-6",
+                promptType: "cold",
+                createdAt: "2026-01-01T06:00:00.000Z",
+              },
+            },
+          }),
+        ],
+      }),
+    );
+
+    const generated = events[0] as { bodyText: string | null; bodyStatus: string };
+    expect(generated.bodyText).toBeNull();
+    expect(generated.bodyStatus).toBe("unavailable");
+  });
+
+  it("reads a body the producer handed over as readable, and an empty one as empty", () => {
+    const withBody = assembleLeadHistory(
+      input({
+        campaigns: [
+          campaign({
+            servedAt: null,
+            generation: {
+              ok: true,
+              data: {
+                id: "gen-3",
+                campaignId: "camp-1",
+                subject: "s",
+                bodyText: "hello there",
+                bodyHtml: null,
+                sequence: null,
+                model: null,
+                promptType: null,
+                createdAt: "2026-01-01T06:00:00.000Z",
+              },
+            },
+          }),
+        ],
+      }),
+    ).events[0] as { bodyStatus: string };
+    expect(withBody.bodyStatus).toBe("ok");
+
+    const emptyBody = assembleLeadHistory(
+      input({
+        campaigns: [
+          campaign({
+            servedAt: null,
+            generation: {
+              ok: true,
+              data: {
+                id: "gen-4",
+                campaignId: "camp-1",
+                subject: "s",
+                bodyText: "   ",
+                bodyHtml: null,
+                sequence: null,
+                model: null,
+                promptType: null,
+                createdAt: "2026-01-01T06:00:00.000Z",
+              },
+            },
+          }),
+        ],
+      }),
+    ).events[0] as { bodyStatus: string };
+    expect(emptyBody.bodyStatus).toBe("empty");
+  });
 });


### PR DESCRIPTION
## What

`GET /orgs/leads/{id}/history` reported a `generated_email` event with a subject, no body, and no field explaining the absence. A consumer could not distinguish "no copy we could read" from "the email says nothing", so the dashboard rendered neither and the panel read as broken.

The `message` event on this same payload already answers that with a three-way `bodyStatus`. The generated-email event now carries the same one:

- `ok` — the producer handed over words
- `empty` — it handed over a body that genuinely says nothing
- `unavailable` — a generation exists and no readable body came with it

## Not in scope

The producer half (content-generation-service serving an empty body for every generation since February 2026) is being fixed in parallel. This service does not reach into the stored sequence to recover the copy.

## Blast radius

Additive: one new optional field on an existing event. Nothing removed, nothing renamed. Prod-direct, no ordering constraint with the producer fix.

## Verified

`tsc`, `npm run build` (openapi regenerated), full unit suite (830 passed) via `rtk proxy npx vitest run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
