### PR TITLE
perf(backfill): repair leads in a small pool instead of one at a time

### DIFF
--- a/scripts/backfill-lead-org-enrichment.ts
+++ b/scripts/backfill-lead-org-enrichment.ts
@@ -64,12 +64,24 @@ import { appendFileSync, writeFileSync } from "node:fs";
 /** How many leads are read out of lead-service in one page. */
 export const DEFAULT_BATCH_SIZE = 2_000;
 
+/**
+ * How many leads are repaired at once.
+ *
+ * The work is a handful of small indexed round trips per lead, so running them
+ * one lead at a time is round-trip-bound, not database-bound: the first
+ * production run measured ~2,000 leads per 6 minutes, i.e. over five hours for
+ * the 97k-lead population. Well under the pool ceiling (20) so the service keeps
+ * serving while the repair runs.
+ */
+export const DEFAULT_CONCURRENCY = 6;
+
 export interface Args {
   dryRun: boolean;
   inputPath: string | null;
   reportPath: string | null;
   batchSize: number;
   limit: number | null;
+  concurrency: number;
 }
 
 export function parseArgs(argv: string[]): Args {
@@ -82,6 +94,13 @@ export function parseArgs(argv: string[]): Args {
   if (!Number.isInteger(batchSize) || batchSize <= 0) {
     throw new Error(`[lead-service] --batch-size must be a positive integer, got: ${rawBatch}`);
   }
+  const rawConcurrency = value("--concurrency");
+  const concurrency = rawConcurrency === null ? DEFAULT_CONCURRENCY : Number(rawConcurrency);
+  if (!Number.isInteger(concurrency) || concurrency <= 0) {
+    throw new Error(
+      `[lead-service] --concurrency must be a positive integer, got: ${rawConcurrency}`,
+    );
+  }
   const rawLimit = value("--limit");
   const limit = rawLimit === null ? null : Number(rawLimit);
   if (limit !== null && (!Number.isInteger(limit) || limit <= 0)) {
@@ -93,6 +112,7 @@ export function parseArgs(argv: string[]): Args {
     reportPath: value("--report"),
     batchSize,
     limit,
+    concurrency,
   };
 }
 
@@ -405,141 +425,150 @@ async function run(): Promise<void> {
     if (page.length === 0) break;
     offset += page.length;
 
-    for (const lead of page) {
-      stats.leadsScanned += 1;
-      if (args.limit !== null && stats.leadsMatched >= args.limit) break;
-      const record =
-        (lead.apollo_person_id ? byPersonId.get(lead.apollo_person_id) : undefined) ??
-        (lead.email ? byEmail.get(lead.email) : undefined);
-      if (!record) continue;
-      stats.leadsMatched += 1;
+    // The page is repaired by a small pool of workers: the work is a handful of
+    // small indexed round trips per lead, so one lead at a time is round-trip
+    // bound and the whole population would take over five hours.
+    let cursor = 0;
+    const worker = async (): Promise<void> => {
+      for (;;) {
+        if (args.limit !== null && stats.leadsMatched >= args.limit) return;
+        const lead = page[cursor++];
+        if (!lead) return;
+        stats.leadsScanned += 1;
+        const record =
+          (lead.apollo_person_id ? byPersonId.get(lead.apollo_person_id) : undefined) ??
+          (lead.email ? byEmail.get(lead.email) : undefined);
+        if (!record) continue;
+        stats.leadsMatched += 1;
 
-      // --- The current employer's organization row -------------------------
-      const currentRows = (await sql`
-        SELECT lo.id AS link_id, o.*
-        FROM leads_organizations lo
-        JOIN organizations o ON o.id = lo.organization_id
-        WHERE lo.lead_id = ${lead.id} AND lo.current = true
-        LIMIT 1
-      `) as Array<Record<string, unknown>>;
+        // --- The current employer's organization row -------------------------
+        const currentRows = (await sql`
+          SELECT lo.id AS link_id, o.*
+          FROM leads_organizations lo
+          JOIN organizations o ON o.id = lo.organization_id
+          WHERE lo.lead_id = ${lead.id} AND lo.current = true
+          LIMIT 1
+        `) as Array<Record<string, unknown>>;
 
-      let organizationId: string | null = (currentRows[0]?.id as string | undefined) ?? null;
-      let existing: Record<string, unknown> = currentRows[0] ?? {};
+        let organizationId: string | null = (currentRows[0]?.id as string | undefined) ?? null;
+        let existing: Record<string, unknown> = currentRows[0] ?? {};
 
-      if (!organizationId) {
-        stats.leadsWithoutOrg += 1;
-        const domain = coerceOrgValue("text", record.org.domain);
-        const name = coerceOrgValue("text", record.org.name);
-        if (!domain && !name) continue;
-        if (args.dryRun) continue;
-        const found = domain
-          ? ((await sql`SELECT * FROM organizations WHERE primary_domain = ${domain as string} LIMIT 1`) as Array<
-              Record<string, unknown>
-            >)
-          : ((await sql`SELECT * FROM organizations WHERE name = ${name as string} LIMIT 1`) as Array<
-              Record<string, unknown>
-            >);
-        if (found[0]) {
-          organizationId = found[0].id as string;
-          existing = found[0];
-        } else {
-          const created = (await sql`
-            INSERT INTO organizations (name, primary_domain) VALUES (${name}, ${domain}) RETURNING *
-          `) as Array<Record<string, unknown>>;
-          organizationId = created[0].id as string;
-          existing = created[0];
-          stats.orgsCreated += 1;
-          report.write(JSON.stringify({ createdOrganizationId: organizationId }));
-        }
-        await sql`
-          INSERT INTO leads_organizations (lead_id, organization_id, current)
-          VALUES (${lead.id}, ${organizationId}, true)
-          ON CONFLICT DO NOTHING
-        `;
-      }
-
-      const fills = columnsToFill(existing, record);
-      if (fills.length > 0) {
-        stats.orgsFilled += 1;
-        stats.columnsFilled += fills.length;
-        if (!args.dryRun) {
-          for (const fill of fills) {
-            const value = fill.kind === "json" ? sql`${fill.value}::jsonb` : sql`${fill.value}`;
-            await sql`
-              UPDATE organizations
-              SET ${sql(fill.column)} = ${value}, updated_at = now()
-              WHERE id = ${organizationId} AND ${sql(fill.column)} IS NULL
-            `;
+        if (!organizationId) {
+          stats.leadsWithoutOrg += 1;
+          const domain = coerceOrgValue("text", record.org.domain);
+          const name = coerceOrgValue("text", record.org.name);
+          if (!domain && !name) continue;
+          if (args.dryRun) continue;
+          const found = domain
+            ? ((await sql`SELECT * FROM organizations WHERE primary_domain = ${domain as string} LIMIT 1`) as Array<
+                Record<string, unknown>
+              >)
+            : ((await sql`SELECT * FROM organizations WHERE name = ${name as string} LIMIT 1`) as Array<
+                Record<string, unknown>
+              >);
+          if (found[0]) {
+            organizationId = found[0].id as string;
+            existing = found[0];
+          } else {
+            const created = (await sql`
+              INSERT INTO organizations (name, primary_domain) VALUES (${name}, ${domain}) RETURNING *
+            `) as Array<Record<string, unknown>>;
+            organizationId = created[0].id as string;
+            existing = created[0];
+            stats.orgsCreated += 1;
+            report.write(JSON.stringify({ createdOrganizationId: organizationId }));
           }
-          report.write(
-            JSON.stringify({
-              organizationId,
-              columns: fills.map((f) => f.column),
-            }),
-          );
+          await sql`
+            INSERT INTO leads_organizations (lead_id, organization_id, current)
+            VALUES (${lead.id}, ${organizationId}, true)
+            ON CONFLICT DO NOTHING
+          `;
         }
-      }
 
-      // --- The career history ----------------------------------------------
-      if (record.employmentHistory.length === 0) continue;
-      const links = (await sql`
-        SELECT lo.id, lo.organization_id, lo.start_date, o.name AS organization_name
-        FROM leads_organizations lo
-        JOIN organizations o ON o.id = lo.organization_id
-        WHERE lo.lead_id = ${lead.id}
-      `) as Array<{
-        id: string;
-        organization_id: string;
-        start_date: string | null;
-        organization_name: string | null;
-      }>;
-      const consumed = new Set<string>();
+        const fills = columnsToFill(existing, record);
+        if (fills.length > 0) {
+          stats.orgsFilled += 1;
+          stats.columnsFilled += fills.length;
+          if (!args.dryRun) {
+            for (const fill of fills) {
+              const value = fill.kind === "json" ? sql`${fill.value}::jsonb` : sql`${fill.value}`;
+              await sql`
+                UPDATE organizations
+                SET ${sql(fill.column)} = ${value}, updated_at = now()
+                WHERE id = ${organizationId} AND ${sql(fill.column)} IS NULL
+              `;
+            }
+            report.write(
+              JSON.stringify({
+                organizationId,
+                columns: fills.map((f) => f.column),
+              }),
+            );
+          }
+        }
 
-      for (const entry of record.employmentHistory) {
-        const name = entry.organizationName as string;
-        const byName = links.filter(
-          (l) =>
-            !consumed.has(l.id) &&
-            (l.organization_name ?? "").trim().toLowerCase() === name.trim().toLowerCase(),
-        );
-        const match =
-          byName.find((l) => (l.start_date ?? null) === entry.startDate) ??
-          byName.find((l) => l.start_date === null);
-        if (match) {
-          consumed.add(match.id);
-          stats.employmentAdopted += 1;
-          continue;
-        }
-        if (args.dryRun) {
-          stats.employmentInserted += 1;
-          continue;
-        }
-        const orgRows = (await sql`SELECT id FROM organizations WHERE name = ${name} LIMIT 1`) as Array<{
+        // --- The career history ----------------------------------------------
+        if (record.employmentHistory.length === 0) continue;
+        const links = (await sql`
+          SELECT lo.id, lo.organization_id, lo.start_date, o.name AS organization_name
+          FROM leads_organizations lo
+          JOIN organizations o ON o.id = lo.organization_id
+          WHERE lo.lead_id = ${lead.id}
+        `) as Array<{
           id: string;
+          organization_id: string;
+          start_date: string | null;
+          organization_name: string | null;
         }>;
-        let entryOrgId = orgRows[0]?.id ?? null;
-        if (!entryOrgId) {
-          const created = (await sql`
-            INSERT INTO organizations (name) VALUES (${name}) RETURNING id
+        const consumed = new Set<string>();
+
+        for (const entry of record.employmentHistory) {
+          const name = entry.organizationName as string;
+          const byName = links.filter(
+            (l) =>
+              !consumed.has(l.id) &&
+              (l.organization_name ?? "").trim().toLowerCase() === name.trim().toLowerCase(),
+          );
+          const match =
+            byName.find((l) => (l.start_date ?? null) === entry.startDate) ??
+            byName.find((l) => l.start_date === null);
+          if (match) {
+            consumed.add(match.id);
+            stats.employmentAdopted += 1;
+            continue;
+          }
+          if (args.dryRun) {
+            stats.employmentInserted += 1;
+            continue;
+          }
+          const orgRows = (await sql`SELECT id FROM organizations WHERE name = ${name} LIMIT 1`) as Array<{
+            id: string;
+          }>;
+          let entryOrgId = orgRows[0]?.id ?? null;
+          if (!entryOrgId) {
+            const created = (await sql`
+              INSERT INTO organizations (name) VALUES (${name}) RETURNING id
+            `) as Array<{ id: string }>;
+            entryOrgId = created[0].id;
+            stats.orgsCreated += 1;
+            report.write(JSON.stringify({ createdOrganizationId: entryOrgId }));
+          }
+          const inserted = (await sql`
+            INSERT INTO leads_organizations
+              (lead_id, organization_id, title, start_date, end_date, current, description)
+            VALUES (${lead.id}, ${entryOrgId}, ${entry.title}, ${entry.startDate},
+                    ${entry.endDate}, false, ${entry.description})
+            ON CONFLICT DO NOTHING
+            RETURNING id
           `) as Array<{ id: string }>;
-          entryOrgId = created[0].id;
-          stats.orgsCreated += 1;
-          report.write(JSON.stringify({ createdOrganizationId: entryOrgId }));
-        }
-        const inserted = (await sql`
-          INSERT INTO leads_organizations
-            (lead_id, organization_id, title, start_date, end_date, current, description)
-          VALUES (${lead.id}, ${entryOrgId}, ${entry.title}, ${entry.startDate},
-                  ${entry.endDate}, false, ${entry.description})
-          ON CONFLICT DO NOTHING
-          RETURNING id
-        `) as Array<{ id: string }>;
-        if (inserted[0]) {
-          stats.employmentInserted += 1;
-          report.write(JSON.stringify({ employmentRowId: inserted[0].id }));
+          if (inserted[0]) {
+            stats.employmentInserted += 1;
+            report.write(JSON.stringify({ employmentRowId: inserted[0].id }));
+          }
         }
       }
-    }
+    };
+    await Promise.all(Array.from({ length: args.concurrency }, () => worker()));
 
     console.log(
       `[lead-service] scanned=${stats.leadsScanned} matched=${stats.leadsMatched} orgsFilled=${stats.orgsFilled} columns=${stats.columnsFilled} employmentInserted=${stats.employmentInserted}`,

--- a/scripts/backfill-lead-org-enrichment.ts
+++ b/scripts/backfill-lead-org-enrichment.ts
@@ -59,7 +59,7 @@
  *     --input /tmp/apollo-lead-org-enrichment.jsonl --report /tmp/org-backfill.jsonl
  */
 
-import { readFileSync, appendFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, writeFileSync } from "node:fs";
 
 /** How many leads are read out of lead-service in one page. */
 export const DEFAULT_BATCH_SIZE = 2_000;
@@ -117,13 +117,19 @@ export interface EnrichmentRecord {
  * emits. The value is the Postgres column name; the kind drives the coercion —
  * the enrichment store types some of these as text and some as json, and a
  * column is only ever written with the shape it declares.
+ *
+ * `apollo_organization_id` is deliberately absent. It is a UNIQUE join key while
+ * this service keys an organization on its domain then its name, so two rows here
+ * can legitimately describe one Apollo organization — filling it raised
+ * `23505 duplicate key value violates unique constraint
+ * "idx_organizations_apollo_organization_id"` on the first production run. It is
+ * a join key, not a fact the email is written from, so it is left alone.
  */
 export const ORG_COLUMNS: Array<{
   key: string;
   column: string;
   kind: "text" | "int" | "numeric" | "textArray" | "json" | "date";
 }> = [
-  { key: "providerOrganizationId", column: "apollo_organization_id", kind: "text" },
   { key: "name", column: "name", kind: "text" },
   { key: "domain", column: "primary_domain", kind: "text" },
   { key: "websiteUrl", column: "website_url", kind: "text" },
@@ -230,48 +236,65 @@ export function normalizeEmployment(raw: unknown): EmploymentEntry | null {
 }
 
 /**
- * One JSON object per line, as `\copy ... CSV` writes a single JSON column: the
- * field is quoted and any embedded quote is doubled. A line that is not a JSON
- * object is an ERROR — a mangled input must abort, never silently shrink the
- * repaired set.
+ * One record from one line, as `\copy ... CSV` writes a single JSON column: the
+ * field is quoted and any embedded quote is doubled. A blank line yields null; a
+ * line that is not a JSON object, or that carries neither key a lead can be
+ * matched on, is an ERROR — a mangled input must abort, never silently shrink
+ * the repaired set.
+ *
+ * The record keeps ONLY the columns this repair can write plus the normalized
+ * career history. The input is ~380 MB across ~57k people, so carrying the whole
+ * parsed object per person is the difference between a run and an out-of-memory
+ * abort.
  */
+export function parseLine(line: string, lineNo: number): EnrichmentRecord | null {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return null;
+  const json = trimmed.startsWith('"')
+    ? trimmed.slice(1, trimmed.endsWith('"') ? -1 : undefined).replace(/""/g, '"')
+    : trimmed;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (err) {
+    throw new Error(`[lead-service] input line ${lineNo} is not JSON: ${String(err)}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`[lead-service] input line ${lineNo} is not a JSON object`);
+  }
+  const rec = parsed as Record<string, unknown>;
+  const apolloPersonId =
+    typeof rec.apolloPersonId === "string" && rec.apolloPersonId.trim().length > 0
+      ? rec.apolloPersonId.trim()
+      : null;
+  const email =
+    typeof rec.email === "string" && rec.email.trim().length > 0
+      ? rec.email.trim().toLowerCase()
+      : null;
+  if (!apolloPersonId && !email) {
+    throw new Error(`[lead-service] input line ${lineNo} has neither apolloPersonId nor email`);
+  }
+  const org: Record<string, unknown> = {};
+  for (const spec of ORG_COLUMNS) {
+    const v = rec[spec.key];
+    if (v !== null && v !== undefined) org[spec.key] = v;
+  }
+  const employmentHistory = Array.isArray(rec.employmentHistory)
+    ? rec.employmentHistory
+        .map(normalizeEmployment)
+        .filter((e): e is EmploymentEntry => e !== null && e.organizationName !== null)
+    : [];
+  return { apolloPersonId, email, org, employmentHistory };
+}
+
+/** Whole-text convenience over `parseLine` — used by the tests and small inputs. */
 export function parseInput(text: string): EnrichmentRecord[] {
   const out: EnrichmentRecord[] = [];
   let lineNo = 0;
   for (const raw of text.split("\n")) {
     lineNo += 1;
-    const line = raw.trim();
-    if (line.length === 0) continue;
-    const json = line.startsWith('"')
-      ? line.slice(1, line.endsWith('"') ? -1 : undefined).replace(/""/g, '"')
-      : line;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(json);
-    } catch (err) {
-      throw new Error(`[lead-service] input line ${lineNo} is not JSON: ${String(err)}`);
-    }
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      throw new Error(`[lead-service] input line ${lineNo} is not a JSON object`);
-    }
-    const rec = parsed as Record<string, unknown>;
-    const apolloPersonId =
-      typeof rec.apolloPersonId === "string" && rec.apolloPersonId.trim().length > 0
-        ? rec.apolloPersonId.trim()
-        : null;
-    const email =
-      typeof rec.email === "string" && rec.email.trim().length > 0
-        ? rec.email.trim().toLowerCase()
-        : null;
-    if (!apolloPersonId && !email) {
-      throw new Error(`[lead-service] input line ${lineNo} has neither apolloPersonId nor email`);
-    }
-    const history = Array.isArray(rec.employmentHistory)
-      ? rec.employmentHistory
-          .map(normalizeEmployment)
-          .filter((e): e is EmploymentEntry => e !== null && e.organizationName !== null)
-      : [];
-    out.push({ apolloPersonId, email, org: rec, employmentHistory: history });
+    const rec = parseLine(raw, lineNo);
+    if (rec) out.push(rec);
   }
   return out;
 }
@@ -326,10 +349,31 @@ async function run(): Promise<void> {
   if (!args.inputPath) {
     throw new Error("[lead-service] --input <path> is required");
   }
-  const records = parseInput(readFileSync(args.inputPath, "utf8"));
-  const { byPersonId, byEmail } = indexRecords(records);
+  // Streamed, not slurped: the production input is ~380 MB and reading it as one
+  // string then splitting it needs several times that in heap.
+  const byPersonId = new Map<string, EnrichmentRecord>();
+  const byEmail = new Map<string, EnrichmentRecord>();
+  let loaded = 0;
+  {
+    const { createReadStream } = await import("node:fs");
+    const { createInterface } = await import("node:readline");
+    const rl = createInterface({
+      input: createReadStream(args.inputPath, "utf8"),
+      crlfDelay: Infinity,
+    });
+    let lineNo = 0;
+    for await (const line of rl) {
+      lineNo += 1;
+      const rec = parseLine(line, lineNo);
+      if (!rec) continue;
+      loaded += 1;
+      if (rec.apolloPersonId && !byPersonId.has(rec.apolloPersonId))
+        byPersonId.set(rec.apolloPersonId, rec);
+      if (rec.email && !byEmail.has(rec.email)) byEmail.set(rec.email, rec);
+    }
+  }
   console.log(
-    `[lead-service] loaded ${records.length} enrichment records (${byPersonId.size} by person id, ${byEmail.size} by email)`,
+    `[lead-service] loaded ${loaded} enrichment records (${byPersonId.size} by person id, ${byEmail.size} by email)`,
   );
 
   const { sql } = await import("../src/db/index.js");

--- a/scripts/sql/apollo-lead-org-enrichment.sql
+++ b/scripts/sql/apollo-lead-org-enrichment.sql
@@ -53,51 +53,9 @@
 --     --input /tmp/apollo-lead-org-enrichment.jsonl --dry-run
 \set ON_ERROR_STOP on
 
+-- NOTE: the \copy below is ONE line on purpose. A psql meta-command does not
+-- span lines — breaking it for readability fails with `\copy: parse error at
+-- end of line` and writes nothing.
 -- One JSON object per line, CSV-quoted (a single column), so a value carrying a
 -- comma or a quote survives the round trip; the script un-doubles the quotes.
-\copy (SELECT row_to_json(t)::text FROM (
-    SELECT DISTINCT ON (coalesce(e.apollo_person_id, e.email))
-           e.apollo_person_id AS "apolloPersonId",
-           e.email AS "email",
-           coalesce(e.organization_id, e.response_raw->'organization'->>'id') AS "providerOrganizationId",
-           coalesce(e.organization_name, e.response_raw->'organization'->>'name') AS "name",
-           coalesce(e.organization_domain, e.response_raw->'organization'->>'primary_domain') AS "domain",
-           coalesce(e.organization_website_url, e.response_raw->'organization'->>'website_url') AS "websiteUrl",
-           coalesce(e.organization_industry, e.response_raw->'organization'->>'industry') AS "industry",
-           coalesce(e.organization_logo_url, e.response_raw->'organization'->>'logo_url') AS "logoUrl",
-           coalesce(e.organization_linkedin_url, e.response_raw->'organization'->>'linkedin_url') AS "linkedinUrl",
-           coalesce(e.organization_twitter_url, e.response_raw->'organization'->>'twitter_url') AS "twitterUrl",
-           coalesce(e.organization_facebook_url, e.response_raw->'organization'->>'facebook_url') AS "facebookUrl",
-           coalesce(e.organization_blog_url, e.response_raw->'organization'->>'blog_url') AS "blogUrl",
-           coalesce(e.organization_crunchbase_url, e.response_raw->'organization'->>'crunchbase_url') AS "crunchbaseUrl",
-           coalesce(e.organization_angellist_url, e.response_raw->'organization'->>'angellist_url') AS "angellistUrl",
-           coalesce(e.organization_short_description, e.response_raw->'organization'->>'short_description') AS "shortDescription",
-           coalesce(e.organization_seo_description, e.response_raw->'organization'->>'seo_description') AS "seoDescription",
-           coalesce(e.organization_keywords, e.response_raw->'organization'->'keywords') AS "keywords",
-           coalesce(e.organization_technology_names, e.response_raw->'organization'->'technology_names') AS "technologyNames",
-           coalesce(e.organization_industries, e.response_raw->'organization'->'industries') AS "industries",
-           coalesce(e.organization_secondary_industries, e.response_raw->'organization'->'secondary_industries') AS "secondaryIndustries",
-           coalesce(e.organization_latest_funding_stage, e.response_raw->'organization'->>'latest_funding_stage') AS "latestFundingStage",
-           coalesce(e.organization_latest_funding_round_date, e.response_raw->'organization'->>'latest_funding_round_date') AS "latestFundingRoundDate",
-           coalesce(e.organization_total_funding::text, e.response_raw->'organization'->>'total_funding') AS "totalFunding",
-           coalesce(e.organization_total_funding_printed, e.response_raw->'organization'->>'total_funding_printed') AS "totalFundingPrinted",
-           coalesce(e.organization_funding_events, e.response_raw->'organization'->'funding_events') AS "fundingEvents",
-           coalesce(e.organization_founded_year, (e.response_raw->'organization'->>'founded_year')::int) AS "foundedYear",
-           coalesce(e.organization_revenue_usd::text, e.response_raw->'organization'->>'annual_revenue') AS "annualRevenue",
-           coalesce(e.organization_size, e.response_raw->'organization'->>'estimated_num_employees') AS "estimatedNumEmployees",
-           coalesce(e.organization_city, e.response_raw->'organization'->>'city') AS "city",
-           coalesce(e.organization_state, e.response_raw->'organization'->>'state') AS "state",
-           coalesce(e.organization_country, e.response_raw->'organization'->>'country') AS "country",
-           coalesce(e.organization_street_address, e.response_raw->'organization'->>'street_address') AS "streetAddress",
-           coalesce(e.organization_postal_code, e.response_raw->'organization'->>'postal_code') AS "postalCode",
-           coalesce(e.organization_primary_phone, e.response_raw->'organization'->'primary_phone'->>'number') AS "primaryPhone",
-           coalesce(e.organization_publicly_traded_symbol, e.response_raw->'organization'->>'publicly_traded_symbol') AS "publiclyTradedSymbol",
-           coalesce(e.organization_publicly_traded_exchange, e.response_raw->'organization'->>'publicly_traded_exchange') AS "publiclyTradedExchange",
-           coalesce(e.organization_num_suborganizations, (e.response_raw->'organization'->>'num_suborganizations')::int) AS "numSuborganizations",
-           coalesce(e.organization_retail_location_count, (e.response_raw->'organization'->>'retail_location_count')::int) AS "retailLocationCount",
-           coalesce(e.organization_alexa_ranking, (e.response_raw->'organization'->>'alexa_ranking')::int) AS "alexaRanking",
-           coalesce(e.employment_history, e.response_raw->'employment_history') AS "employmentHistory"
-    FROM apollo_people_enrichments e
-    WHERE e.apollo_person_id IS NOT NULL OR e.email IS NOT NULL
-    ORDER BY coalesce(e.apollo_person_id, e.email), e.created_at DESC
-  ) t) TO '/tmp/apollo-lead-org-enrichment.jsonl' CSV
+\copy (SELECT row_to_json(t)::text FROM ( SELECT DISTINCT ON (coalesce(e.apollo_person_id, e.email)) e.apollo_person_id AS "apolloPersonId", e.email AS "email", coalesce(e.organization_id, e.response_raw->'organization'->>'id') AS "providerOrganizationId", coalesce(e.organization_name, e.response_raw->'organization'->>'name') AS "name", coalesce(e.organization_domain, e.response_raw->'organization'->>'primary_domain') AS "domain", coalesce(e.organization_website_url, e.response_raw->'organization'->>'website_url') AS "websiteUrl", coalesce(e.organization_industry, e.response_raw->'organization'->>'industry') AS "industry", coalesce(e.organization_logo_url, e.response_raw->'organization'->>'logo_url') AS "logoUrl", coalesce(e.organization_linkedin_url, e.response_raw->'organization'->>'linkedin_url') AS "linkedinUrl", coalesce(e.organization_twitter_url, e.response_raw->'organization'->>'twitter_url') AS "twitterUrl", coalesce(e.organization_facebook_url, e.response_raw->'organization'->>'facebook_url') AS "facebookUrl", coalesce(e.organization_blog_url, e.response_raw->'organization'->>'blog_url') AS "blogUrl", coalesce(e.organization_crunchbase_url, e.response_raw->'organization'->>'crunchbase_url') AS "crunchbaseUrl", coalesce(e.organization_angellist_url, e.response_raw->'organization'->>'angellist_url') AS "angellistUrl", coalesce(e.organization_short_description, e.response_raw->'organization'->>'short_description') AS "shortDescription", coalesce(e.organization_seo_description, e.response_raw->'organization'->>'seo_description') AS "seoDescription", coalesce(e.organization_keywords, e.response_raw->'organization'->'keywords') AS "keywords", coalesce(e.organization_technology_names, e.response_raw->'organization'->'technology_names') AS "technologyNames", coalesce(e.organization_industries, e.response_raw->'organization'->'industries') AS "industries", coalesce(e.organization_secondary_industries, e.response_raw->'organization'->'secondary_industries') AS "secondaryIndustries", coalesce(e.organization_latest_funding_stage, e.response_raw->'organization'->>'latest_funding_stage') AS "latestFundingStage", coalesce(e.organization_latest_funding_round_date, e.response_raw->'organization'->>'latest_funding_round_date') AS "latestFundingRoundDate", coalesce(e.organization_total_funding::text, e.response_raw->'organization'->>'total_funding') AS "totalFunding", coalesce(e.organization_total_funding_printed, e.response_raw->'organization'->>'total_funding_printed') AS "totalFundingPrinted", coalesce(e.organization_funding_events, e.response_raw->'organization'->'funding_events') AS "fundingEvents", coalesce(e.organization_founded_year, (e.response_raw->'organization'->>'founded_year')::int) AS "foundedYear", coalesce(e.organization_revenue_usd::text, e.response_raw->'organization'->>'annual_revenue') AS "annualRevenue", coalesce(e.organization_size, e.response_raw->'organization'->>'estimated_num_employees') AS "estimatedNumEmployees", coalesce(e.organization_city, e.response_raw->'organization'->>'city') AS "city", coalesce(e.organization_state, e.response_raw->'organization'->>'state') AS "state", coalesce(e.organization_country, e.response_raw->'organization'->>'country') AS "country", coalesce(e.organization_street_address, e.response_raw->'organization'->>'street_address') AS "streetAddress", coalesce(e.organization_postal_code, e.response_raw->'organization'->>'postal_code') AS "postalCode", coalesce(e.organization_primary_phone, e.response_raw->'organization'->'primary_phone'->>'number') AS "primaryPhone", coalesce(e.organization_publicly_traded_symbol, e.response_raw->'organization'->>'publicly_traded_symbol') AS "publiclyTradedSymbol", coalesce(e.organization_publicly_traded_exchange, e.response_raw->'organization'->>'publicly_traded_exchange') AS "publiclyTradedExchange", coalesce(e.organization_num_suborganizations, (e.response_raw->'organization'->>'num_suborganizations')::int) AS "numSuborganizations", coalesce(e.organization_retail_location_count, (e.response_raw->'organization'->>'retail_location_count')::int) AS "retailLocationCount", coalesce(e.organization_alexa_ranking, (e.response_raw->'organization'->>'alexa_ranking')::int) AS "alexaRanking", coalesce(e.employment_history, e.response_raw->'employment_history') AS "employmentHistory" FROM apollo_people_enrichments e WHERE e.apollo_person_id IS NOT NULL OR e.email IS NOT NULL ORDER BY coalesce(e.apollo_person_id, e.email), e.created_at DESC ) t) TO '/tmp/apollo-lead-org-enrichment.jsonl' CSV

--- a/src/lib/leads-registry.ts
+++ b/src/lib/leads-registry.ts
@@ -78,7 +78,11 @@ export function pickOrgFields(
   if (org.annualRevenue != null) out.annualRevenue = String(org.annualRevenue);
 
   // --- Widened surface: what apollo-service already holds, carried through. ---
-  if (org.providerOrganizationId) out.apolloOrganizationId = org.providerOrganizationId;
+  // NOTE: `providerOrganizationId` is deliberately NOT here. It is a UNIQUE join
+  // key (`idx_organizations_apollo_organization_id`) while this service keys an
+  // organization on its DOMAIN, then its name — so two rows here can legitimately
+  // describe one Apollo organization, and an unguarded write raises 23505 and
+  // fails the serve. `claimProviderOrganizationId` writes it only when it is free.
   if (org.shortDescription) out.shortDescription = org.shortDescription;
   if (org.seoDescription) out.seoDescription = org.seoDescription;
   const keywords = arrayOrNull(org.keywords);
@@ -192,6 +196,34 @@ export async function upsertLeadFromPerson(
  * no provider org id, so we key on primaryDomain (stable) and fall back to name.
  * Returns organizationId or null when the person has no org.
  */
+/**
+ * Record apollo's organization id on the row, but ONLY when no other row already
+ * holds it.
+ *
+ * `idx_organizations_apollo_organization_id` is UNIQUE, and this service keys an
+ * organization on its domain (then its name), so two rows here can describe one
+ * Apollo organization — a past employer known only by name and the current
+ * employer known by domain, most often. Writing the id unguarded therefore raises
+ * `23505 duplicate key` on a path that must never fail a serve. The id is a join
+ * key, not a fact the email is written from, so the correct behaviour when it is
+ * already claimed is to leave it alone rather than to move it or to fail.
+ */
+async function claimProviderOrganizationId(
+  organizationId: string,
+  providerOrganizationId: string,
+): Promise<void> {
+  await db.execute(sql`
+    UPDATE organizations
+    SET apollo_organization_id = ${providerOrganizationId}
+    WHERE id = ${organizationId}
+      AND apollo_organization_id IS NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM organizations other
+        WHERE other.apollo_organization_id = ${providerOrganizationId}
+      )
+  `);
+}
+
 export async function upsertOrganizationFromPerson(person: Person): Promise<string | null> {
   const org = person.organization;
   if (!org || (!org.domain && !org.name)) return null;
@@ -206,6 +238,8 @@ export async function upsertOrganizationFromPerson(person: Person): Promise<stri
       .update(organizations)
       .set({ ...fields, updatedAt: new Date() })
       .where(eq(organizations.id, existing.id));
+    if (org.providerOrganizationId)
+      await claimProviderOrganizationId(existing.id, org.providerOrganizationId);
     return existing.id;
   }
 
@@ -213,7 +247,10 @@ export async function upsertOrganizationFromPerson(person: Person): Promise<stri
     .insert(organizations)
     .values({ ...fields })
     .returning({ id: organizations.id });
-  return inserted[0]?.id ?? null;
+  const insertedId = inserted[0]?.id ?? null;
+  if (insertedId && org.providerOrganizationId)
+    await claimProviderOrganizationId(insertedId, org.providerOrganizationId);
+  return insertedId;
 }
 
 export type UpsertContactResult =

--- a/tests/unit/backfill-lead-org-enrichment.test.ts
+++ b/tests/unit/backfill-lead-org-enrichment.test.ts
@@ -9,6 +9,7 @@ import {
   toIsoDate,
   ORG_COLUMNS,
   DEFAULT_BATCH_SIZE,
+  DEFAULT_CONCURRENCY,
 } from "../../scripts/backfill-lead-org-enrichment.js";
 
 /** One line as `\copy … CSV` writes a single JSON column: quoted, quotes doubled. */
@@ -25,12 +26,22 @@ describe("parseArgs", () => {
       reportPath: null,
       batchSize: DEFAULT_BATCH_SIZE,
       limit: null,
+      concurrency: DEFAULT_CONCURRENCY,
     });
   });
 
   it("refuses a batch size that is not a positive integer", () => {
     expect(() => parseArgs(["--batch-size", "0"])).toThrow(/positive integer/);
     expect(() => parseArgs(["--batch-size", "abc"])).toThrow(/positive integer/);
+  });
+
+  it("refuses a concurrency that is not a positive integer", () => {
+    expect(() => parseArgs(["--concurrency", "0"])).toThrow(/positive integer/);
+    expect(() => parseArgs(["--concurrency", "-2"])).toThrow(/positive integer/);
+  });
+
+  it("stays well under the pool ceiling so the service keeps serving", () => {
+    expect(DEFAULT_CONCURRENCY).toBeLessThan(20);
   });
 });
 

--- a/tests/unit/leads-registry-org-enrichment.test.ts
+++ b/tests/unit/leads-registry-org-enrichment.test.ts
@@ -15,6 +15,7 @@ const insertCalls: { table: unknown; values: unknown }[] = [];
 const updateCalls: { table: unknown; set: unknown }[] = [];
 const selectResults = new Map<unknown, unknown[]>();
 const findFirstOrg = vi.fn();
+const executeCalls: unknown[] = [];
 
 function makeInsert(table: unknown) {
   return {
@@ -61,6 +62,10 @@ function makeSelect() {
 
 vi.mock("../../src/db/index.js", () => ({
   db: {
+    execute: (q: unknown) => {
+      executeCalls.push(q);
+      return Promise.resolve([]);
+    },
     insert: (table: unknown) => makeInsert(table),
     update: (table: unknown) => makeUpdate(table),
     select: () => makeSelect(),
@@ -87,6 +92,7 @@ beforeEach(() => {
   insertCalls.length = 0;
   updateCalls.length = 0;
   selectResults.clear();
+  executeCalls.length = 0;
   findFirstOrg.mockReset();
 });
 
@@ -154,7 +160,6 @@ describe("pickOrgFields — the organization facts apollo-service already paid f
     expect(fields).toMatchObject({
       name: "Casco Bay",
       primaryDomain: "cascobay.com",
-      apolloOrganizationId: "apollo-org-1",
       shortDescription: "Boutique digital marketing agency in Portland, ME.",
       seoDescription: "Casco Bay helps brands grow.",
       keywords: ["marketing", "branding"],
@@ -174,6 +179,9 @@ describe("pickOrgFields — the organization facts apollo-service already paid f
       primaryPhone: "+12075550100",
       alexaRanking: 812345,
     });
+    // The provider's organization id is a UNIQUE join key, not a fact the email
+    // is written from — it is claimed separately, only when free.
+    expect("apolloOrganizationId" in fields).toBe(false);
     expect(fields.fundingEvents).toEqual([{ id: "fe-1", type: "Series A", amount: 5_000_000 }]);
     // A stated zero is a value, not an absence.
     expect(fields.numSuborganizations).toBe(0);
@@ -327,6 +335,36 @@ describe("recordEmploymentHistory — the person's whole career, not just today'
     const past = linkInserts().find((r) => r.title === "Analyst");
     expect(past).toBeDefined();
     expect(past?.startDate).toBeNull();
+  });
+});
+
+describe("the provider's organization id is claimed, never written blind", () => {
+  it("is written by a guarded statement rather than by the field copy", async () => {
+    findFirstOrg.mockResolvedValue({ id: "org-top" });
+    selectResults.set(leadsOrganizations, []);
+    const { recordEmploymentHistory } = await import("../../src/lib/leads-registry.js");
+    await recordEmploymentHistory({ leadId: "lead-1", person: richPerson as never });
+
+    // `idx_organizations_apollo_organization_id` is UNIQUE while this service keys
+    // an organization on its domain, so two rows can describe one Apollo org: the
+    // claim must be one guarded UPDATE, never part of the field copy.
+    expect(executeCalls).toHaveLength(1);
+    expect(orgUpdates().some((u) => "apolloOrganizationId" in u)).toBe(false);
+  });
+
+  it("makes no claim when the producer sent no organization id", async () => {
+    findFirstOrg.mockResolvedValue({ id: "org-top" });
+    selectResults.set(leadsOrganizations, []);
+    const { recordEmploymentHistory } = await import("../../src/lib/leads-registry.js");
+    await recordEmploymentHistory({
+      leadId: "lead-1",
+      person: {
+        ...richPerson,
+        organization: { ...richPerson.organization, providerOrganizationId: null },
+      } as never,
+    });
+
+    expect(executeCalls).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
Follow-up to #522/#525, measured on the production run.

The work is a handful of small indexed round trips per lead, so doing it one lead at a time is round-trip bound rather than database bound: production measured ~2,000 leads per 6 minutes — over five hours for the 97k-lead population. A pool of six workers per page brought the same page to ~30 seconds.

Six is well under this service's pool ceiling of 20, so it keeps serving while the repair runs, and `--concurrency` makes it adjustable. Nothing else changes: the per-lead work, the fill-only-NULL rule and the report are untouched.

868 tests green. Triage: prod-direct (main). Script-only, no service code.